### PR TITLE
buildtools: fix == bashism in mkversion.sh

### DIFF
--- a/buildtools/mkversion.sh
+++ b/buildtools/mkversion.sh
@@ -23,7 +23,7 @@ fi
 
 if [ -r "$1" ]; then
   eval `cat noit_version.h | awk '/^#define/ { print $2"="$3;}'`
-  if [ "$NOIT_BRANCH" == "$BRANCH" -a "$NOIT_VERSION" == "$VERSION" ]; then
+  if [ "$NOIT_BRANCH" = "$BRANCH" -a "$NOIT_VERSION" = "$VERSION" ]; then
     echo "    * version unchanged"
     exit
   fi


### PR DESCRIPTION
With a branch named bpdev I was getting an error at compile time:

  [: 1: branches/bpdev: unexpected operator

This was because /bin/sh on my distro is dash which doesn't know what ==
is. Fix this by using a single =.
