### PR TITLE
Add Delete messages to noit so we get a message when we deschedule a check.

### DIFF
--- a/src/modules/postgres_ingestor.c
+++ b/src/modules/postgres_ingestor.c
@@ -693,6 +693,8 @@ stratcon_ingest_execute(conn_q *cq, const char *r, const char *remote_cn,
         DECLARE_PARAM_STR(final_buff, final_len);
         free(final_buff);
         break;
+      case 'D':
+        break;
       case 'C':
         DECLARE_PARAM_STR(raddr, strlen(raddr));
         PROCESS_NEXT_FIELD(token,len);
@@ -770,6 +772,8 @@ stratcon_ingest_execute(conn_q *cq, const char *r, const char *remote_cn,
       GET_QUERY(status_insert);
       PG_TM_EXEC(status_insert, d->whence);
       PQclear(d->res);
+      break;
+    case 'D':
       break;
     case 'M':
       switch(d->metric_type) {

--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -777,6 +777,8 @@ noit_poller_deschedule(uuid_t in) {
   checker = (noit_check_t *)vcheck;
   checker->flags |= (NP_DISABLED|NP_KILLED);
 
+  noit_check_log_delete(checker);
+
   noit_skiplist_remove(&polls_by_name, checker, NULL);
   noit_hash_delete(&polls, (char *)in, UUID_SIZE, NULL, NULL);
 

--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -265,6 +265,7 @@ API_EXPORT(void)
 /* These are from noit_check_log.c */
 API_EXPORT(void) noit_check_log_check(noit_check_t *check);
 API_EXPORT(void) noit_check_log_status(noit_check_t *check);
+API_EXPORT(void) noit_check_log_delete(noit_check_t *check);
 API_EXPORT(void) noit_check_log_metrics(noit_check_t *check);
 API_EXPORT(void) noit_check_log_metric(noit_check_t *check,
                                        struct timeval *whence, metric_t *m);

--- a/src/stratcon_datastore.c
+++ b/src/stratcon_datastore.c
@@ -221,6 +221,7 @@ stratcon_datastore_journal(struct sockaddr *remote,
     case 'C':
     case 'S':
     case 'M':
+    case 'D':
       if(line[1] == '\t' && (cp1 = strchr(line+2, '\t')) != NULL &&
          (cp2 = strchr(cp1+1, '\t')) != NULL &&
          (cp2-cp1 >= UUID_STR_LEN)) {


### PR DESCRIPTION
Add a modifier when a metric gets descheduled to push a message with the uuid payload to the stream.
- This will help in event processor to know when to release a check from the active window

To use add to noit config:

```
<log name="delete"/>
```
