### PR TITLE
Add a 100k Limit to HTTP Read Lengths

### DIFF
--- a/src/modules-lua/noit/HttpClient.lua
+++ b/src/modules-lua/noit/HttpClient.lua
@@ -43,6 +43,7 @@ function HttpClient:connect(target, port, ssl)
     self.e = noit.socket(target)
     self.target = target
     self.port = port
+    self.truncated = nil
     local rv, err = self.e:connect(self.target, self.port)
     if rv ~= 0 then
         return rv, err
@@ -133,6 +134,7 @@ function te_length(self, content_enc_func, read_limit)
     local len = tonumber(self.headers["content-length"])
     if read_limit and read_limit > 0 and len > read_limit then
       len = read_limit
+      self.truncated = true
     end
     repeat
         local str = self.e:read(len)
@@ -165,6 +167,7 @@ function te_chunked(self, content_enc_func, read_limit)
         if self.hooks.consume ~= nil then self.hooks.consume(decoded) end
         if read_limit and read_limit > 0 then
           if string.len(self.content_bytes) > read_limit then
+            self.truncated = true
             return
           end
         end

--- a/src/modules-lua/noit/module/http.lua
+++ b/src/modules-lua/noit/module/http.lua
@@ -273,7 +273,7 @@ function initiate(module, check)
     local max_len = 80
     local pcre_match_limit = check.config.pcre_match_limit or 10000
     local redirects = check.config.redirects or 0
-    local read_limit = check.config.read_limit or 102400
+    local read_limit = tonumber(check.config.read_limit) or 102400
 
     -- expect the worst
     check.bad()
@@ -450,6 +450,9 @@ function initiate(module, check)
     if codere ~= nil and codere(client.code) then
       good = true
     end
+
+    -- truncated response
+    check.metric_uint32("truncated", client.truncated and 1 or 0)
 
     -- turnaround time
     local seconds = elapsed(check, "duration", starttime, endtime)


### PR DESCRIPTION
- By setting the limit to 0 (zero) the limit is unlimited.
