### PR TITLE
Fixes/eventer double add

### DIFF
--- a/src/modules-lua/noit/module/http.lua
+++ b/src/modules-lua/noit/module/http.lua
@@ -435,7 +435,7 @@ function initiate(module, check)
             if host ~= nil then
                 headers.Host = host
                 local r = dns:lookup(host)
-                if r.a == '' then
+                if r.a == nil then
                     check.status("failed to resolve " + host)
                     return
                 end


### PR DESCRIPTION
- On linux we are seeing a double eventer add using epoll, which will error out. This patch fixes the issue.
