### PR TITLE
Add support for multiple body matches via body_match_* settings.

### DIFF
--- a/src/modules-lua/noit/module/http.lua
+++ b/src/modules-lua/noit/module/http.lua
@@ -515,7 +515,7 @@ function initiate(module, check)
     for key, value in pairs(check.config) do
       m = string.find(key, BODY_MATCHES_PREFIX)
 
-      if m then
+      if m == 1 then
         has_body_matches = true
         key = string.gsub(key, BODY_MATCHES_PREFIX, '')
 


### PR DESCRIPTION
This branch adds support for multiple body matches.

Config options are specified in the following format: `body_match_<key> = value`.

For example:

```
body_match_one = test (.*?)
body_match_two = error (\d+)
```

All the matches are extracted and added as a metric with the name in the following format: `body_match_<key>`.
