### PR TITLE
Trivial fix to sort templates before returning them

### DIFF
--- a/ui/web/lib/Reconnoiter_DB.php
+++ b/ui/web/lib/Reconnoiter_DB.php
@@ -107,6 +107,7 @@ class Reconnoiter_DB {
       $sql = "$sql where templateid = ?";
       $binds[] = $templateid;
     }
+    $sql = "$sql order by title";
     $sth = $this->db->prepare($sql);
     $sth->execute($binds);
     $a = array();


### PR DESCRIPTION
Trivial fix to sort templates before returning them, makes the templates sorted in the web ui rather than random order.
