### PR TITLE
add protobuf development headers to debian build

### DIFF
--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -2,7 +2,7 @@ Source: reconnoiter
 Section: admin
 Priority: optional
 Maintainer: Thom May <thom@debian.org>
-Build-Depends: debhelper (>=4.1.16), autoconf, libtool, gettext, zlib1g-dev, uuid-dev, libpcre3-dev, libssl-dev, libpq-dev,  libxml2-dev, libxslt-dev, libapr1-dev, libaprutil1-dev, xsltproc,  libncurses5-dev, libssh2-1-dev, libsnmp-dev, libmysqlclient-dev, subversion, default-jdk, libevent-dev
+Build-Depends: debhelper (>=4.1.16), autoconf, libtool, gettext, zlib1g-dev, uuid-dev, libpcre3-dev, libssl-dev, libpq-dev,  libxml2-dev, libxslt-dev, libapr1-dev, libaprutil1-dev, xsltproc,  libncurses5-dev, libssh2-1-dev, libsnmp-dev, libmysqlclient-dev, subversion, default-jdk, libevent-dev, libprotobuf-c0-dev
 Standards-Version: 3.6.1.0
 
 Package: noit


### PR DESCRIPTION
this gets the debian packages building again!
