### PR TITLE
EHLO Response Metrics Support

### DIFF
--- a/src/modules-lua/Makefile.in
+++ b/src/modules-lua/Makefile.in
@@ -29,6 +29,7 @@ MODULES_DIR=@MODULES_DIR@
 
 LUA=noit/timeval.lua \
 	noit/HttpClient.lua \
+	noit/extras.lua \
 	noit/module/varnish.lua \
 	noit/module/smtp.lua \
 	noit/module/http.lua \

--- a/src/modules-lua/noit/extras.lua
+++ b/src/modules-lua/noit/extras.lua
@@ -1,0 +1,61 @@
+-- Copyright (c) 2012, OmniTI Computer Consulting, Inc.
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are
+-- met:
+--
+--     * Redistributions of source code must retain the above copyright
+--       notice, this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above
+--       copyright notice, this list of conditions and the following
+--       disclaimer in the documentation and/or other materials provided
+--       with the distribution.
+--     * Neither the name OmniTI Computer Consulting, Inc. nor the names
+--       of its contributors may be used to endorse or promote products
+--       derived from this software without specific prior written
+--       permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+-- "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+-- A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+-- OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+-- SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+-- LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+-- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+-- THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+local string = require("string")
+local table = require("table")
+module("noit.extras")
+
+-- from http://www.wellho.net/resources/ex.php4?item=u108/split
+-- modified to split up to 'max' times
+function split(str, delimiter, max)
+  local result = { }
+  local from  = 1
+  local delim_from, delim_to = string.find( str, delimiter, from  )
+  local nb = 0
+  if max == nil then
+    max = 0
+  end
+  while delim_from do
+    local insert_string = string.sub( str, from , delim_from-1 )
+    nb = nb + 1
+    table.insert( result, insert_string )
+    from  = delim_to + 1
+    delim_from, delim_to = string.find( str, delimiter, from  )
+    if nb == max then
+      break
+    end
+  end
+  local last_res = string.sub (str, from)
+  if last_res ~= nil and last_res ~= "" then
+    table.insert( result, last_res )
+  end
+  return result
+end
+

--- a/src/modules-lua/noit/module/smtp.lua
+++ b/src/modules-lua/noit/module/smtp.lua
@@ -145,7 +145,7 @@ local function mkaction(e, check)
     check.metric(phase .. "_time",  elapsed_ms)
 
     if phase == 'ehlo' and message ~= nil then
-      local fields = string.split(message, "\r\n")
+      local fields = noit.extras.split(message, "\r\n")
       if fields ~= nil then
         local response = ""
         local extensions = ""
@@ -158,7 +158,7 @@ local function mkaction(e, check)
           for line, value in pairs(fields) do
             if value ~= nil and value ~= "" then
               value = value:gsub("^%s*(.-)%s*$", "%1")
-              local subfields = string.split(value, "%s+", 1)
+              local subfields = noit.extras.split(value, "%s+", 1)
               if subfields ~= nil and subfields[1] ~= nil then
                 local header = subfields[1]
                 if subfields[2] ~= nil then
@@ -240,32 +240,5 @@ function initiate(module, check)
   local elapsed = noit.timeval.now() - starttime
   local elapsed_ms = math.floor(tostring(elapsed) * 1000)
   check.metric("duration",  elapsed_ms)
-end
-
--- from http://www.wellho.net/resources/ex.php4?item=u108/split
--- modified to split up to 'max' times
-function string:split(delimiter, max)
-  local result = { }
-  local from  = 1
-  local delim_from, delim_to = string.find( self, delimiter, from  )
-  local nb = 0
-  if max == nil then
-    max = 0
-  end
-  while delim_from do
-    local insert_string = string.sub( self, from , delim_from-1 )
-    nb = nb + 1
-    table.insert( result, insert_string )
-    from  = delim_to + 1
-    delim_from, delim_to = string.find( self, delimiter, from  )
-    if nb == max then
-      break
-    end
-  end
-  local last_res = string.sub (self, from)
-  if last_res ~= nil and last_res ~= "" then
-    table.insert( result, last_res )
-  end
-  return result
 end
 

--- a/src/modules/lua.c
+++ b/src/modules/lua.c
@@ -891,6 +891,7 @@ noit_lua_loader_load(noit_module_loader_t *loader,
 } while(0)
 
   require(noit.timeval);
+  require(noit.extras);
 
   lua_gc(L, LUA_GCRESTART, 0);
 


### PR DESCRIPTION
I added support into smtp.lua to show metrics for the EHLO response.

Basically, it pulls out the top response line as the banner, then goes through each of the EHLO response lines, storing values at "ehlo_response_<metric name>". If there is a field without a parameter (example: "HELP"), it stores the value "true" to indicate that it is there (example: 'ehlo_response_help = true'). If there are one or more parameters (example: "AUTH GSSAPI DIGEST-MD5 CRAM-MD5"), it stores all of the parameters exactly as they were received (example: 'ehlo_response_auth = GSSAPI DIGEST-MD5 CRAM-MD5').
