### PR TITLE
JDBC DSN and basic SSL support

### DIFF
--- a/src/java/com/omniti/jezebel/check/mysql.java
+++ b/src/java/com/omniti/jezebel/check/mysql.java
@@ -31,6 +31,8 @@
  */
 
 package com.omniti.jezebel.check;
+import java.util.Map;
+import java.util.HashMap;
 import com.omniti.jezebel.check.JDBC;
 import com.omniti.jezebel.JezebelCheck;
 public class mysql extends JDBC implements JezebelCheck {
@@ -39,5 +41,11 @@ public class mysql extends JDBC implements JezebelCheck {
   protected String defaultPort() { return "3306"; }
   protected String jdbcConnectUrl(String host, String port, String db) {
     return "jdbc:mysql://" + host + ":" + port + "/" + db;
+  }
+  protected Map<String,String> setupBasicSSL() {
+    HashMap<String,String> props = new HashMap<String,String>();
+    props.put("useSSL", "true");
+    props.put("verifyServerCertificate", "false");
+    return props;
   }
 }

--- a/src/java/com/omniti/jezebel/check/oracle.java
+++ b/src/java/com/omniti/jezebel/check/oracle.java
@@ -31,6 +31,8 @@
  */
 
 package com.omniti.jezebel.check;
+import java.util.Map;
+import java.util.HashMap;
 import com.omniti.jezebel.check.JDBC;
 import com.omniti.jezebel.JezebelCheck;
 public class oracle extends JDBC implements JezebelCheck {
@@ -39,5 +41,10 @@ public class oracle extends JDBC implements JezebelCheck {
   protected String defaultPort() { return "1521"; }
   protected String jdbcConnectUrl(String host, String port, String db) {
     return "jdbc:oracle:thin:@" + host + ":" + port + ":" + db;
+  }
+  protected Map<String,String> setupBasicSSL() {
+    HashMap<String,String> props = new HashMap<String,String>();
+    props.put("oracle.net.ssl_cipher_suites", "(SSL_DH_anon_WITH_3DES_EDE_CBC_SHA, SSL_DH_anon_WITH_RC4_128_MD5,SSL_DH_anon_WITH_DES_CBC_SHA)");
+    return props;
   }
 }

--- a/src/java/com/omniti/jezebel/check/postgres.java
+++ b/src/java/com/omniti/jezebel/check/postgres.java
@@ -31,6 +31,8 @@
  */
 
 package com.omniti.jezebel.check;
+import java.util.Map;
+import java.util.HashMap;
 import com.omniti.jezebel.check.JDBC;
 import com.omniti.jezebel.JezebelCheck;
 public class postgres extends JDBC implements JezebelCheck {
@@ -39,5 +41,11 @@ public class postgres extends JDBC implements JezebelCheck {
   protected String defaultPort() { return "5432"; }
   protected String jdbcConnectUrl(String host, String port, String db) {
     return "jdbc:postgresql://" + host + ":" + port + "/" + db;
+  }
+  protected Map<String,String> setupBasicSSL() {
+    HashMap<String,String> props = new HashMap<String,String>();
+    props.put("ssl", "true");
+    props.put("sslfactory", "org.postgresql.ssl.NonValidatingFactory");
+    return props;
   }
 }

--- a/src/java/com/omniti/jezebel/check/sqlserver.java
+++ b/src/java/com/omniti/jezebel/check/sqlserver.java
@@ -31,6 +31,8 @@
  */
 
 package com.omniti.jezebel.check;
+import java.util.Map;
+import java.util.HashMap;
 import com.omniti.jezebel.check.JDBC;
 import com.omniti.jezebel.JezebelCheck;
 public class sqlserver extends JDBC implements JezebelCheck {
@@ -39,5 +41,11 @@ public class sqlserver extends JDBC implements JezebelCheck {
   protected String defaultPort() { return "1433"; }
   protected String jdbcConnectUrl(String host, String port, String db) {
     return "jdbc:sqlserver://" + host + ":" + port + ";databaseName=" + db;
+  }
+  protected Map<String,String> setupBasicSSL() {
+    HashMap<String,String> props = new HashMap<String,String>();
+    props.put("encrypt", "true");
+    props.put("trustServerCertificate", "true");
+    return props;
   }
 }


### PR DESCRIPTION
If passed a DSN in the config will break that apart to build connection info.  If sslmode=anything but disable will first setup basic non client cert SSL which can then be overridden by passing jdbc_X params.
