### PR TITLE
Fix to signal handling for external modules

### DIFF
--- a/src/modules/external_proc.c
+++ b/src/modules/external_proc.c
@@ -248,7 +248,6 @@ int external_child(external_data_t *data) {
     return -1;
   }
 
-  signal(SIGCHLD, external_sigchld);
   noit_skiplist_init(&active_procs);
   noit_skiplist_set_compare(&active_procs, __proc_state_check_no,
                             __proc_state_check_no_key);
@@ -264,6 +263,8 @@ int external_child(external_data_t *data) {
     int64_t check_no;
     int16_t argcnt, *arglens, envcnt, *envlens;
     int i;
+
+    signal(SIGCHLD, external_sigchld);
 
     /* We poll here so that we can be interrupted by the SIGCHLD */
     pfd.fd = in_fd;


### PR DESCRIPTION
Uncovered a bug where the main loop that handles signals in the external modules would only allow one interruption due to setting up the signal handler before the loop rather than in it; once the loop was signalled once, it would no longer accept interruptions. Moved the signal handling into the loop so that it will always accept the SIGCHLD interruption.
