### PR TITLE
PHP warning and debian package fixes

### DIFF
--- a/pkg/debian/stratcon.install
+++ b/pkg/debian/stratcon.install
@@ -8,7 +8,7 @@ usr/share/java/commons-codec-1.5.jar
 usr/share/java/commons-dbcp-1.2.2.jar
 usr/share/java/commons-io-1.2.jar
 usr/share/java/commons-pool-1.4.jar
-usr/share/java/esper-4.1.0.jar
+usr/share/java/esper-4.5.0.jar
 usr/share/java/protobuf-java-2.4.1.jar
 usr/share/java/postgresql-8.3-604.jdbc3.jar
 usr/share/java/rabbitmq-client-2.4.1.jar

--- a/ui/web/htdocs/template_browse_json.php
+++ b/ui/web/htdocs/template_browse_json.php
@@ -79,10 +79,10 @@ else if($want == 'targetname') {
 		 $target_sid_map = array();
 
 		 foreach ($valid_sids[$sv] as $match) {
-  	    	   if(!isset($target_sid_map[$match[target]])) {
-	    	     $target_sid_map[$match[target]] = array();
+  	    	   if(!isset($target_sid_map[$match['target']])) {
+	    	     $target_sid_map[$match['target']] = array();
 	           }
-	           $target_sid_map[$match[target]][] = $match[sid];
+	           $target_sid_map[$match['target']][] = $match['sid'];
                  }
 
 	 	 foreach ($target_sid_map as $target_name => $sid_list) {


### PR DESCRIPTION
Fixed warnings in php about undefined constant types, updated stratcon esper jar version in debian install
