### PR TITLE
Change the NTP version send for ntp control messages

### DIFF
--- a/src/modules-lua/noit/module/ntp.lua
+++ b/src/modules-lua/noit/module/ntp.lua
@@ -126,7 +126,7 @@ function next_sequence()
 end
 
 function make_ntp_control(req)
-    req.version = req.version or 4 -- NTP version
+    req.version = req.version or 2 -- NTP version
     req.mode = req.mode or 6 -- control
     req.leap = req.leap or 0
     -- contruct


### PR DESCRIPTION
This fixes interoperability with the ntpd in solaris 10

If the version should be configurable rather than just being lowered, let me know and I'll add it in.
