### PR TITLE
noit_rest: fix segfault when running the handoff/journals endpoint

### DIFF
--- a/debug/gdb-load-py
+++ b/debug/gdb-load-py
@@ -1,0 +1,2 @@
+source gdb-stratcon.py
+run  -D -d -c stratcon.conf

--- a/debug/gdb-stratcon.py
+++ b/debug/gdb-stratcon.py
@@ -1,0 +1,45 @@
+import gdb
+
+watchpoints = {}
+
+class http_closure_wp(gdb.Breakpoint):
+    def __init__(self, spec):
+        gdb.Breakpoint.__init__(self, spec, gdb.BP_WATCHPOINT)
+        self.address = spec
+
+    # Print out the stack here
+    def stop (self):
+         gdb.execute("bt")
+
+         return True
+
+# Set a watchpoint on alloc
+class http_closure_alloc_bp(gdb.Breakpoint):
+    def stop (self):
+        frame = gdb.newest_frame()
+        restc = gdb.parse_and_eval("restc")
+        addr = str(restc)
+        spec = restc['wants_shutdown'].address
+
+        print("alloc of " + str(addr) + " setting watchpoint @ " + str(spec))
+        watchpoints[addr] = http_closure_wp("* (int *)" + str(spec))
+
+        return False
+
+# Delete the watchpoint on free
+class http_closure_free_bp(gdb.Breakpoint):
+    def stop (self):
+        frame = gdb.newest_frame()
+        restc = gdb.parse_and_eval("v")
+        addr = str(restc)
+
+        print("dealloc of " + str(addr) + " deleting watchpoint")
+        gdb.execute("bt")
+        wp = watchpoints[addr]
+        wp.delete()
+        del watchpoints[addr]
+
+        return False
+
+http_closure_alloc_bp("noit_rest.c:263")
+http_closure_free_bp("noit_rest.c:284")


### PR DESCRIPTION
This fixes a segfault. Here is the problem backtrace:

```
alloc of 0x6d32a0 setting watchpoint @ 0x6d32d0
Hardware watchpoint 3: * (int *)0x6d32d0
dealloc of 0x6d32a0 deleting watchpoint
#0  noit_http_rest_closure_free (v=0x6d32a0) at noit_rest.c:284
#1  0x00007ffff33614b6 in handoff_stream (restc=0x6d32a0, npats=0, pats=0x0) at handoff_ingestor.c:253
#2  0x0000000000428a35 in noit_rest_request_dispatcher (ctx=0x6cfce0) at noit_rest.c:295
#3  0x0000000000426835 in noit_http_session_drive (e=0x6c0390, origmask=1, closure=0x6cfce0, now=0x8, done=<optimized out>)
    at noit_http.c:890
#4  0x0000000000428607 in noit_http_rest_handler (e=0x6c0390, mask=1, closure=0x6c0330, now=0x7fffffffc340) at noit_rest.c:359
#5  0x000000000041848a in noit_control_dispatch (e=0x6c0390, mask=<optimized out>, closure=0x6c0330, now=0x7fffffffc340)
    at noit_listener.c:455
#6  0x000000000043f31e in eventer_epoll_impl_trigger (e=<optimized out>, mask=1) at eventer_epoll_impl.c:207
#7  0x000000000043f54b in eventer_epoll_impl_loop () at eventer_epoll_impl.c:273
#8  0x0000000000416ab1 in child_main () at stratcond.c:231
#9  0x0000000000417694 in noit_main (appname=<optimized out>, config_filename=<optimized out>, debug=-14088,.
    foreground=<optimized out>, _glider=<optimized out>, drop_to_user=0x7fffffffc900 "", drop_to_group=0x685030 "daemon",.
    passed_child_main=0x4168b0 <child_main>) at noit_main.c:200
#10 0x0000000000416f78 in main (argc=<optimized out>, argv=<optimized out>) at stratcond.c:237
```

And we get into this situation when handling the handoff/journals endpoint and
end up freeing the memory belonging to restc then walking it again in
noit_http_rest_clean_request. Not good.

Final fix from Theo.
