### PR TITLE
Shut down Noit if there are too many restarts in a time span

### DIFF
--- a/src/noit_main.c
+++ b/src/noit_main.c
@@ -124,10 +124,9 @@ noit_main(const char *appname,
   char appscratch[1024];
   char *glider = (char *)_glider;
   char *watchdog_timeout_str;
-  char *retries = NULL;
-  char *span = NULL;
-  int retry_val = 5;
-  int span_val = 60;
+  int retry_val;
+  int span_val;
+  int ret;
   
    
   /* First initialize logging, so we can log errors */
@@ -166,14 +165,14 @@ noit_main(const char *appname,
   if(trace_dir) noit_watchdog_glider_trace_dir(trace_dir);
 
   snprintf(appscratch, sizeof(appscratch), "/%s/watchdog/@retries", appname);
-  noit_conf_get_string(NULL, appscratch, &retries);
-  if(retries) {
-    retry_val = atoi(retries);
+  ret = noit_conf_get_int(NULL, appscratch, &retry_val);
+  if((ret == 0) || (retry_val == 0)){
+    retry_val = 5;
   }
   snprintf(appscratch, sizeof(appscratch), "/%s/watchdog/@span", appname);
-  noit_conf_get_string(NULL, appscratch, &span);
-  if(span) {
-    span_val = atoi(span);
+  ret = noit_conf_get_int(NULL, appscratch, &span_val);
+  if((ret == 0) || (span_val == 0)){
+    span_val = 60;
   }
 
   /* Lastly, run through all other system inits */

--- a/src/utils/noit_watchdog.h
+++ b/src/utils/noit_watchdog.h
@@ -33,13 +33,9 @@
 #ifndef _NOIT_WATCHDOG_H
 #define _NOIT_WATCHDOG_H
 
+#include <time.h>
 #include "noit_config.h"
 #include "noit_defines.h"
-
-typedef struct{
-    time_t event_time;
-    void* next;
-} __attribute__ ((packed)) retry_data;
 
 /*! \fn int noit_watchdog_prefork_init()
     \brief Prepare the program to split into a child/parent-monitor relationship.
@@ -56,7 +52,8 @@ API_EXPORT(int)
     \brief Updates the list of retries and signals to quit if the limit is exceeded
     \param retries The number of times to attempt to restart the task with a certain span of time
     \param span The amount of time in seconds to measure attempts to restart the task over
-    \param data A pointer to the list of event data
+    \param offset The current location in the data array to place the new time in
+    \param times An array of times used to determine if there have been too many restarts
     \return Returns 1 to signal a quit, 0 otherwise
 
 .
@@ -65,7 +62,7 @@ API_EXPORT(int)
  */
 
 API_EXPORT(int)
-  update_retries(int retries, int span, retry_data** data);
+  update_retries(int retries, int span, int* offset, time_t times[]);
 
 /*! \fn int noit_watchdog_start_child(const char *app, int (*func)(), int timeout, int retries, int span)
     \brief Starts a function as a separate child under close watch.


### PR DESCRIPTION
I added support to shut down noit if it restarts too many times in a specified period of time.

This is configurable in the "watchdog" element in the main config file - adding "retries" (for the number of time to allow restarting) and "span" (for the number of seconds to look back at to determine if noit has restarted too many times) will allow this to be configured. If nothing is specified here, the system will default to 5 retries and a span of 60 seconds.

The system will track when it restarts. When it reaches the retry count within the specified span, noit will exit.
