### PR TITLE
Fix of rabbitmq routing keys

### DIFF
--- a/src/java/com/omniti/reconnoiter/broker/RabbitBroker.java
+++ b/src/java/com/omniti/reconnoiter/broker/RabbitBroker.java
@@ -147,7 +147,11 @@ public class RabbitBroker implements IMQBroker  {
     returnedQueueName = channel.queueDeclare(queueName, durableQueue,
                                              exclusiveQueue, autoDelete, null).getQueue();
     for (String rk : routingKey.split(",")) {
-        if ( rk.equalsIgnoreCase("null") ) rk = "";
+        if ( rk.equalsIgnoreCase("null") ) {
+            rk = "";
+        } else {
+            rk = rk + ".#";
+        }
         channel.queueBind(returnedQueueName, exchangeName, rk);
     }
   }


### PR DESCRIPTION
When using rabbitmq drivers, stratcon composes the routing key as:
{routingkey}.account.uuid
(the account probably has to do something with Circonus, am I right?)

But IEP tries to split the configured routingkey variable by comma and then binds to all the parts. So, say the defined routing key is "check". stratcon will emit routing key "check.0.0.0.0.a.b.c.d.....", but IEP will bind to "check". In this case, the message will not be delivered, because the binding does not match. Stratcon will complain, that it is unable to route the message and IEP will receive nothing.

This patch fixes it. IEP will bind to all parts of the split configuration parameter and add ".#" to the end, so everything starting with "check." will go to the IEP queue.
