### PR TITLE
Modify http client so it supports dot (".") in the header name.

### DIFF
--- a/src/modules-lua/noit/HttpClient.lua
+++ b/src/modules-lua/noit/HttpClient.lua
@@ -94,7 +94,7 @@ function HttpClient:get_headers()
         local str = self.e:read("\n")
         if str == nil or str == "\r\n" or str == "\n" then break end
         str = string.gsub(str, '%s+$', '')
-        local hdr, val = string.match(str, "^([-_%a%d]+):%s*(.*)$")
+        local hdr, val = string.match(str, "^([%.-_%a%d]+):%s*(.*)$")
         if hdr == nil then
             if lasthdr == nil then error ("malformed header line") end
             hdr = lasthdr


### PR DESCRIPTION
Currently Lua HTTP client doesn't allow dots in the header name.

RFC doesn't explicitly exclude dot from the header name and that's why I modified the client to also allow it.
