### PR TITLE
UI: Remove harmful slash stripping

### DIFF
--- a/ui/web/htdocs/graph_store.php
+++ b/ui/web/htdocs/graph_store.php
@@ -2,8 +2,7 @@
 
 require_once('Reconnoiter_DB.php');
 
-$json = stripslashes($_POST['json']);
-$graph = json_decode($json, true);
+$graph = json_decode($_POST['json'], true);
 $saved_id = $graph['id'];
 $db = Reconnoiter_DB::getDB();
 


### PR DESCRIPTION
The slashes should not be removed here. PHP does this automatically and this duplicate stripping mangles the data, if it contains back slashes.
