### PR TITLE
Handle nil values gracefully in composites

### DIFF
--- a/ui/web/htdocs/js/recon.js
+++ b/ui/web/htdocs/js/recon.js
@@ -544,12 +544,22 @@ function exportCanvasAsPNG(startfrom) {
                         //if the expression refers to a dataset that isnt numeric, throw an error and dont plot this dataset
                         if (data[mat] && (data[mat].metric_type == 'numeric') && data[mat].data[i][1]) 
                             return data[mat].data[i][1];
-                        else 
+                        //If it is a numeric dataset but contains a null value, return the null
+                        else if (data[mat] && (data[mat].metric_type == 'numeric') && (data[mat].data[i][1] == ""))
+                            return null;
+                        else
                             return "BAD";
                     });
-                    if (nexpr.match(/BAD/)) 
+
+                    var val;
+                    if (nexpr.match(/BAD/))  {
                         return false;
-                    var val = my_rpn_eval(nexpr, {});
+                    }
+                    // any nulls that were returned should be replaced with a 0 for calculation
+                    else if (nexpr.match(/null/)) {
+                        nexpr = nexpr.replace(/null/g,'0.0');
+                    }
+                    val = my_rpn_eval(nexpr, {});
                     data[cindex].data.push([data[nindex].data[i][0], val]);
                 }
                 return true;


### PR DESCRIPTION
Currently the composite graph functions will throw an error if you're
trying to create a composite graph and there are nil values in the
numeric data source.

This patch aims to fix that by returning the nil values as a null, then
treating them as 0.0 when it comes to calculating the graph.
