### PR TITLE
mysql: don't crash if sslmode isn't configured

### DIFF
--- a/src/modules/mysql.c
+++ b/src/modules/mysql.c
@@ -297,7 +297,7 @@ static int mysql_drive_session(eventer_t e, int mask, void *closure,
         AVAIL_BAIL(mysql_error(ci->conn));
 
 #if MYSQL_VERSION_ID >= 50000
-      if (!strcmp(sslmode, "require")) {
+      if (sslmode && !strcmp(sslmode, "require")) {
         /* mysql has a bad habit of silently failing to establish ssl and
          * falling back to unencrypted, so after making the connection, let's 
          * check that we're actually using SSL by checking for a non-NULL 


### PR DESCRIPTION
if there's no sslmode in the DSN for a mysql check, we get:
==12373== Thread 11:
==12373== Invalid read of size 1
==12373==    at 0xB086E3B: mysql_drive_session (mysql.c:300)
==12373==    by 0x447E07: eventer_jobq_consumer (eventer_jobq.c:417)
==12373==    by 0x5EAFD8B: start_thread (pthread_create.c:304)
==12373==    by 0x6B5BC2C: clone (clone.S:112)
==12373==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==12373== 
==12373== 
==12373== Process terminating with default action of signal 11 (SIGSEGV)
==12373==  Access not within mapped region at address 0x0
==12373==    at 0xB086E3B: mysql_drive_session (mysql.c:300)
==12373==    by 0x447E07: eventer_jobq_consumer (eventer_jobq.c:417)
==12373==    by 0x5EAFD8B: start_thread (pthread_create.c:304)
==12373==    by 0x6B5BC2C: clone (clone.S:112)
