### PR TITLE
make aggregation of collect5 stats work

### DIFF
--- a/src/modules/collectd.c
+++ b/src/modules/collectd.c
@@ -117,12 +117,14 @@ typedef struct meta_data_s meta_data_t;
 
 #define TYPE_HOST            0x0000
 #define TYPE_TIME            0x0001
+#define TYPE_TIME_HR         0x0008
 #define TYPE_PLUGIN          0x0002
 #define TYPE_PLUGIN_INSTANCE 0x0003
 #define TYPE_TYPE            0x0004
 #define TYPE_TYPE_INSTANCE   0x0005
 #define TYPE_VALUES          0x0006
 #define TYPE_INTERVAL        0x0007
+#define TYPE_INTERVAL_HR     0x0009
 
 /* Types to transmit notifications */
 #define TYPE_MESSAGE         0x0100
@@ -163,6 +165,14 @@ typedef struct meta_data_s meta_data_t;
         (t == DS_TYPE_ABSOLUTE) ? "absolute" : \
         "unknown"
 
+#define CDTIME_T_TO_TIME_T(t) ((time_t) ((t) / 1073741824))
+#define CDTIME_T_TO_US(t)  ((suseconds_t) (((double) (t))  / 1073.741824))
+#define CDTIME_T_TO_TIMEVAL(cdt,tvp) \
+  do { \
+    (tvp)->tv_sec = CDTIME_T_TO_TIME_T (cdt); \
+    (tvp)->tv_usec = CDTIME_T_TO_US ((cdt) % 1073741824); \
+  } while (0)
+
 #define BUFF_SIZE 1024
 
 typedef unsigned long long counter_t;
@@ -184,7 +194,7 @@ struct value_list_s
 {
   value_t *values;
   int      values_len;
-  time_t   time;
+  struct timeval time;
   int      interval;
   char     host[DATA_MAX_NAME_LEN];
   char     plugin[DATA_MAX_NAME_LEN];
@@ -224,7 +234,7 @@ typedef struct notification_meta_s
 typedef struct notification_s
 {
   int    severity;
-  time_t time;
+  struct timeval time;
   char   message[NOTIF_MAX_MSG_LEN];
   char   host[DATA_MAX_NAME_LEN];
   char   plugin[DATA_MAX_NAME_LEN];
@@ -940,7 +950,7 @@ static int parse_packet (/* {{{ */
   int packet_was_encrypted = (flags & PP_ENCRYPTED);
   int printed_ignore_warning = 0;
 
-#define VALUE_LIST_INIT { NULL, 0, 0, interval_g, "localhost", "", "", "", "", NULL }
+#define VALUE_LIST_INIT { NULL, 0, {0}, interval_g, "localhost", "", "", "", "", NULL }
   value_list_t vl = VALUE_LIST_INIT;
   notification_t n;
 
@@ -1038,7 +1048,7 @@ static int parse_packet (/* {{{ */
       {
         noitL(noit_error,
               "collectd: NOT dispatching values [%lld,%s:%s:%s]\n",
-              (long long int)vl.time, vl.host, vl.plugin, vl.type);
+              (long long int)vl.time.tv_sec, vl.host, vl.plugin, vl.type);
       }
 
       sfree (vl.values);
@@ -1050,8 +1060,18 @@ static int parse_packet (/* {{{ */
       status = parse_part_number (&buffer, &buffer_size, &tmp);
       if (status == 0)
       {
-        vl.time = (time_t) tmp;
-        n.time = (time_t) tmp;
+        vl.time.tv_sec = (time_t) tmp;
+        n.time.tv_sec = (time_t) tmp;
+      }
+    }
+    else if (pkg_type == TYPE_TIME_HR)
+    {
+      uint64_t tmp = 0;
+      status = parse_part_number (&buffer, &buffer_size, &tmp);
+      if (status == 0)
+      {
+        CDTIME_T_TO_TIMEVAL(tmp, &vl.time);
+        CDTIME_T_TO_TIMEVAL(tmp, &n.time);
       }
     }
     else if (pkg_type == TYPE_INTERVAL)
@@ -1061,6 +1081,14 @@ static int parse_packet (/* {{{ */
           &tmp);
       if (status == 0)
         vl.interval = (int) tmp;
+    }
+    else if (pkg_type == TYPE_INTERVAL_HR)
+    {
+      uint64_t tmp = 0;
+      status = parse_part_number (&buffer, &buffer_size,
+          &tmp);
+      if (status == 0)
+        vl.interval = CDTIME_T_TO_TIME_T(tmp);
     }
     else if (pkg_type == TYPE_HOST)
     {


### PR DESCRIPTION
steal some CDTIME_T macros from collectd, and then implement support
for the new hires time and interval packets.

5.0 appears only to send the hires values, and 4 only sends the only TIME and INTERVAL types, so we don't need to be particularly clever about parsing stuff.
