### PR TITLE
Dont include ttfirstbye metric if firstbytetime is nil

### DIFF
--- a/src/modules-lua/noit/module/http.lua
+++ b/src/modules-lua/noit/module/http.lua
@@ -412,7 +412,7 @@ function initiate(module, check)
     elapsed(check, "tt_connect", starttime, connecttime)
 
     if firstbytetime ~= nil then
-        elapsed(check, "tt_firstbyte", starttime, firstbytetime)
+      elapsed(check, "tt_firstbyte", starttime, firstbytetime)
     end
 
     -- size


### PR DESCRIPTION
Here is an error we recently noticed in staging: `"attempt to index local 'o1' (a nil value)`

`tt_firstbyte` metric is not present if the TCP connection is accepted but the server never sends any data over it or if the connection is immediately closed.

This will make the code explode in the [timeval subtraction](https://github.com/omniti-labs/reconnoiter/blob/master/src/modules-lua/noit/timeval.lua#L60) inside the [elapsed](https://github.com/omniti-labs/reconnoiter/blob/master/src/modules-lua/noit/module/http.lua#L149) function.

P.S. Actual calculation is `endtime - starttime` which means `o1 = endtime`, `o2 = starttime` and not vice-versa.
