### PR TITLE
Bug Fix When Changing Check Target From FQDN to IP Address

### DIFF
--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -783,6 +783,10 @@ noit_check_update(noit_check_t *new_check,
     new_check->flags |= NP_SINGLE_RESOLVE;
   else
     new_check->flags &= ~NP_SINGLE_RESOLVE;
+  if (flags & NP_RESOLVE)
+    new_check->flags |= NP_RESOLVE;
+  else
+    new_check->flags &= ~NP_RESOLVE;
 
   if(noit_check_set_ip(new_check, target)) {
     noit_boolean should_resolve;


### PR DESCRIPTION
There was a bug in the C source causing Reconnoiter to attempt to resolve an IP Address as a fully qualified domain name if you updated the check from a FQDN to an IP Address; fixed this bug to make sure the bit gets set correctly.
