### PR TITLE
SSL Updates For TCP and IMAP Checks

### DIFF
--- a/docs/config/modules/noit.module.imap.xml
+++ b/docs/config/modules/noit.module.imap.xml
@@ -284,6 +284,28 @@ SL checks).</para>
         </listitem>
       </varlistentry>
     </variablelist>
+    <variablelist>
+      <varlistentry>
+        <term>header_Host</term>
+        <listitem>
+          <variablelist>
+            <varlistentry>
+              <term>required</term>
+              <listitem>
+                <para>optional</para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>allowed</term>
+              <listitem>
+                <para>.+</para>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+          <para>The host header to validate against the SSL certificate (for SSL checks).</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
   </section>
   <example>
     <title>Checking IMAP connection.</title>

--- a/docs/config/modules/noit.module.tcp.xml
+++ b/docs/config/modules/noit.module.tcp.xml
@@ -228,6 +228,28 @@ SL checks).</para>
         </listitem>
       </varlistentry>
     </variablelist>
+    <variablelist>
+      <varlistentry>
+        <term>header_Host</term>
+        <listitem>
+          <variablelist>
+            <varlistentry>
+              <term>required</term>
+              <listitem>
+                <para>optional</para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>allowed</term>
+              <listitem>
+                <para>.+</para>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+          <para>The host header to validate against the SSL certificate (for SSL checks).</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
   </section>
   <example>
     <title>Checking TCP connection.</title>

--- a/src/modules-lua/noit/extras.lua
+++ b/src/modules-lua/noit/extras.lua
@@ -28,6 +28,7 @@
 -- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 -- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+local ipairs = ipairs
 local string = require("string")
 local table = require("table")
 module("noit.extras")
@@ -67,3 +68,47 @@ function iptonumber(str)
   return num
 end
 
+function check_host_header_against_certificate(host_header, cert_subject, san_list)
+  local san_list_check = function (array, value)
+    for i, line in ipairs(array) do
+      if line == value then
+        return true
+      else
+        line = string.gsub(line, '%.', "%%%.")
+        line = string.gsub(line, "%*", "[^\.]*")
+        local match = string.match(value, line)
+        if match == value then
+          return true
+        end
+      end
+    end
+    return false
+  end
+  -- First, check for SAN values if they exist - if they do, check for a match
+  local san_array = { }
+  if san_list ~= nil then
+    san_array = split(san_list, ", ")
+  end
+  if san_list_check(san_array, host_header) then
+    -- The host header was in the SAN list, so we're done
+    return nil
+  end
+  -- Next, pull out the CN value
+  local cn = string.sub(cert_subject, string.find(cert_subject, 'CN=[^/\n]*'))
+  if cn == nil or cn == '' then
+    -- no common name given, give an error
+    return 'CN not found in certificate'
+  end
+  cn = string.sub(cn, 4)
+  if cn == host_header then
+    -- CN and host_header match exactly, so no error
+    return nil
+  end
+  cn = string.gsub(cn, '%.', "%%%.")
+  cn = string.gsub(cn, "%*", "[^\.]*")
+  local match = string.match(host_header, cn)
+  if match == host_header then
+    return nil
+  end
+  return 'host header does not match CN or SANs in certificate'
+end

--- a/src/modules-lua/noit/module/http.lua
+++ b/src/modules-lua/noit/module/http.lua
@@ -295,52 +295,6 @@ function get_absolute_path(uri)
     return toReturn
 end
 
-function san_list_check(array, value)
-  for i, line in ipairs(array) do
-    if line == value then
-      return true
-    else
-      line = string.gsub(line, '%.', "%%%.")
-      line = string.gsub(line, "%*", "[^\.]*")
-      local match = string.match(value, line)
-      if match == value then
-        return true
-      end
-    end
-  end
-  return false
-end
-
-function check_host_header_against_certificate(host_header, cert_subject, san_list)
-  -- First, check for SAN values if they exist - if they do, check for a match
-  local san_array = { }
-  if san_list ~= nil then
-    san_array = noit.extras.split(san_list, ", ")
-  end
-  if san_list_check(san_array, host_header) then
-    -- The host header was in the SAN list, so we're done
-    return nil
-  end
-  -- Next, pull out the CN value
-  local cn = string.sub(cert_subject, string.find(cert_subject, 'CN=[^/\n]*'))
-  if cn == nil or cn == '' then
-    -- no common name given, give an error
-    return 'CN not found in certificate'
-  end
-  cn = string.sub(cn, 4)
-  if cn == host_header then
-    -- CN and host_header match exactly, so no error
-    return nil
-  end
-  cn = string.gsub(cn, '%.', "%%%.")
-  cn = string.gsub(cn, "%*", "[^\.]*")
-  local match = string.match(host_header, cn)
-  if match == host_header then
-    return nil
-  end
-  return 'host header does not match CN or SANs in certificate'
-end
-
 function initiate(module, check)
     local url = check.config.url or 'http:///'
     local schema, host, port, uri = string.match(url, "^(https?)://([^:/]*):?([0-9]*)(/?.*)$");
@@ -632,7 +586,10 @@ function initiate(module, check)
     -- ssl ctx
     local ssl_ctx = client:ssl_ctx()
     if ssl_ctx ~= nil then
-      local header_match_error = check_host_header_against_certificate(host_header, ssl_ctx.subject, ssl_ctx.san_list)
+      local header_match_error = nil
+      if host_header ~= '' then
+        header_match_error = noit.extras.check_host_header_against_certificate(host_header, ssl_ctx.subject, ssl_ctx.san_list)
+      end
       if ssl_ctx.error ~= nil then status = status .. ',sslerror' end
       if header_match_error == nil then
         check.metric_string("cert_error", ssl_ctx.error)

--- a/src/modules-lua/noit/module/tcp.lua
+++ b/src/modules-lua/noit/module/tcp.lua
@@ -63,6 +63,9 @@ SL checks).</parameter>
     <parameter name="ciphers"
                required="optional"
                allowed=".+">A list of ciphers to be used in the SSL protocol (for SSL checks).</parameter>
+    <parameter name="header_Host"
+               required="optional"
+               allowed=".+">The host header to validate against the SSL certificate (for SSL checks).</parameter>
   </checkconfig>
   <examples>
     <example>
@@ -127,6 +130,7 @@ function initiate(module, check)
   local good = false
   local status = ""
   local use_ssl = false
+  local host_header = check.config.header_Host or ''
 
   if check.config.port == nil then
     check.status("port is not specified")
@@ -146,10 +150,17 @@ function initiate(module, check)
     return
   end
 
+  local ca_chain = 
+     noit.conf_get_string("/noit/eventer/config/default_ca_chain")
+
+  if check.config.ca_chain ~= nil and check.config.ca_chain ~= '' then
+    ca_chain = check.config.ca_chain
+  end
+
   if use_ssl == true then
     rv, err = e:ssl_upgrade_socket(check.config.certificate_file,
                                         check.config.key_file,
-                                        check.config.ca_chain,
+                                        ca_chain,
                                         check.config.ciphers)
   end 
 
@@ -167,10 +178,23 @@ function initiate(module, check)
   -- ssl metrics
   local ssl_ctx = e:ssl_ctx()
   if ssl_ctx ~= nil then
+    local header_match_error = nil
+    if host_header ~= '' then
+      header_match_error = noit.extras.check_host_header_against_certificate(host_header, ssl_ctx.subject, ssl_ctx.san_list)
+    end
     if ssl_ctx.error ~= nil then status = status .. ',sslerror' end
-    check.metric_string("cert_error", ssl_ctx.error)
+    if header_match_error == nil then
+      check.metric_string("cert_error", ssl_ctx.error)
+    elseif ssl_ctx.error == nil then
+      check.metric_string("cert_error", header_match_error)
+    else
+      check.metric_string("cert_error", ssl_ctx.error .. ', ' .. header_match_error)
+    end
     check.metric_string("cert_issuer", ssl_ctx.issuer)
     check.metric_string("cert_subject", ssl_ctx.subject)
+    if ssl_ctx.san_list ~= nil then
+      check.metric_string("cert_subject_alternative_names", ssl_ctx.san_list)
+    end
     check.metric_uint32("cert_start", ssl_ctx.start_time)
     check.metric_uint32("cert_end", ssl_ctx.end_time)
     check.metric_int32("cert_end_in", ssl_ctx.end_time - os.time())


### PR DESCRIPTION
A couple of changes...

1) I added improved SSL support to the TCP and IMAP checks. If the user fails to specify a ca-chain file, it will now use the default one, as in the HTTP check. I have also added a "header_Host" field to each of these checks that a user can enter to verify the CN/SANs coming from the certificate. If the user fails to specify a header_Host, it will not give a certificate mismatch error. I also moved the Lua code to verify the headers from HTTP.lua to extras.lua where it can be used by multiple checks.

2) I changed the default behavior of the HTTP check to not throw an error when no header_Host is provided. This will match the behavior in the TCP and IMAP checks and be consistent.
