### PR TITLE
Fix an empty string URI when we get a Location header like "http://examp...

### DIFF
--- a/src/modules-lua/noit/module/http.lua
+++ b/src/modules-lua/noit/module/http.lua
@@ -277,7 +277,7 @@ function get_new_uri(old_uri, new_uri)
 end
 
 function get_absolute_path(uri)
-    if uri == nil then return "/" end
+    if uri == nil or #uri == 0 then return "/" end
     local toReturn = uri
     local go_back = string.find(toReturn, "%.%./")
     while go_back ~= nil do


### PR DESCRIPTION
...le.com" (without the trailing slash).

Kudos to Ryan Phillips <ryan.phillips rackspace.com> for figuring this bug out.
