### PR TITLE
Use target_ip instead of target for collectd and statsd comparisons

### DIFF
--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -1043,7 +1043,8 @@ noit_poller_target_do(const char *target, int (*f)(noit_check_t *, void *),
   noit_skiplist_node *next;
 
   memset(&pivot, 0, sizeof(pivot));
-  memcpy(pivot.target_ip, (char*)target, strlen((char*)target));
+  if (strlen((char*)target) < sizeof(pivot.target_ip))
+    memcpy(pivot.target_ip, (char*)target, strlen((char*)target));
   pivot.name = "";
   pivot.target = "";
   noit_skiplist_find_neighbors(&polls_by_target_ip, &pivot, NULL, NULL, &next);


### PR DESCRIPTION
Changed the way collectd and statsd look for matches for data - use the target_ip instead of the target.
