### PR TITLE
Updated to use target_ip in noit_check skiplist

### DIFF
--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -1046,8 +1046,7 @@ noit_poller_target_do(const char *target, int (*f)(noit_check_t *, void *),
   tlist = sn->data;
 
   memset(&pivot, 0, sizeof(pivot));
-  if (strlen((char*)target) < sizeof(pivot.target_ip))
-    memcpy(pivot.target_ip, (char*)target, strlen((char*)target));
+  strlcpy(pivot.target_ip, (char*)target, sizeof(pivot.target_ip));
   pivot.name = "";
   pivot.target = "";
   noit_skiplist_find_neighbors(tlist, &pivot, NULL, NULL, &next);


### PR DESCRIPTION
Updated in noit_check so that when matching IP addresses to targets, we will use the target_ip value rather than the target value.

I added a secondary index to the polls_by_name skiplist to sort by target_ip, then modified the code to update this list whenever the DNS resolution of the check changes.
