### PR TITLE
Various SMTP Check Upgrades

### DIFF
--- a/src/modules-lua/noit/module/smtp.lua
+++ b/src/modules-lua/noit/module/smtp.lua
@@ -319,6 +319,7 @@ function initiate(module, check)
   if try_starttls then
     local starttls  = action("starttls", "STARTTLS", 220)
     if not starttls then
+      check.unavailable()
       check.status("Could not start TLS for this target")
       return
     end


### PR DESCRIPTION
Made a few upgrades to the SMTP Check:
- If no CA Chain is provided, use the default one rather than not using any
- Check to make sure that starttls actually works and return an error if it fails
- Improve error handling to avoid trying to process nil values
- Report subject alternative names when using TLS
