### PR TITLE
Fix sending of SNI to use the 'most correct' host header.

### DIFF
--- a/src/modules-lua/noit/module/http.lua
+++ b/src/modules-lua/noit/module/http.lua
@@ -312,7 +312,7 @@ function initiate(module, check)
     local redirects = check.config.redirects or 0
     local include_body = false
     local read_limit = tonumber(check.config.read_limit) or nil
-    local host_header = check.config.header_Host or ''
+    local host_header = check.config.header_Host
     local http_version = check.config.http_version or '1.1'
 
     -- expect the worst
@@ -320,6 +320,7 @@ function initiate(module, check)
     check.unavailable()
 
     if host == nil then host = check.target end
+    if host_header == nil then host_header = host end
     if schema == nil then
         schema = 'http'
         uri = '/'
@@ -445,7 +446,6 @@ function initiate(module, check)
     repeat
         local optclient = HttpClient:new(callbacks)
         local rv, err = optclient:connect(target, port, use_ssl, host_header)
-
         if rv ~= 0 then
             check.status(err or "unknown error")
             return

--- a/src/modules/lua_noit.c
+++ b/src/modules/lua_noit.c
@@ -682,7 +682,7 @@ noit_lua_socket_connect_ssl(lua_State *L) {
     return 1;
   }
 
-  if (snihost != NULL) {
+  if (snihost != NULL && strlen(snihost) >= 1) {
     eventer_ssl_ctx_set_sni(sslctx, snihost);
   }
 


### PR DESCRIPTION
- This also slightly changes the behavior of the `Host:` header, having it fallback to the Target, instead of empty quotes `''`, but makes the SNI value match up with it.
