### PR TITLE
Don't follow that last redirect in HTTP

### DIFF
--- a/src/modules-lua/noit/module/http.lua
+++ b/src/modules-lua/noit/module/http.lua
@@ -457,7 +457,7 @@ function initiate(module, check)
         redirects = redirects - 1
         client = optclient
 
-        if next_location ~= nil then
+        if redirects > 0 and next_location ~= nil then
             -- reset some stuff for the redirect
             local prev_port = port
             local prev_host = host


### PR DESCRIPTION
When we have zero redirects left to follow, don't try to resolve the last URL and reset everything.
