### PR TITLE
Varnish module appears broken for v 2.1.5 and newer. 

### DIFF
--- a/src/modules-lua/noit/module/varnish.lua
+++ b/src/modules-lua/noit/module/varnish.lua
@@ -83,6 +83,7 @@ function initiate(module, check)
   local rv, err = e:connect(check.target_ip, check.config.port or 8081)
 
   e:write("stats\r\n")
+  e:write("quit\r\n")
   str = e:read("\n")
 
   if rv ~= 0 or not str then
@@ -102,14 +103,16 @@ function initiate(module, check)
     return
   end
 
-  local rawstats = e:read(len)
+  local rawstats = e:read("Closing CLI connection")
   local i = 0
   for v, k in string.gmatch(rawstats, "%s*(%d+)%s+([^\r\n]+)") do
-    k = string.gsub(k, "^%s*", "")
-    k = string.gsub(k, "%s*$", "")
-    k = string.gsub(k, "%s", "_")
-    check.metric(k,v)
-    i = i + 1
+    if string.find(k, "^[a-zA-Z]") then
+       k = string.gsub(k, "^%s*", "")
+       k = string.gsub(k, "%s*$", "")
+       k = string.gsub(k, "%s", "_")
+       print(k .. " - " .. v)
+       i = i + 1
+     end
   end
   check.status(string.format("%d stats", i))
   check.good()


### PR DESCRIPTION
I guess a header change broke the current varnish module. Using as is returned one metric: '----------------------------- = 0' which is obviously a part of the header.

My pull request makes the assumption of all metrics start with a alphabetic character, and that the connection termination string is always "Closing CLI connection" which seems to be the case up until the current version (3.0.3) 
