### PR TITLE
Configurable Text Metric Size Limit

### DIFF
--- a/src/modules/check_test.c
+++ b/src/modules/check_test.c
@@ -97,7 +97,7 @@ noit_check_t *
 noit_fire_check(xmlNodePtr attr, xmlNodePtr config, const char **error) {
   char *target = NULL, *name = NULL, *module = NULL, *filterset = NULL;
   char *resolve_rtype = NULL;
-  int timeout = 0, flags = NP_TRANSIENT, i, mod_cnt;
+  int timeout = 0, flags = NP_TRANSIENT, i, mod_cnt, text_size_limit = 512;
   noit_module_t *m;
   noit_check_t *c = NULL;
   xmlNodePtr a, co;
@@ -117,6 +117,10 @@ noit_fire_check(xmlNodePtr attr, xmlNodePtr config, const char **error) {
       char *timeout_str = (char *)xmlNodeGetContent(a);
       timeout = atoi(timeout_str);
       free(timeout_str);
+    } else if(!strcmp((char *)a->name, "text_size_limit")) {
+      char *size_limit_str = (char *)xmlNodeGetContent(a);
+      text_size_limit = atoi(size_limit_str);
+      free(size_limit_str);
     } else if(!strcmp((char *)a->name, "resolve_rtype")) 
       resolve_rtype = (char *)xmlNodeGetContent(a);
   }
@@ -157,7 +161,7 @@ noit_fire_check(xmlNodePtr attr, xmlNodePtr config, const char **error) {
   c = calloc(1, sizeof(*c));
   c->module = strdup(module);
   noit_check_update(c, target, name, filterset,
-                    conf_hash, moptions, 0, timeout, NULL, flags);
+                    conf_hash, moptions, 0, timeout, NULL, flags, text_size_limit);
   uuid_generate(c->checkid);
   c->flags |= NP_DISABLED; /* this is hack to know we haven't run it yet */
   if(NOIT_CHECK_SHOULD_RESOLVE(c))

--- a/src/noit.conf.in
+++ b/src/noit.conf.in
@@ -115,7 +115,8 @@
   </rest>
   <checks filterset="default"
           resolve_rtype="prefer-ipv4"
-          transient_min_period="1000" transient_period_granularity="500">
+          transient_min_period="1000" transient_period_granularity="500"
+          text_size_limit = "512">
     <config xmlns:ip_acl="noit://module/ip_acl">
       <ip_acl:global/>
     </config>

--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -170,6 +170,7 @@ typedef struct noit_check {
   void **module_metadata;
   noit_hash_table **module_configs;
   struct timeval initial_schedule_time;
+  u_int32_t text_size_limit;   /* Maximum size of a text data field before truncating */
 } noit_check_t;
 
 #define NOIT_CHECK_LIVE(a) ((a)->fire_event != NULL)
@@ -207,7 +208,8 @@ API_EXPORT(int)
                        const char *oncheck,
                        int flags,
                        uuid_t in,
-                       uuid_t out);
+                       uuid_t out,
+                       u_int32_t text_size_limit);
 
 API_EXPORT(int)
   noit_check_resolve(noit_check_t *check);
@@ -222,7 +224,8 @@ API_EXPORT(int)
                     u_int32_t period,
                     u_int32_t timeout,
                     const char *oncheck,
-                    int flags);
+                    int flags,
+                    u_int32_t text_size_limit);
 
 API_EXPORT(noit_boolean)
   noit_check_is_valid_target(const char *str);


### PR DESCRIPTION
Added the ability to truncate the value of any text metric. The default value is 512 characters; if no value is given, all text metrics will be automatically truncated to 512 characters. This is configurable either on all checks or on individual checks via the configuration file; the "text_size_limit" attribute must be set.
