### PR TITLE
initialize threading in ssh2 module

### DIFF
--- a/src/modules/ssh2.c
+++ b/src/modules/ssh2.c
@@ -48,6 +48,7 @@
 #include "utils/noit_hash.h"
 
 #include <libssh2.h>
+#include <gcrypt.h>
 
 #define DEFAULT_SSH_PORT 22
 
@@ -103,7 +104,11 @@ static void ssh2_cleanup(noit_module_t *self, noit_check_t *check) {
     memset(ci, 0, sizeof(*ci));
   }
 }
+
+GCRY_THREAD_OPTION_PTHREAD_IMPL;
+
 static int ssh2_init(noit_module_t *self) {
+  gcry_control(GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
   return 0;
 }
 static int ssh2_config(noit_module_t *self, noit_hash_table *options) {


### PR DESCRIPTION
This seems to have fixed the noitd crashes mentioned in this thread:
http://lists.omniti.com/pipermail/reconnoiter-users/2012-September/000798.html

As suggested by Theo, I've added the `gcry_control()` call at module initialization, along with a call to `GCRY_THREAD_OPTION_PTHREAD_IMPL;` to make it all work.

I've seen no segfaults for several days after adding this (and previously on that same system the crashes were pretty common).
