### PR TITLE
Don't Allow noit_hash_init_size values of zero

### DIFF
--- a/src/utils/noit_hash.c
+++ b/src/utils/noit_hash.c
@@ -109,7 +109,10 @@ void noit_hash_init(noit_hash_table *h) {
 void noit_hash_init_size(noit_hash_table *h, int size) {
   memset(h, 0, sizeof(noit_hash_table));
   h->initval = lrand48();
-  h->table_size = size;
+  if (size > 0)
+    h->table_size = size;
+  else
+    h->table_size = NoitHASH_INITIAL_SIZE;
   h->buckets = calloc(h->table_size, sizeof(noit_hash_bucket *));
 }
 


### PR DESCRIPTION
If a user calls the noit_hash_init_size function with a size of zero, the system used to calloc an object of size zero. Instead, it will now calloc the default hash table size instead.
