### PR TITLE
Stratcon/Noit Connection Bugs Fixed

### DIFF
--- a/src/stratcon_jlog_streamer.c
+++ b/src/stratcon_jlog_streamer.c
@@ -303,10 +303,11 @@ noit_connection_ctx_free(noit_connection_ctx_t *ctx) {
   }
   ctx->consumer_free(ctx->consumer_ctx);
   if (ctx->e) {
-    if (ctx->e->fd) {
-        close(ctx->e->fd);
+    if (ctx->e->fd >= 0) {
+        int mask = 0;
+        eventer_remove_fd(ctx->e->fd);
+        ctx->e->opset->close(ctx->e->fd, &mask, ctx->e);
     }
-    eventer_remove_fd(ctx->e->fd);
     ctx->e->fd = 0;
     eventer_remove(ctx->e);
     eventer_free(ctx->e);


### PR DESCRIPTION
Found and corrected a couple of bugs with regards to the connection between Stratcon and Noits
- If a noit was removed from the list of active nodes on Stratcon, it wouldn't break the connection and would continue to receive data.
- If the "show" REST command was called, there were some cases where the reference count for Stratcon eventer data was being incremented, but never decremented, resulting in noit connections not being cleaned up and freed when removed from the system.
