### PR TITLE
Include Error Fix For lua_snmp.c

### DIFF
--- a/src/modules/lua_snmp.c
+++ b/src/modules/lua_snmp.c
@@ -30,12 +30,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "lua_noit.h"
 #include "noit_defines.h"
 
 #include <string.h>
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
+#include "lua_noit.h"
 
 static int
 nl_convert_mib(lua_State *L) {


### PR DESCRIPTION
Including lua_noit.h before including net-snmp files causes compilation errors on OSX and CentOS due to redefinition of the clear macro. Moved the lua_noit.h include to after the net-snmp includes.
