### PR TITLE
More Accurate Lua Syntax

### DIFF
--- a/src/modules-lua/noit/extras.lua
+++ b/src/modules-lua/noit/extras.lua
@@ -77,8 +77,8 @@ function check_host_header_against_certificate(host_header, cert_subject, san_li
       if line == value then
         return true
       else
-        line = string.gsub(line, '%.', "%%%.")
-        line = string.gsub(line, "%*", "[^%.]*")
+        line = string.gsub(line, '%.', "%%.")
+        line = string.gsub(line, "%*", "[^.]*")
         local match = string.match(value, line)
         if match == value then
           return true
@@ -107,8 +107,8 @@ function check_host_header_against_certificate(host_header, cert_subject, san_li
     -- CN and host_header match exactly, so no error
     return nil
   end
-  cn = string.gsub(cn, '%.', "%%%.")
-  cn = string.gsub(cn, "%*", "[^%.]*")
+  cn = string.gsub(cn, '%.', "%%.")
+  cn = string.gsub(cn, "%*", "[^.]*")
   local match = string.match(host_header, cn)
   if match == host_header then
     return nil


### PR DESCRIPTION
Fixed a couple of Lua calls to gsub that were unnecessarily using percent signs to escape characters in the replace string. Escaping these characters is unnecessary and while it is accepted and ignored in Lua 5.1, it will break future released of Lua.
