### PR TITLE
Update To Remove Calls To table.getn()

### DIFF
--- a/src/lua/test/echo.lua
+++ b/src/lua/test/echo.lua
@@ -1,5 +1,5 @@
 -- echo command line arguments
 
-for i=0,table.getn(arg) do
+for i=0,#arg do
  print(i,arg[i])
 end

--- a/src/modules-lua/json.lua
+++ b/src/modules-lua/json.lua
@@ -356,7 +356,7 @@ function isArray(t)
       maxIndex = math.max(maxIndex,k)
     else
       if (k=='n') then
-        if v ~= table.getn(t) then return false end  -- False if n does not hold the number of elements
+        if v ~= #t then return false end  -- False if n does not hold the number of elements
       else -- Else of (k=='n')
         if isEncodable(v) then return false end
       end  -- End of (k~='n')

--- a/src/modules-lua/noit/HttpClient.lua
+++ b/src/modules-lua/noit/HttpClient.lua
@@ -272,7 +272,7 @@ function HttpClient:auth_digest(method, uri, user, pass, challenge)
     local c = ', ' .. challenge
     local nc = '00000001'
     local function rand_string(t, l)
-        local n = table.getn(t)
+        local n = #t
         local o = ''
         while l > 0 do
           o = o .. t[math.random(1,n)]

--- a/src/modules-lua/noit/module/redis.lua
+++ b/src/modules-lua/noit/module/redis.lua
@@ -142,7 +142,7 @@ function build_redis_command(command)
   local redis_comm = "*"
   local comm_list = string.split(command, "%s+")
 
-  redis_comm = redis_comm .. table.getn(comm_list) .. "\r\n"
+  redis_comm = redis_comm .. #comm_list .. "\r\n"
 
   for c in ipairs(comm_list) do
     redis_comm = redis_comm .. "$" .. comm_list[c]:len() .. "\r\n" .. comm_list[c] .. "\r\n"
@@ -183,7 +183,7 @@ function get_info_metrics(conn, check)
         for idx in pairs(alloc_metrics) do
           count = count + 1
           met = string.split(alloc_metrics[idx], "=")
-          if ( 3 == table.getn(met) ) then
+          if ( 3 == #met ) then
               check.metric_int32("allocation_stats`" .. met[2], met[3])
           else
               check.metric_int32("allocation_stats`" .. met[1], met[2])


### PR DESCRIPTION
table.getn() is a depreciated function call... In versions of lua > 5.1, table.getn() is no longer support. The length operator ('#') should be used instead.
