### PR TITLE
Multiple DHCP Check Fixes

### DIFF
--- a/docs/config/modules/noit.module.dhcp.xml
+++ b/docs/config/modules/noit.module.dhcp.xml
@@ -18,6 +18,34 @@
   </variablelist>
   <section>
     <title>Module Configuration</title>
+    <variablelist>
+      <varlistentry>
+        <term>internal_port</term>
+        <listitem>
+          <variablelist>
+            <varlistentry>
+              <term>required</term>
+              <listitem>
+                <para>optional</para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>default</term>
+              <listitem>
+                <para>55000</para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>allowed</term>
+              <listitem>
+                <para>\d+</para>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+          <para>The local port that individual checks will pass DHCP configuration information to.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
   </section>
   <section>
     <title>Check Configuration</title>


### PR DESCRIPTION
Made some fixes to the DHCP check.

1) There was an outdated lua call to the "tonumber" function that was taking a hex string with a leading "0x" as a parameter. This is supported in Lua 5.1, but is deprecated. Modified this to work in all version of Lua.

2) Some DHCP servers require that DHCP requests be sent from port 68 (a restricted port). The DHCP check was always sending from an unbound, random port. To correct this, I added another coroutine in the init phase to listen on a user-defined port (default 55000). Rather than sending directly to the DHCP server, the DHCP check will send relevant information to this port on 127.0.0.1. The coroutine will read this, convert it into a relevant DHCP message, and pass it to the DHCP server. This will allow the check itself to not run as a privileged user while still allowing binding to the privileged port.
