### PR TITLE
Varnish Check Sets Metrics Again

### DIFF
--- a/src/modules-lua/noit/module/varnish.lua
+++ b/src/modules-lua/noit/module/varnish.lua
@@ -110,7 +110,7 @@ function initiate(module, check)
        k = string.gsub(k, "^%s*", "")
        k = string.gsub(k, "%s*$", "")
        k = string.gsub(k, "%s", "_")
-       print(k .. " - " .. v)
+       check.metric(k, v)
        i = i + 1
      end
   end


### PR DESCRIPTION
The Varnish check was not setting metrics... it was only attempting to print them. The check now sets metrics properly again.
