### PR TITLE
Fixed Munin Check

### DIFF
--- a/src/modules-lua/noit/module/munin.lua
+++ b/src/modules-lua/noit/module/munin.lua
@@ -116,7 +116,7 @@ function initiate(module, check)
   local i = 0
   for p in string.gmatch(plugins, "%s*(%S+)%s*") do
     e:write("fetch " .. p .. "\r\n")
-    local rawstats = e:read("\n")
+    local rawstats = e:read(".\n")
     for k, v in string.gmatch(rawstats, "\n?(%S+)%.value%s+([^\r\n]+)") do
       if v == "U" then
         check.metric_double(p .. "`" .. k,nil)


### PR DESCRIPTION
The Munin check was not getting all of the data it needed...
It was only reading the first line after each fetch command,
thus losing all of the data in subsequent lines. The Munin
check needs to read everything up to a dot followed by a 
newline to work properly.
