### PR TITLE
Fix JDBC and Resmon NullPointers

### DIFF
--- a/src/java/com/omniti/jezebel/ResmonResult.java
+++ b/src/java/com/omniti/jezebel/ResmonResult.java
@@ -98,7 +98,7 @@ public class ResmonResult {
         synchronized(metrics) {
             for (Map.Entry<String,ResmonMetricData> e : metrics.entrySet()) {
                 ResmonMetricData d = e.getValue();
-                char valueChars[] = {'[','[','N','U','L','L',']',']'};
+                char valueChars[] = {'[','[','n','u','l','l',']',']'};
                 if ( d.value != null ) {
                   valueChars = d.value.toCharArray();
                 }

--- a/src/java/com/omniti/jezebel/check/JDBC.java
+++ b/src/java/com/omniti/jezebel/check/JDBC.java
@@ -213,7 +213,12 @@ public abstract class JDBC implements JezebelCheck {
               default:
                 if(auto) {
                   String s = rs.getString(i);
-                  if (s != null) {
+                  if (s == null) {
+                    // don't do any auto decoding if it is null, just treat
+                    // it as a string since we have no way to guess
+                    rr.set(name, s);
+                  }
+                  else {
                     try { Long l = Long.decode(s); rr.set(name, l); }
                     catch (NumberFormatException nfe) {
                       try { Double d = Double.valueOf(s); rr.set(name, d); }


### PR DESCRIPTION
If we got null back from DB when using auto types, we would generate a NullPointerException when attempting to decode it as a number, so... lets just not try to decode a null shall we.

Then, once we passed null through, ResmonResult would die on a NullPointerException as well, so init the value it is going to print to the special [[NULL]] string and only set the actul value if it isn't null.
