### PR TITLE
Allow Empty String Text Values When Unpacking Bundles

### DIFF
--- a/src/noit_check_log_helpers.c
+++ b/src/noit_check_log_helpers.c
@@ -292,7 +292,7 @@ noit_check_log_b_to_sm(const char *line, int len, char ***out) {
       default:
         break;
     }
-    if(value_size == 0) continue; /* WTF, bad metric_type? */
+    if(value_size == 0 && m.metric_type != METRIC_STRING) continue; /* WTF, bad metric_type? */
 
     size = 2 /* M\t */ + strlen(timestamp) + 1 /* \t */ +
            strlen(uuid_str) + 1 /* \t */ + strlen(metric->name) +


### PR DESCRIPTION
The empty string is a valid value for text metrics; however, the bundle unpacking code was kicking out any value with a string length of zero. Changed this to only reject non-text values with a string length of zero and allow text values with a length of zero.
