### PR TITLE
Function drop_old_metrics was broken

### DIFF
--- a/sql/sprocs/stratcon.drop_old_metrics.sql
+++ b/sql/sprocs/stratcon.drop_old_metrics.sql
@@ -36,8 +36,8 @@ begin
       from pg_class c
       join pg_namespace n on (c.relnamespace = n.oid)
      where relkind = 'r'
-       and relname like 'metric_%_archive_%' 
-       and ( relname <= ('metric_numeric_archive_' || v_tdate) or relname <= ('metric_text_archive_' || v_tdate))
+       and ( ( relname like 'metric_numeric_archive_%' and relname <= ('metric_numeric_archive_' || v_tdate) ) or 
+             ( relname like 'metric_text_archive_%' and relname <= ('metric_text_archive_' || v_tdate) ) )
      order by relname 
   loop
     v_sql := 'drop table ' || v_rec.tablename;


### PR DESCRIPTION
The logic of selecting tables was wrong. I wonder how it worked for me in the first place. Anyway, it's fixed now. 

Anyone upgrading has to run the function recreate though, like this:

psql -d reconnoiter -U stratcon < sql/sprocs/stratcon.drop_old_metrics.sql
