### PR TITLE
Handle Exception In noit_connection_ssl_upgrade Properly

### DIFF
--- a/src/stratcon_jlog_streamer.c
+++ b/src/stratcon_jlog_streamer.c
@@ -576,6 +576,9 @@ noit_connection_ssl_upgrade(eventer_t e, int mask, void *closure,
   GET_FEEDTYPE(nctx, feedtype);
   STRATCON_CONNECT_SSL(e->fd, (char *)feedtype, nctx->remote_str,
                             (char *)cn_expected);
+  if (mask & EVENTER_EXCEPTION) {
+    goto error;
+  }
   rv = eventer_SSL_connect(e, &mask);
   sslctx = eventer_get_eventer_ssl_ctx(e);
 


### PR DESCRIPTION
The function noit_connection_ssl_upgrade was not handling exceptions
properly... this resuled in the connection hanging when we got a
timeout event. Fixed the function to handle exceptions properly.
