### PR TITLE
Fix MySQL Jezebel connection using null dbname

### DIFF
--- a/src/java/com/omniti/jezebel/check/mysql.java
+++ b/src/java/com/omniti/jezebel/check/mysql.java
@@ -40,7 +40,7 @@ public class mysql extends JDBC implements JezebelCheck {
            catch (Exception e) { throw new RuntimeException(e); } }
   protected String defaultPort() { return "3306"; }
   protected String jdbcConnectUrl(String host, String port, String db) {
-    return "jdbc:mysql://" + host + ":" + port + "/" + db;
+    return "jdbc:mysql://" + host + ":" + port + "/" + ((db != null) ? db : "");
   }
   protected Map<String,String> setupBasicSSL() {
     HashMap<String,String> props = new HashMap<String,String>();


### PR DESCRIPTION
If we didn't pass a dbname to jezebel, it would use the string null leading to either:
Access denied for user 'xxxxxx'@'%' to database 'null'

or

Unknown database 'null'

Instead we should have been using an empty string and let mysql ... do whatever it is that it do.
