### PR TITLE
Add Dot To Beginning Of Numeric SNMP OIDs

### DIFF
--- a/src/modules-lua/noit/module/jezebel.lua
+++ b/src/modules-lua/noit/module/jezebel.lua
@@ -111,8 +111,11 @@ function constructXml(check)
   local config = root:addchild("config")
   if check.module == "snmp" then
     for key, value in pairs(check.config) do
-      value = check.interpolate(value);
+      value = check.interpolate(value):gsub("^%s*(.-)%s*$", "%1")
       if string.sub(key, 1, 4) == "oid_" then
+        if string.find(value, "^%d") then
+          value = "." .. value
+        end
         local converted = snmp.convert_mib(value)
         -- we want to add even if there's an error
         -- since we want to preserve the name of


### PR DESCRIPTION
If the SNMP OID in a check starts with a number instead of a
letter or a dot, add a dot to the beginning of it. This will
allow Reconnoiter to process the value as a proper OID.
