### PR TITLE
Add Ability To Query SNMP OIDs Individually

### DIFF
--- a/docs/config/modules/snmp.xml
+++ b/docs/config/modules/snmp.xml
@@ -149,6 +149,34 @@
         </listitem>
       </varlistentry>
     </variablelist>
+    <variablelist>
+      <varlistentry>
+        <term>separate_queries</term>
+        <listitem>
+          <variablelist>
+            <varlistentry>
+              <term>required</term>
+              <listitem>
+                <para>optional</para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>default</term>
+              <listitem>
+                <para>false</para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>allowed</term>
+              <listitem>
+                <para>^(?:true|false|on|off)$</para>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+          <para>Whether or not to query each OID separately.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
   </section>
   <example>
     <title>Simple snmp polling of two switchports</title>

--- a/src/modules/snmp.xml
+++ b/src/modules/snmp.xml
@@ -23,6 +23,10 @@
     <parameter name="type_.+"
                required="optional"
                allowed=".+">Defines a coercion for a metric type.  The name of the metric must identically match one of the oid_(.+) patterns. The value can be either one of the single letter codes in the metric_type_t enum or the following string variants: guess, int32, uint32, int64, uint64, double, string.</parameter>
+    <parameter name="separate_queries"
+               required="optional"
+               default="false"
+               allowed="^(?:true|false|on|off)$">Whether or not to query each OID separately.</parameter>
   </checkconfig>
   <examples>
     <example>


### PR DESCRIPTION
Added a control to the SNMP check to allow for querying all of
the OIDs for a check separately. This fixes the issue where some
SNMP servers are not configured to handle bulk OID requests, as
well as the SNMP v1 issue where sending a single bad OID can
invalidate the entire request.
