### PR TITLE
Fix linking with openssl with disable sslv2 (e.g. debian)

### DIFF
--- a/src/eventer/eventer_SSL_fd_opset.c
+++ b/src/eventer/eventer_SSL_fd_opset.c
@@ -536,9 +536,11 @@ eventer_ssl_ctx_new(eventer_ssl_orientation_t type,
                                  SSLv3_server_method() : SSLv3_client_method());
 #endif
 #ifdef SSL_TXT_SSLV2
+#ifndef OPENSSL_NO_SSL2
     else if(layer && !strcasecmp(layer, SSL_TXT_SSLV2))
       ctx->ssl_ctx = SSL_CTX_new(type == SSL_SERVER ?
                                  SSLv2_server_method() : SSLv2_client_method());
+#endif
 #endif
 #ifdef SSL_TXT_TLSV1
     else if(layer && !strcasecmp(layer, SSL_TXT_TLSV1))


### PR DESCRIPTION
On debian and probably also on other linux distributions, linking fails with the following error:
- linking noitd
  noit-objs/eventer/eventer_SSL_fd_opset.o: In function `eventer_ssl_ctx_new':
  /opt/reconnoiter/source/src/eventer/eventer_SSL_fd_opset.c:541: undefined reference to`SSLv2_server_method'
  /opt/reconnoiter/source/src/eventer/eventer_SSL_fd_opset.c:541: undefined reference to `SSLv2_client_method'
  collect2: error: ld returned 1 exit status

This is because openssl is compiled without SSLv2 and the #ifdef fails to isolate the affected code.
This adds an additional #ifndef on OPENSSL_NO_SSL2 like specified in <openssl/ssh.h>.
