### PR TITLE
Added Execution Path To External, Plus Bug Fixes

### DIFF
--- a/docs/config/modules/external.xml
+++ b/docs/config/modules/external.xml
@@ -62,6 +62,34 @@
         </listitem>
       </varlistentry>
     </variablelist>
+    <variablelist>
+      <varlistentry>
+        <term>path</term>
+        <listitem>
+          <variablelist>
+            <varlistentry>
+              <term>required</term>
+              <listitem>
+                <para>optional</para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>default</term>
+              <listitem>
+                <para>/</para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>allowed</term>
+              <listitem>
+                <para>.+</para>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+          <para>The path under which all external commands to be executed will be located. Commands outside of this path will not be executed.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
   </section>
   <section>
     <title>Check Configuration</title>

--- a/src/modules/external_proc.h
+++ b/src/modules/external_proc.h
@@ -54,6 +54,7 @@ typedef struct {
   int child;
   int pipe_n2e[2];
   int pipe_e2n[2];
+  char* path;
   eventer_jobq_t *jobq;
   noit_atomic64_t check_no_seq;
   noit_hash_table external_checks;


### PR DESCRIPTION
Added a new module config variable, "path", to the External check.
This will specify a directory to run commands out of; if an individual
check tries to specify a command outside of this path, it will not
be executed.

In addition, fixed a bug where the "group" permissions were not being
set properly and changed the check statuses of failed checks to be
more descriptive/useful.
