### PR TITLE
Update BUILDING

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -75,6 +75,6 @@ PostgreSQL 8.4 is required.
 # git clone git@github.com:circonus-labs/reconnoiter.git
 # cd reconnoiter
 # autoconf
-# ./configure
+# ./configure LDFLAGS="-L/opt/omni/lib/"
 # make
 }}}


### PR DESCRIPTION
Pass the location of the libraries installed from the ms.omniti.com repo to linker.
Resolves:

``````
checking for protobuf_c_message_get_packed_size in -lprotobuf-c... no
configure: error: libprotobuf-c required```
``````
