### PR TITLE
Add the maven-compiler-plugin directive so that older versions of Maven ...

### DIFF
--- a/src/java/reconnoiter-riemann/pom.xml
+++ b/src/java/reconnoiter-riemann/pom.xml
@@ -23,19 +23,24 @@
           </archive>
         </configuration>
       </plugin>
-    <plugin>
-      <artifactId>maven-assembly-plugin</artifactId>
-      <configuration>
-        <archive>
-          <manifest>
-            <mainClass>com.omniti.reconnoiter.IEPRiemann</mainClass>
-          </manifest>
-        </archive>
-        <descriptorRefs>
-          <descriptorRef>jar-with-dependencies</descriptorRef>
-        </descriptorRefs>
-      </configuration>
-    </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>com.omniti.reconnoiter.IEPRiemann</mainClass>
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
...don't try and use the 1.3 JDK.

Previous to Maven 3.0, it assumes everything is compatible with Java 1.3. You can fix this by specifying the maven-complier-plugin version later than 3.0 where Java 5 will be used.

http://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#source

Errors:

```
/data/noit/src/java/reconnoiter-riemann/src/main/java/com/omniti/reconnoiter/EventHandler.java:[61,20] generics are not supported in -source 1.3
(use -source 5 or higher to enable generics)
  private LinkedList<MessageHandler> alternates;

/data/noit/src/java/reconnoiter-riemann/src/main/java/com/omniti/reconnoiter/EventHandler.java:[109,28] for-each loops are not supported in -source 1.3
(use -source 5 or higher to enable for-each loops)
    for ( MessageHandler mh : alternates )
```
