### PR TITLE
Handle nil banner value

### DIFF
--- a/src/modules-lua/noit/module/tcp.lua
+++ b/src/modules-lua/noit/module/tcp.lua
@@ -217,7 +217,7 @@ function initiate(module, check)
   if config.banner_match ~= nil then
     str = e:read("\n")
     if str == nil then
-      check.status("bad banner length " .. (str and str:len() or "0"))
+      check.status("could not read banner")
       return
     end
     local firstbytetime = noit.timeval.now()


### PR DESCRIPTION
This prevents checks from returning a status like "bad argument #1 to 'len' (string expected, got nil)"
