### PR TITLE
Fix derivation for newer PostgreSQL versions

### DIFF
--- a/sql/sprocs/stratcon.window_robust_derive.sql
+++ b/sql/sprocs/stratcon.window_robust_derive.sql
@@ -11,7 +11,7 @@ declare
   rec stratcon.metric_numeric_rollup_segment%rowtype;
   r record;
   rise numeric;
-  last_row_whence timestamp;
+  last_row_whence timestamptz;
   last_value numeric;
   run numeric;
   v_sql text;


### PR DESCRIPTION
Apparently, PostgreSQL 9.3 changed how timestamps without timezone work. This fixes the counter_dev computation.
