### PR TITLE
adding LDFLAGS to linux build instructions

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -43,8 +43,7 @@ PostgreSQL 8.4 is required.
 # svn co https://labs.omniti.com/reconnoiter/trunk reconnoiter
 # cd reconnoiter
 # autoconf
-# export LDFLAGS="-ldl -lm"
-# ./configure
+# LDFLAGS="-ldl -lm" ./configure
 # make
 }}}
 


### PR DESCRIPTION
I was recently trying to build noit inside a docker container:
https://github.com/virgo-agent-toolkit/agent-poller-noit-parity (Ubuntu 14.04 image)

I also tried this on an actual Ubuntu cloud server and I still got issues while following the instructions  for building.

console o/p without this change:
https://gist.github.com/ynachiket/2d6ddbd39f0e57362662

console o/p with this change:
https://gist.github.com/ynachiket/bbec6517cd9e1be00b92
