### PR TITLE
Pull connection creation into DB specific modules, support Oracle RAC

### DIFF
--- a/src/java/src/com/omniti/jezebel/check/JDBC.java
+++ b/src/java/src/com/omniti/jezebel/check/JDBC.java
@@ -45,6 +45,7 @@ import com.omniti.jezebel.JezebelTools;
 public abstract class JDBC implements JezebelCheck {
   public JDBC() { }
   protected abstract String jdbcConnectUrl(String host, String port, String db);
+  protected abstract Connection jdbcConnection(String url, Properties props) throws SQLException;
   protected abstract String defaultPort();
   protected abstract Map<String,String> setupBasicSSL();
 
@@ -72,6 +73,7 @@ public abstract class JDBC implements JezebelCheck {
 
     String sql = config.remove("sql");
     String url = jdbcConnectUrl(check.get("target_ip"), port, database);
+
     Properties props = new Properties();
     props.setProperty("user", username == null ? "" : username);
     props.setProperty("password", password == null ? "" : password);
@@ -130,7 +132,7 @@ public abstract class JDBC implements JezebelCheck {
     Connection conn = null;
     try {
       Date t1 = new Date();
-      conn = DriverManager.getConnection(url, props);
+      conn = jdbcConnection(url, props);
       Date t2 = new Date();
       rr.set("connect_duration", t2.getTime() - t1.getTime());
       queryToResmon(conn, config, sql, rr);

--- a/src/java/src/com/omniti/jezebel/check/mysql.java
+++ b/src/java/src/com/omniti/jezebel/check/mysql.java
@@ -33,6 +33,8 @@
 package com.omniti.jezebel.check;
 import java.util.Map;
 import java.util.HashMap;
+import java.sql.*;
+import java.util.Properties;
 import com.omniti.jezebel.check.JDBC;
 import com.omniti.jezebel.JezebelCheck;
 public class mysql extends JDBC implements JezebelCheck {
@@ -47,5 +49,8 @@ public class mysql extends JDBC implements JezebelCheck {
     props.put("useSSL", "true");
     props.put("verifyServerCertificate", "false");
     return props;
+  }
+  protected Connection jdbcConnection(String url, Properties props) throws SQLException {
+    return DriverManager.getConnection(url, props);
   }
 }

--- a/src/java/src/com/omniti/jezebel/check/oracle.java
+++ b/src/java/src/com/omniti/jezebel/check/oracle.java
@@ -33,8 +33,11 @@
 package com.omniti.jezebel.check;
 import java.util.Map;
 import java.util.HashMap;
+import java.sql.*;
+import java.util.Properties;
 import com.omniti.jezebel.check.JDBC;
 import com.omniti.jezebel.JezebelCheck;
+import java.lang.reflect.Method;
 public class oracle extends JDBC implements JezebelCheck {
   static { try { Class.forName("oracle.jdbc.driver.OracleDriver"); }
            catch (Exception e) { throw new RuntimeException(e); } }
@@ -44,6 +47,9 @@ public class oracle extends JDBC implements JezebelCheck {
       return "jdbc:oracle:thin:@//" + host + ":" + port + db;
     if(db.startsWith(":"))
       return "jdbc:oracle:thin:@" + host + ":" + port + db;
+    // RAC connection description
+    if(db.startsWith("("))
+      return "jdbc:oracle:thin:@" + db;
     // Assume a SID (:name) as opposed to a SERVICE_NAME (/name)
     return "jdbc:oracle:thin:@" + host + ":" + port + ":" + db;
   }
@@ -51,5 +57,23 @@ public class oracle extends JDBC implements JezebelCheck {
     HashMap<String,String> props = new HashMap<String,String>();
     props.put("oracle.net.ssl_cipher_suites", "(SSL_DH_anon_WITH_3DES_EDE_CBC_SHA, SSL_DH_anon_WITH_RC4_128_MD5,SSL_DH_anon_WITH_DES_CBC_SHA)");
     return props;
+  }
+  protected Connection jdbcConnection(String url, Properties props) throws SQLException {
+    try {
+        Class<?> odsc = Class.forName("oracle.jdbc.pool.OracleDataSource");
+        Object ods = odsc.newInstance();
+
+        Method m = odsc.getDeclaredMethod("setUrl", String.class);
+        m.invoke(ods, url);
+
+        m = odsc.getDeclaredMethod("setFastConnectionFailoverEnabled", Boolean.class);
+        m.invoke(ods, true);
+
+	m = odsc.getDeclaredMethod("getConnection", String.class, String.class, Properties.class);
+	return (Connection)m.invoke(ods, props.getProperty("user"), props.getProperty("password"), props);
+    }
+    catch (Exception e) {
+	return DriverManager.getConnection(url, props);
+    }
   }
 }

--- a/src/java/src/com/omniti/jezebel/check/postgres.java
+++ b/src/java/src/com/omniti/jezebel/check/postgres.java
@@ -33,6 +33,8 @@
 package com.omniti.jezebel.check;
 import java.util.Map;
 import java.util.HashMap;
+import java.sql.*;
+import java.util.Properties;
 import com.omniti.jezebel.check.JDBC;
 import com.omniti.jezebel.JezebelCheck;
 public class postgres extends JDBC implements JezebelCheck {
@@ -47,5 +49,8 @@ public class postgres extends JDBC implements JezebelCheck {
     props.put("ssl", "true");
     props.put("sslfactory", "org.postgresql.ssl.NonValidatingFactory");
     return props;
+  }
+  protected Connection jdbcConnection(String url, Properties props) throws SQLException {
+    return DriverManager.getConnection(url, props);
   }
 }

--- a/src/java/src/com/omniti/jezebel/check/sqlserver.java
+++ b/src/java/src/com/omniti/jezebel/check/sqlserver.java
@@ -33,6 +33,8 @@
 package com.omniti.jezebel.check;
 import java.util.Map;
 import java.util.HashMap;
+import java.sql.*;
+import java.util.Properties;
 import com.omniti.jezebel.check.JDBC;
 import com.omniti.jezebel.JezebelCheck;
 public class sqlserver extends JDBC implements JezebelCheck {
@@ -47,5 +49,8 @@ public class sqlserver extends JDBC implements JezebelCheck {
     props.put("encrypt", "true");
     props.put("trustServerCertificate", "true");
     return props;
+  }
+  protected Connection jdbcConnection(String url, Properties props) throws SQLException {
+    return DriverManager.getConnection(url, props);
   }
 }


### PR DESCRIPTION
In order to support Oracle RAC and their fast connection failover, we
need to use a different class to get the DB connection rather than
DriverManager.

To accomplish this, pulled the connection creation via getConnection
into the specific classes, and modified Oracle check to use reflection
to pull in the OracleDataSource class if we have it, otherwise use
DriverManager.

RAC is supported by using the connect string as your database param,
we build the connect url by then using just that string.
