### PR TITLE
Add handling of NoitStatus

### DIFF
--- a/src/java/reconnoiter-riemann/src/main/java/com/omniti/reconnoiter/EventHandler.java
+++ b/src/java/reconnoiter-riemann/src/main/java/com/omniti/reconnoiter/EventHandler.java
@@ -204,11 +204,12 @@ public class EventHandler implements IEventHandler {
 	                  "name:" + ns.getCheck_name(),
 	                  "module:" + ns.getCheck_module(),
 	                  "noit:" + ns.getNoit(),
+	                  "availability:" + ns.getAvailability(),
 	                  "type:status" });
       e = new Event(ns.getCheck_target(), // host
                     "status", // service
                     ns.getState(), // state
-                    ns.getAvailability(), // description
+                    ns.getStatus(), // description
                     ns.getDuration(), // value
                     tags, // tags
                     ns.getTime()/1000, //time


### PR DESCRIPTION
Originally, only numeric and text metrics were pushed to Riemann as events. This PR adds support for pushing check status too. Added a distinction tag "type:(numeric|text|status)" to all events.
