### PR TITLE
bugfix debian install scripts to work on ubuntu 14.04

### DIFF
--- a/pkg/debian/noit.install
+++ b/pkg/debian/noit.install
@@ -2,15 +2,15 @@ etc/reconnoiter/config_templates.conf
 etc/reconnoiter/noit.conf
 usr/bin/noit-config
 usr/bin/noittrap
-usr/bin/jezebel
+src/java/jezebel usr/bin
 usr/bin/noit_jlogctl
 usr/lib/noit/
 usr/sbin/noitd
-usr/share/java/jezebel.jar
-usr/share/java/log4j-1.2.15.jar
-usr/share/java/jetty-6.1.20.jar
-usr/share/java/servlet-api-2.5-20081211.jar
-usr/share/java/jetty-util-6.1.20.jar
-usr/share/java/commons-cli-1.1.jar
-usr/share/java/commons-logging-1.1.1.jar
+src/java/lib/jezebel.jar usr/share/java
+src/java/lib/log4j-1.2.15.jar usr/share/java
+src/java/lib/jetty-6.1.20.jar usr/share/java
+src/java/lib/servlet-api-2.5-20081211.jar usr/share/java
+src/java/lib/jetty-util-6.1.20.jar usr/share/java
+src/java/lib/commons-cli-1.1.jar usr/share/java
+src/java/lib/commons-logging-1.1.1.jar usr/share/java
 usr/share/man/man8/noitd.8

--- a/pkg/debian/rules
+++ b/pkg/debian/rules
@@ -10,7 +10,7 @@ build: build-stamp
 
 build-stamp:
 	autoconf
-	./configure --prefix=/usr --libexecdir=/usr/lib --sysconfdir=/etc/reconnoiter --localstatedir=/var/lib/reconnoiter --datarootdir=/usr/share --with-java-libdir=/usr/share/java
+	LDFLAGS="-ldl -lm" ./configure --prefix=/usr --libexecdir=/usr/lib --sysconfdir=/etc/reconnoiter --localstatedir=/var/lib/reconnoiter --datarootdir=/usr/share --with-java-libdir=/usr/share/java
 	$(MAKE)
 	touch $@
 

--- a/pkg/debian/stratcon.install
+++ b/pkg/debian/stratcon.install
@@ -1,20 +1,18 @@
 etc/reconnoiter/stratcon.conf
-usr/bin/run-iep.sh
-usr/sbin/stratcond
-usr/share/java/activemq-all-5.2.0.jar
-usr/share/java/antlr-runtime-3.1.1.jar
-usr/share/java/cglib-nodep-2.2.jar
-usr/share/java/commons-codec-1.5.jar
-usr/share/java/commons-dbcp-1.2.2.jar
-usr/share/java/commons-io-1.2.jar
-usr/share/java/commons-pool-1.4.jar
-usr/share/java/esper-4.5.0.jar
-usr/share/java/protobuf-java-2.4.1.jar
-usr/share/java/postgresql-8.3-604.jdbc3.jar
-usr/share/java/rabbitmq-client-2.4.1.jar
-usr/share/java/spring-beans-2.5.5.jar
-usr/share/java/spring-context-2.5.5.jar
-usr/share/java/reconnoiter.jar
+/src/java/reconnoiter-riemann/run-iep.sh usr/bin
+src/java/lib/ usr/sbin/stratcond
+src/java/lib/activemq-all-5.2.0.jar usr/share/java
+src/java/lib/antlr-runtime-3.1.1.jar usr/share/java
+src/java/lib/cglib-nodep-2.2.jar usr/share/java
+src/java/lib/commons-codec-1.5.jar usr/share/java
+src/java/lib/commons-dbcp-1.2.2.jar usr/share/java
+src/java/lib/commons-io-1.2.jar usr/share/java
+src/java/lib/commons-pool-1.4.jar usr/share/java
+src/java/lib/protobuf-java-2.4.1.jar usr/share/java
+src/java/lib/postgresql-8.3-604.jdbc3.jar usr/share/java
+src/java/lib/rabbitmq-client-2.4.1.jar usr/share/java
+src/java/lib/spring-beans-2.5.5.jar usr/share/java
+src/java/lib/spring-context-2.5.5.jar usr/share/java
+src/java/lib/reconnoiter.jar usr/share/java
 usr/share/man/man8/stratcond.8
 usr/share/reconnoiter/
-

--- a/trusty-snmp-c.patch
+++ b/trusty-snmp-c.patch
@@ -1,0 +1,596 @@
+diff --git a/debian/control b/debian/control
+index a20475e..14806d7 100644
+--- a/debian/control
++++ b/debian/control
+@@ -153,3 +153,13 @@ Description: SNMP (Simple Network Management Protocol) MIB browser
+  graphical frontend for the Net-SNMP tools. It can be used to browse
+  the MIB tree and interactively send requests to SNMP agents.
+ 
++Package: libsnmpclient-c
++Section: libdevel
++Architecture: any
++Provides: libsnmpclient-c
++Depends: libc6-dev, libsnmp30 (=${binary:Version}), libwrap0-dev, libssl-dev, procps, libkvm-dev [kfreebsd-any], libsensors4-dev [linux-any], ${misc:Depends}
++Description: A custom patch-set library provided by circonus which is
++ a requirement for reconnoiter.
++ .
++ SNMP libraries required for circonus reconnoiter.
++
+diff --git a/debian/libsnmpclient-c.install b/debian/libsnmpclient-c.install
+index e69de29..4b5b563 100644
+--- a/debian/libsnmpclient-c.install
++++ b/debian/libsnmpclient-c.install
+@@ -0,0 +1,2 @@
++usr/lib/*/libnetsnmp-c*.a*
++usr/lib/*/libnetsnmp-c.so*
+diff --git a/debian/libsnmpclient-c.shlibs b/debian/libsnmpclient-c.shlibs
+index e69de29..1400b80 100644
+--- a/debian/libsnmpclient-c.shlibs
++++ b/debian/libsnmpclient-c.shlibs
+@@ -0,0 +1 @@
++libnetsnmp-c 30 libnetsnmp-c (>= 5.7.2~dfsg)
+diff --git a/debian/libsnmpclient-c.substvars b/debian/libsnmpclient-c.substvars
+index e69de29..a70d3bb 100644
+--- a/debian/libsnmpclient-c.substvars
++++ b/debian/libsnmpclient-c.substvars
+@@ -0,0 +1,2 @@
++shlibs:Depends=libc6 (>= 2.17), libssl1.0.0 (>= 1.0.0)
++misc:Depends=
+diff --git a/include/net-snmp/session_api.h b/include/net-snmp/session_api.h
+index 88dbc41..1a70a98 100644
+--- a/include/net-snmp/session_api.h
++++ b/include/net-snmp/session_api.h
+@@ -209,6 +209,10 @@ extern          "C" {
+      *  4. Replace snmp_send(ss,pdu) with snmp_sess_send(sessp,pdu)
+      */
+ 
++    struct netsnmp_transport_s;
++
++    NETSNMP_IMPORT
++    void           *snmp_sess_open_C1(netsnmp_session *, struct netsnmp_transport_s **);
+     NETSNMP_IMPORT
+     void           *snmp_sess_open(netsnmp_session *);
+     NETSNMP_IMPORT
+@@ -239,6 +243,8 @@ extern          "C" {
+      * Returns 0 if success, -1 if fail.
+      */
+     NETSNMP_IMPORT
++    int             snmp_sess_read_C1(void *, int fd);
++    NETSNMP_IMPORT
+     int             snmp_sess_read(void *, fd_set *);
+     /*
+      * Similar to snmp_sess_read(), but accepts a pointer to a large file
+diff --git a/snmplib/Makefile.in b/snmplib/Makefile.in
+index 506b8d4..0818c31 100644
+--- a/snmplib/Makefile.in
++++ b/snmplib/Makefile.in
+@@ -133,7 +133,7 @@ INSTALLUCDHEADERS= asn1.h \
+ 	transform_oids.h
+ 
+ # libraries
+-INSTALLLIBS=libnetsnmp.$(LIB_EXTENSION)$(LIB_VERSION)
++INSTALLLIBS=libnetsnmp.$(LIB_EXTENSION)$(LIB_VERSION) libnetsnmp-c.$(LIB_EXTENSION)$(LIB_VERSION)
+ INSTALLUCDLIBS=libsnmp.$(LIB_EXTENSION)$(LIB_VERSION)
+ 
+ #
+@@ -233,6 +233,10 @@ libnetsnmp.$(LIB_EXTENSION)$(LIB_VERSION):    $(TOBJS)
+ 	$(LIB_LD_CMD) $@ $(TOBJS) @LD_NO_UNDEFINED@ $(LDFLAGS) @LNETSNMPLIBS@
+ 	$(RANLIB) $@
+ 
++libnetsnmp-c.$(LIB_EXTENSION)$(LIB_VERSION):    $(TOBJS)
++	$(LIB_LD_CMD) $@ $(TOBJS) @LD_NO_UNDEFINED@ $(LDFLAGS) @LNETSNMPLIBS@
++	$(RANLIB) $@
++
+ libsnmp.$(LIB_EXTENSION)$(LIB_VERSION):    $(TOBJS)
+ 	$(LIB_LD_CMD) $@ $(TOBJS) @LD_NO_UNDEFINED@ $(LDFLAGS) @LNETSNMPLIBS@
+ 	$(RANLIB) $@
+diff --git a/snmplib/snmp_api.c b/snmplib/snmp_api.c
+index 33e6157..585e3c8 100644
+--- a/snmplib/snmp_api.c
++++ b/snmplib/snmp_api.c
+@@ -1602,6 +1602,97 @@ _sess_open(netsnmp_session * in_session)
+     return snmp_sess_add(in_session, transport, NULL, NULL);
+ }
+ 
++void *
++snmp_sess_open_C1(netsnmp_session * in_session, netsnmp_transport **out_t)
++{
++    struct session_list *slp;
++    netsnmp_transport *transport = NULL;
++    int rc;
++
++    if(out_t) *out_t = NULL;
++
++    in_session->s_snmp_errno = 0;
++    in_session->s_errno = 0;
++
++    _init_snmp();
++
++    {
++        char *clientaddr_save = NULL;
++        int family;
++        struct in6_addr a;
++
++        if (NULL != in_session->localname) {
++            clientaddr_save =
++                netsnmp_ds_get_string(NETSNMP_DS_LIBRARY_ID,
++                                      NETSNMP_DS_LIB_CLIENT_ADDR);
++            netsnmp_ds_set_string(NETSNMP_DS_LIBRARY_ID,
++                                  NETSNMP_DS_LIB_CLIENT_ADDR,
++                                  in_session->localname);
++        }
++
++        family = AF_INET6;
++        if(inet_pton(family, in_session->peername, &a) != 1) family = AF_INET;
++
++        if (in_session->flags & SNMP_FLAGS_STREAM_SOCKET) {
++            transport =
++                netsnmp_tdomain_transport_full("snmp", in_session->peername,
++                                               in_session->local_port,
++                                               (family == AF_INET) ? "tcp" : "tcp6",
++                                               NULL);
++        } else {
++            transport =
++                netsnmp_tdomain_transport_full("snmp", in_session->peername,
++                                               in_session->local_port,
++                                               (family == AF_INET) ? "udp" : "udp6",
++                                               NULL);
++        }
++
++        if (NULL != clientaddr_save)
++            netsnmp_ds_set_string(NETSNMP_DS_LIBRARY_ID,
++                                  NETSNMP_DS_LIB_CLIENT_ADDR, clientaddr_save);
++    }
++
++    if (transport == NULL) {
++        DEBUGMSGTL(("_sess_open", "couldn't interpret peername\n"));
++        in_session->s_snmp_errno = SNMPERR_BAD_ADDRESS;
++        in_session->s_errno = errno;
++        snmp_set_detail(in_session->peername);
++        return NULL;
++    }
++
++    /* Optional supplimental transport configuration information and
++       final call to actually open the transport */
++    if ((rc = netsnmp_sess_config_and_open_transport(in_session, transport))
++        != SNMPERR_SUCCESS) {
++        transport = NULL;
++        return NULL;
++    }
++
++#if defined(SO_BROADCAST) && defined(SOL_SOCKET)
++    if ( in_session->flags & SNMP_FLAGS_UDP_BROADCAST) {
++        int   b = 1;
++        int   rc;
++
++        rc = setsockopt(transport->sock, SOL_SOCKET, SO_BROADCAST,
++                        (char *)&b, sizeof(b));
++
++        if ( rc != 0 ) {
++            in_session->s_snmp_errno = SNMPERR_BAD_ADDRESS; /* good as any? */
++            in_session->s_errno = errno;
++
++            DEBUGMSGTL(("_sess_open", "couldn't enable UDP_BROADCAST\n"));
++            return NULL;
++        }
++    }
++#endif
++
++    if(out_t) *out_t = transport;
++
++    slp = snmp_sess_add(in_session, transport, NULL, NULL);
++    if(!slp) SET_SNMP_ERROR(in_session->s_snmp_errno);
++
++    return slp;
++}
+ /*
+  * EXTENDED SESSION API ------------------------------------------ 
+  * 
+@@ -5845,6 +5936,370 @@ _sess_read(void *sessp, netsnmp_large_fd_set * fdset)
+ }
+ 
+ 
++int
++_sess_read_C1(void *sessp, int fd)
++{
++    struct session_list *slp = (struct session_list *) sessp;
++    netsnmp_session *sp = slp ? slp->session : NULL;
++    struct snmp_internal_session *isp = slp ? slp->internal : NULL;
++    netsnmp_transport *transport = slp ? slp->transport : NULL;
++    size_t          pdulen = 0, rxbuf_len = 65536;
++    u_char         *rxbuf = NULL;
++    int             length = 0, olength = 0, rc = 0;
++    void           *opaque = NULL;
++
++    if (!sp || !isp || !transport) {
++        DEBUGMSGTL(("sess_read", "read fail: closing...\n"));
++        return 0;
++    }
++
++    /* to avoid subagent crash */ 
++    if (transport->sock < 0) { 
++        snmp_log (LOG_INFO, "transport->sock got negative fd value %d\n", transport->sock);
++        return 0; 
++    }
++
++    if (fd != transport->sock) {
++        snmp_log (LOG_INFO, "transport->sock fd mismatch %d != %d\n", transport->sock, fd);
++        return 0;
++    }
++
++    sp->s_snmp_errno = 0;
++    sp->s_errno = 0;
++
++    if (transport->flags & NETSNMP_TRANSPORT_FLAG_LISTEN) {
++        int             data_sock = transport->f_accept(transport);
++
++        if (data_sock >= 0) {
++            /*
++             * We've successfully accepted a new stream-based connection.
++             * It's not too clear what should happen here if we are using the
++             * single-session API at this point.  Basically a "session
++             * accepted" callback is probably needed to hand the new session
++             * over to the application.
++             * 
++             * However, for now, as in the original snmp_api, we will ASSUME
++             * that we're using the traditional API, and simply add the new
++             * session to the list.  Note we don't have to get the Session
++             * list lock here, because under that assumption we already hold
++             * it (this is also why we don't just use snmp_add).
++             * 
++             * The moral of the story is: don't use listening stream-based
++             * transports in a multi-threaded environment because something
++             * will go HORRIBLY wrong (and also that SNMP/TCP is not trivial).
++             * 
++             * Another open issue: what should happen to sockets that have
++             * been accept()ed from a listening socket when that original
++             * socket is closed?  If they are left open, then attempting to
++             * re-open the listening socket will fail, which is semantically
++             * confusing.  Perhaps there should be some kind of chaining in
++             * the transport structure so that they can all be closed.
++             * Discuss.  ;-)
++             */
++
++	    netsnmp_transport *new_transport=netsnmp_transport_copy(transport);
++            if (new_transport != NULL) {
++                struct session_list *nslp = NULL;
++
++                new_transport->sock = data_sock;
++                new_transport->flags &= ~NETSNMP_TRANSPORT_FLAG_LISTEN;
++
++                nslp = (struct session_list *)snmp_sess_add_ex(sp,
++			  new_transport, isp->hook_pre, isp->hook_parse,
++			  isp->hook_post, isp->hook_build,
++			  isp->hook_realloc_build, isp->check_packet,
++			  isp->hook_create_pdu);
++
++                if (nslp != NULL) {
++                    nslp->next = Sessions;
++                    Sessions = nslp;
++                    /*
++                     * Tell the new session about its existance if possible.
++                     */
++                    DEBUGMSGTL(("sess_read",
++                                "perform callback with op=CONNECT\n"));
++                    (void)nslp->session->callback(NETSNMP_CALLBACK_OP_CONNECT,
++                                                  nslp->session, 0, NULL,
++                                                  sp->callback_magic);
++                }
++                return 0;
++            } else {
++                sp->s_snmp_errno = SNMPERR_MALLOC;
++                sp->s_errno = errno;
++                snmp_set_detail(strerror(errno));
++                return -1;
++            }
++        } else {
++            sp->s_snmp_errno = SNMPERR_BAD_RECVFROM;
++            sp->s_errno = errno;
++            snmp_set_detail(strerror(errno));
++            return -1;
++        }
++    }
++
++    /*
++     * Work out where to receive the data to.  
++     */
++
++    if (transport->flags & NETSNMP_TRANSPORT_FLAG_STREAM) {
++        if (isp->packet == NULL) {
++            /*
++             * We have no saved packet.  Allocate one.  
++             */
++            if ((isp->packet = (u_char *) malloc(rxbuf_len)) == NULL) {
++                DEBUGMSGTL(("sess_read", "can't malloc %" NETSNMP_PRIz
++                            "u bytes for rxbuf\n", rxbuf_len));
++                return 0;
++            } else {
++                rxbuf = isp->packet;
++                isp->packet_size = rxbuf_len;
++                isp->packet_len = 0;
++            }
++        } else {
++            /*
++             * We have saved a partial packet from last time.  Extend that, if
++             * necessary, and receive new data after the old data.  
++             */
++            u_char         *newbuf;
++
++            if (isp->packet_size < isp->packet_len + rxbuf_len) {
++                newbuf =
++                    (u_char *) realloc(isp->packet,
++                                       isp->packet_len + rxbuf_len);
++                if (newbuf == NULL) {
++                    DEBUGMSGTL(("sess_read",
++                                "can't malloc %" NETSNMP_PRIz
++                                "u more for rxbuf (%" NETSNMP_PRIz "u tot)\n",
++                                rxbuf_len, isp->packet_len + rxbuf_len));
++                    return 0;
++                } else {
++                    isp->packet = newbuf;
++                    isp->packet_size = isp->packet_len + rxbuf_len;
++                    rxbuf = isp->packet + isp->packet_len;
++                }
++            } else {
++                rxbuf = isp->packet + isp->packet_len;
++                rxbuf_len = isp->packet_size - isp->packet_len;
++            }
++        }
++    } else {
++        if ((rxbuf = (u_char *) malloc(rxbuf_len)) == NULL) {
++            DEBUGMSGTL(("sess_read", "can't malloc %" NETSNMP_PRIz
++                        "u bytes for rxbuf\n", rxbuf_len));
++            return 0;
++        }
++    }
++
++    length = netsnmp_transport_recv(transport, rxbuf, rxbuf_len, &opaque,
++                                    &olength);
++
++    if (length == -1 && !(transport->flags & NETSNMP_TRANSPORT_FLAG_STREAM)) {
++        sp->s_snmp_errno = SNMPERR_BAD_RECVFROM;
++        sp->s_errno = errno;
++        snmp_set_detail(strerror(errno));
++        SNMP_FREE(rxbuf);
++        SNMP_FREE(opaque);
++        return -1;
++    }
++
++    if (0 == length && transport->flags & NETSNMP_TRANSPORT_FLAG_EMPTY_PKT) {
++        /* this allows for a transport that needs to return from
++         * packet processing that doesn't necessarily have any
++         * consumable data in it. */
++
++        /* reset the flag since it's a per-message flag */
++        transport->flags &= (~NETSNMP_TRANSPORT_FLAG_EMPTY_PKT);
++
++        return 0;
++    }
++
++    /*
++     * Remote end closed connection.  
++     */
++
++    if (length <= 0 && transport->flags & NETSNMP_TRANSPORT_FLAG_STREAM) {
++        /*
++         * Alert the application if possible.  
++         */
++        if (sp->callback != NULL) {
++            DEBUGMSGTL(("sess_read", "perform callback with op=DISCONNECT\n"));
++            (void) sp->callback(NETSNMP_CALLBACK_OP_DISCONNECT, sp, 0,
++                                NULL, sp->callback_magic);
++        }
++        /*
++         * Close socket and mark session for deletion.  
++         */
++        DEBUGMSGTL(("sess_read", "fd %d closed\n", transport->sock));
++        transport->f_close(transport);
++        SNMP_FREE(isp->packet);
++        SNMP_FREE(opaque);
++        return -1;
++    }
++
++    if (transport->flags & NETSNMP_TRANSPORT_FLAG_STREAM) {
++        u_char *pptr = isp->packet;
++	void *ocopy = NULL;
++
++        isp->packet_len += length;
++
++        while (isp->packet_len > 0) {
++
++            /*
++             * Get the total data length we're expecting (and need to wait
++             * for).
++             */
++            if (isp->check_packet) {
++                pdulen = isp->check_packet(pptr, isp->packet_len);
++            } else {
++                pdulen = asn_check_packet(pptr, isp->packet_len);
++            }
++
++            DEBUGMSGTL(("sess_read",
++                        "  loop packet_len %" NETSNMP_PRIz "u, PDU length %"
++                        NETSNMP_PRIz "u\n", isp->packet_len, pdulen));
++
++            if (pdulen > MAX_PACKET_LENGTH) {
++                /*
++                 * Illegal length, drop the connection.  
++                 */
++                snmp_log(LOG_ERR, 
++			 "Received broken packet. Closing session.\n");
++		if (sp->callback != NULL) {
++		  DEBUGMSGTL(("sess_read",
++			      "perform callback with op=DISCONNECT\n"));
++		  (void)sp->callback(NETSNMP_CALLBACK_OP_DISCONNECT,
++				     sp, 0, NULL, sp->callback_magic);
++		}
++		DEBUGMSGTL(("sess_read", "fd %d closed\n", transport->sock));
++                transport->f_close(transport);
++                SNMP_FREE(opaque);
++                /** XXX-rks: why no SNMP_FREE(isp->packet); ?? */
++                return -1;
++            }
++
++            if (pdulen > isp->packet_len || pdulen == 0) {
++                /*
++                 * We don't have a complete packet yet.  If we've already
++                 * processed a packet, break out so we'll shift this packet
++                 * to the start of the buffer. If we're already at the
++                 * start, simply return and wait for more data to arrive.
++                 */
++                DEBUGMSGTL(("sess_read",
++                            "pkt not complete (need %" NETSNMP_PRIz "u got %"
++                            NETSNMP_PRIz "u so far)\n", pdulen,
++                            isp->packet_len));
++
++                if (pptr != isp->packet)
++                    break; /* opaque freed for us outside of loop. */
++
++                SNMP_FREE(opaque);
++                return 0;
++            }
++
++            /*  We have *at least* one complete packet in the buffer now.  If
++		we have possibly more than one packet, we must copy the opaque
++		pointer because we may need to reuse it for a later packet.  */
++
++	    if (pdulen < isp->packet_len) {
++		if (olength > 0 && opaque != NULL) {
++		    ocopy = malloc(olength);
++		    if (ocopy != NULL) {
++			memcpy(ocopy, opaque, olength);
++		    }
++		}
++	    } else if (pdulen == isp->packet_len) {
++		/*  Common case -- exactly one packet.  No need to copy the
++		    opaque pointer.  */
++		ocopy = opaque;
++		opaque = NULL;
++	    }
++
++            if ((rc = _sess_process_packet(sessp, sp, isp, transport,
++                                           ocopy, ocopy?olength:0, pptr,
++                                           pdulen))) {
++                /*
++                 * Something went wrong while processing this packet -- set the
++                 * errno.  
++                 */
++                if (sp->s_snmp_errno != 0) {
++                    SET_SNMP_ERROR(sp->s_snmp_errno);
++                }
++            }
++
++	    /*  ocopy has been free()d by _sess_process_packet by this point,
++		so set it to NULL.  */
++
++	    ocopy = NULL;
++
++	    /*  Step past the packet we've just dealt with.  */
++
++            pptr += pdulen;
++            isp->packet_len -= pdulen;
++        }
++
++	/*  If we had more than one packet, then we were working with copies
++	    of the opaque pointer, so we still need to free() the opaque
++	    pointer itself.  */
++
++	SNMP_FREE(opaque);
++
++        if (isp->packet_len >= MAXIMUM_PACKET_SIZE) {
++            /*
++             * Obviously this should never happen!  
++             */
++            snmp_log(LOG_ERR,
++                     "too large packet_len = %" NETSNMP_PRIz
++                     "u, dropping connection %d\n",
++                     isp->packet_len, transport->sock);
++            transport->f_close(transport);
++            /** XXX-rks: why no SNMP_FREE(isp->packet); ?? */
++            return -1;
++        } else if (isp->packet_len == 0) {
++            /*
++             * This is good: it means the packet buffer contained an integral
++             * number of PDUs, so we don't have to save any data for next
++             * time.  We can free() the buffer now to keep the memory
++             * footprint down.
++             */
++            SNMP_FREE(isp->packet);
++            isp->packet_size = 0;
++            isp->packet_len = 0;
++            return rc;
++        }
++
++        /*
++         * If we get here, then there is a partial packet of length
++         * isp->packet_len bytes starting at pptr left over.  Move that to the
++         * start of the buffer, and then realloc() the buffer down to size to
++         * reduce the memory footprint.  
++         */
++
++        memmove(isp->packet, pptr, isp->packet_len);
++        DEBUGMSGTL(("sess_read",
++                    "end: memmove(%p, %p, %" NETSNMP_PRIz "u); realloc(%p, %"
++                    NETSNMP_PRIz "u)\n",
++                    isp->packet, pptr, isp->packet_len,
++		    isp->packet, isp->packet_len));
++
++        if ((rxbuf = (u_char *)realloc(isp->packet, isp->packet_len)) == NULL) {
++            /*
++             * I don't see why this should ever fail, but it's not a big deal.
++             */
++            DEBUGMSGTL(("sess_read", "realloc() failed\n"));
++        } else {
++            DEBUGMSGTL(("sess_read", "realloc() okay, old buffer %p, new %p\n",
++                        isp->packet, rxbuf));
++            isp->packet = rxbuf;
++            isp->packet_size = isp->packet_len;
++        }
++        return rc;
++    } else {
++        rc = _sess_process_packet(sessp, sp, isp, transport, opaque,
++                                  olength, rxbuf, length);
++        SNMP_FREE(rxbuf);
++        return rc;
++    }
++}
+ 
+ /*
+  * returns 0 if success, -1 if fail 
+@@ -5863,6 +6318,22 @@ snmp_sess_read(void *sessp, fd_set * fdset)
+ }
+ 
+ int
++snmp_sess_read_C1(void *sessp, int fd)
++{
++    struct session_list *psl;
++    netsnmp_session *pss;
++    int             rc;
++
++    rc = _sess_read_C1(sessp, fd);
++    psl = (struct session_list *) sessp;
++    pss = psl->session;
++    if (rc && pss->s_snmp_errno) {
++        SET_SNMP_ERROR(pss->s_snmp_errno);
++    }
++    return rc;
++}
++
++int
+ snmp_sess_read2(void *sessp, netsnmp_large_fd_set * fdset)
+ {
+     struct session_list *psl;
+@@ -6041,11 +6512,11 @@ snmp_sess_select_info2_flags(void *sessp, int *numfds,
+         }
+ 
+         DEBUGMSG(("sess_select", "%d ", slp->transport->sock));
+-        if ((slp->transport->sock + 1) > *numfds) {
++        if (numfds && (slp->transport->sock + 1) > *numfds) {
+             *numfds = (slp->transport->sock + 1);
+         }
+ 
+-        NETSNMP_LARGE_FD_SET(slp->transport->sock, fdset);
++        if(fdset) NETSNMP_LARGE_FD_SET(slp->transport->sock, fdset);
+         if (slp->internal != NULL && slp->internal->requests) {
+             /*
+              * Found another session with outstanding requests.  


### PR DESCRIPTION
I have created the attached patch-set so that the reconnoiter packages will build on more modern Debian based distributions like Ubuntu 14.04 and Debian 7. 

The trusty-snmp-c.patch is intended to be applied to the dpkg source package net-snmp and create a separate package "libsnmpclient-c" so that entire SNMP stacks do not need to be installed on the noit servers. I have tested this patch on several vanilla amazon Debian and ubuntu instances to confirm that it works. I have deliberately kept the patch separate so that the patch does not pollute the vanilla snmp-c.patch which  you supply (and that works on all systems). I hope that fits with your conventions?

A few other bugs have been fixed in the Debian scripts so that they follow what is outlined in the "BUILDING" README file (i.e. the LD="") environment variables on the configure line. 