### PR TITLE
Updated debian control file.

### DIFF
--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -2,7 +2,7 @@ Source: reconnoiter
 Section: admin
 Priority: optional
 Maintainer: Thom May <thom@debian.org>
-Build-Depends: debhelper (>=4.1.16), autoconf, libtool, gettext, zlib1g-dev, uuid-dev, libpcre3-dev, libssl-dev, libpq-dev,  libxml2-dev, libxslt-dev, libapr1-dev, libaprutil1-dev, xsltproc,  libncurses5-dev, libssh2-1-dev, libsnmp-dev, libmysqlclient-dev, subversion, default-jdk, libevent-dev, libprotobuf-c0-dev, libgcrypt11-dev, libhwloc-dev, ck, libhwloc-dev, libsnmpclient-c, riemann-c-client libriemann-client-dev, riemann
+Build-Depends: debhelper (>=4.1.16), autoconf, libtool, gettext, zlib1g-dev, uuid-dev, libpcre3-dev, libssl-dev, libpq-dev,  libxml2-dev, libxslt-dev, libapr1-dev, libaprutil1-dev, xsltproc,  libncurses5-dev, libssh2-1-dev, libsnmp-dev, libmysqlclient-dev, subversion, default-jdk, libevent-dev, libprotobuf-c0-dev, libgcrypt11-dev, ck, libhwloc-dev, libsnmpclient-c, riemann-c-client libriemann-client-dev, riemann
 Standards-Version: 3.6.1.0
 
 Package: noit

--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -2,7 +2,7 @@ Source: reconnoiter
 Section: admin
 Priority: optional
 Maintainer: Thom May <thom@debian.org>
-Build-Depends: debhelper (>=4.1.16), autoconf, libtool, gettext, zlib1g-dev, uuid-dev, libpcre3-dev, libssl-dev, libpq-dev,  libxml2-dev, libxslt-dev, libapr1-dev, libaprutil1-dev, xsltproc,  libncurses5-dev, libssh2-1-dev, libsnmp-dev, libmysqlclient-dev, subversion, default-jdk, libevent-dev, libprotobuf-c0-dev, libgcrypt11-dev
+Build-Depends: debhelper (>=4.1.16), autoconf, libtool, gettext, zlib1g-dev, uuid-dev, libpcre3-dev, libssl-dev, libpq-dev,  libxml2-dev, libxslt-dev, libapr1-dev, libaprutil1-dev, xsltproc,  libncurses5-dev, libssh2-1-dev, libsnmp-dev, libmysqlclient-dev, subversion, default-jdk, libevent-dev, libprotobuf-c0-dev, libgcrypt11-dev, libhwloc-dev, ck, libhwloc-dev, libsnmpclient-c, riemann-c-client libriemann-client-dev, riemann
 Standards-Version: 3.6.1.0
 
 Package: noit


### PR DESCRIPTION
This PR only changes the pkg/debian/control file. It improves the dependencies so that all of the available functionality is available for reconnoiter. It assumes that the custom net-snmp patch has been applied and the Concurrency-Kit package is built and installed. At this point there is no FQ iep driver available.