### PR TITLE
moved definition of histogram_t to histogram_impl.h

### DIFF
--- a/src/modules/histogram_impl.c
+++ b/src/modules/histogram_impl.c
@@ -79,15 +79,6 @@ static double power_of_ten[256] = {
   1e-05, 0.0001, 0.001, 0.01, 0.1
 };
 
-struct histogram {
-  u_int16_t allocd;
-  u_int16_t used;
-  struct {
-    hist_bucket_t bucket;
-    u_int64_t count;
-  } *bvs;
-};
-
 u_int64_t bvl_limits[7] = {
   0x00000000000000ffULL, 0x0000000000000ffffULL,
   0x0000000000ffffffULL, 0x00000000fffffffffULL,

--- a/src/modules/histogram_impl.h
+++ b/src/modules/histogram_impl.h
@@ -34,14 +34,21 @@
 #define DEFAULT_HIST_SIZE 100
 #include <mtev_config.h>
 
-typedef struct histogram histogram_t;
-
 typedef struct hist_rollup_config hist_rollup_config_t;
 
 typedef struct hist_bucket {
   int8_t val; /* value * 10 */
   int8_t exp; /* -128 -> 127 */
 } hist_bucket_t;
+
+typedef struct histogram {
+  u_int16_t allocd;
+  u_int16_t used;
+  struct {
+    hist_bucket_t bucket;
+    u_int64_t count;
+  } *bvs;
+} histogram_t;
 
 /* These 16 bits give us:
  * Allows us to express exactly:


### PR DESCRIPTION
I moved the definition of histogram_t into histogram_impl.h so that the size is defined at compile time for external tools using this code.