### PR TITLE
Add "sweeping" Parameter To Stratcon Ingestion

### DIFF
--- a/src/modules/handoff_ingestor.c
+++ b/src/modules/handoff_ingestor.c
@@ -186,6 +186,9 @@ stratcon_ingest_launch_file_ingestion(const char *path,
                                       const char *id_str,
                                       const mtev_boolean sweeping) {
   char msg[PATH_MAX + 7], hfile[PATH_MAX]; /*file:\r\n*/
+
+  (void)sweeping;
+
   if(strcmp(path + strlen(path) - 2, ".h")) {
     snprintf(hfile, sizeof(hfile), "%s.h", path);
     if(link(path, hfile) < 0 && errno != EEXIST) {

--- a/src/modules/handoff_ingestor.c
+++ b/src/modules/handoff_ingestor.c
@@ -183,7 +183,8 @@ static int
 stratcon_ingest_launch_file_ingestion(const char *path,
                                       const char *remote_str,
                                       const char *remote_cn,
-                                      const char *id_str) {
+                                      const char *id_str,
+                                      const mtev_boolean sweeping) {
   char msg[PATH_MAX + 7], hfile[PATH_MAX]; /*file:\r\n*/
   if(strcmp(path + strlen(path) - 2, ".h")) {
     snprintf(hfile, sizeof(hfile), "%s.h", path);

--- a/src/modules/postgres_ingestor.c
+++ b/src/modules/postgres_ingestor.c
@@ -1431,6 +1431,8 @@ stratcon_ingest_launch_file_ingestion(const char *path,
   char pgfile[PATH_MAX];
   eventer_t ingest;
 
+  (void)sweeping;
+
   if(strcmp(path + strlen(path) - 3, ".pg")) {
     snprintf(pgfile, sizeof(pgfile), "%s.pg", path);
     if(link(path, pgfile) < 0 && errno != EEXIST) {

--- a/src/modules/postgres_ingestor.c
+++ b/src/modules/postgres_ingestor.c
@@ -1425,7 +1425,8 @@ static int
 stratcon_ingest_launch_file_ingestion(const char *path,
                                       const char *remote_str,
                                       const char *remote_cn,
-                                      const char *id_str) {
+                                      const char *id_str,
+                                      const mtev_boolean sweeping) {
   pg_interim_journal_t *ij;
   char pgfile[PATH_MAX];
   eventer_t ingest;

--- a/src/stratcon_datastore.c
+++ b/src/stratcon_datastore.c
@@ -114,12 +114,14 @@ interim_journal_free(void *vij) {
 
 static int
 stratcon_ingest(const char *fullpath, const char *remote_str,
-                const char *remote_cn, const char *id_str) {
+                const char *remote_cn, const char *id_str,
+                const mtev_boolean sweeping) {
   ingest_chain_t *ic;
   int err = 0;
   for(ic = ingestor_chain; ic; ic = ic->next)
     if(ic->ingestor->launch_file_ingestion(fullpath, remote_str,
-                                           remote_cn, id_str))
+                                           remote_cn, id_str,
+                                           sweeping))
       err = -1;
   if(err == 0) {
     unlink(fullpath);
@@ -176,7 +178,8 @@ stratcon_datastore_journal_sync(eventer_t e, int mask, void *closure,
       ij->fd = -1;
       snprintf(id_str, sizeof(id_str), "%d", ij->storagenode_id);
       stratcon_ingest(ij->filename, ij->remote_str,
-                      ij->remote_cn, id_str);
+                      ij->remote_cn, id_str,
+                      mtev_false);
     }
     mtev_hash_destroy(syncset->ws, free, interim_journal_free);
     free(syncset->ws);

--- a/src/stratcon_datastore.h
+++ b/src/stratcon_datastore.h
@@ -46,7 +46,8 @@
 
 typedef struct {
   int (*launch_file_ingestion)(const char *file, const char *ip,
-                               const char *cn, const char *store);
+                               const char *cn, const char *store,
+                               const mtev_boolean sweeping);
   void (*iep_check_preload)();
   int (*storage_node_lookup)(const char *uuid_str, const char *remote_cn,
                              int *sid_out, int *storagenode_id_out,

--- a/src/stratcon_ingest.c
+++ b/src/stratcon_ingest.c
@@ -62,12 +62,14 @@
 
 static void
 stratcon_ingest_sweep_journals_int(const char *base,
-                                   char *first, char *second, char *third,
+                                   char *first, char *second, 
+                                   char *third, mtev_boolean sweeping,
                                    int (*test)(const char *),
                                    int (*ingest)(const char *fullpath,
                                                  const char *remote_str,
                                                  const char *remote_cn,
-                                                 const char *id_str)) {
+                                                 const char *id_str,
+                                                 const mtev_boolean sweeping)) {
   char path[PATH_MAX];
   DIR *root;
   struct dirent *de, *entry;
@@ -103,16 +105,16 @@ stratcon_ingest_sweep_journals_int(const char *base,
   for(i=0; i<cnt; i++) {
     if(!strcmp(entries[i], ".") || !strcmp(entries[i], "..")) continue;
     if(!first)
-      stratcon_ingest_sweep_journals_int(base, entries[i], NULL, NULL, test, ingest);
+      stratcon_ingest_sweep_journals_int(base, entries[i], NULL, NULL, sweeping, test, ingest);
     else if(!second)
-      stratcon_ingest_sweep_journals_int(base, first, entries[i], NULL, test, ingest);
+      stratcon_ingest_sweep_journals_int(base, first, entries[i], NULL, sweeping, test, ingest);
     else if(!third)
-      stratcon_ingest_sweep_journals_int(base, first, second, entries[i], test, ingest);
+      stratcon_ingest_sweep_journals_int(base, first, second, entries[i], sweeping, test, ingest);
     else if(test(entries[i])) {
       char fullpath[PATH_MAX];
       snprintf(fullpath, sizeof(fullpath), "%s/%s/%s/%s/%s", base,
                first,second,third,entries[i]);
-      ingest(fullpath,first,second,third);
+      ingest(fullpath,first,second,third,sweeping);
     }
   }
   for(i=0; i<cnt; i++)
@@ -124,7 +126,8 @@ stratcon_ingest_sweep_journals(const char *base, int (*test)(const char *),
                                int (*ingest)(const char *fullpath,
                                              const char *remote_str,
                                              const char *remote_cn,
-                                             const char *id_str)) {
-  stratcon_ingest_sweep_journals_int(base, NULL,NULL,NULL, test, ingest);
+                                             const char *id_str,
+                                             const mtev_boolean sweeping)) {
+  stratcon_ingest_sweep_journals_int(base, NULL,NULL,NULL, mtev_true, test, ingest);
 }
 

--- a/src/stratcon_ingest.h
+++ b/src/stratcon_ingest.h
@@ -40,5 +40,6 @@ API_EXPORT(void)
                                  int (*ingest)(const char *fullpath,
                                                const char *remote_str,
                                                const char *remote_cn,
-                                               const char *id_str));
+                                               const char *id_str,
+                                               const mtev_boolean sweeping));
 #endif


### PR DESCRIPTION
Add a parameter, "sweeping", to stratcon ingestion functions. This will
allow us to differentiate between files that we're receiving via JLOG
and files that we find via a sweep when stratcon starts up.