### PR TITLE
Fixed edge case in historam bucket computation.

### DIFF
--- a/src/modules/histogram_impl.c
+++ b/src/modules/histogram_impl.c
@@ -439,11 +439,11 @@ double_to_hist_bucket(double d) {
     // of the exected rounding errors of the above transformations)
     hb.val = sign * (int)floor(d + 1e-13);
     if(hb.val == 100 || hb.val == -100) {
-      if (hb.exp > -127) {
+      if (hb.exp < 127) {
         hb.val /= 10;
-        hb.exp--;
-      } else {
-        hb.val = 0;
+        hb.exp++;
+      } else { // can't increase exponent. Return NaN
+        hb.val = (int8_t)0xff;
         hb.exp = 0;
       }
     }


### PR DESCRIPTION
The bucket boundary should be given by the formula: ```(hb.val * 10) * 10^(hb.exp)```
In the boundary case that the computed `hb.val == 100`, we need to absorb the excess
power of 10 into the exponent, by _increasing_ it's value by one.
This is only possible if `hb.exp < 127`. if `hb.exp == 127` the value lies outside of the
histogram range, in which case we return NaN.