### PR TITLE
Use mtevFatal Instead Of assert/abort

### DIFF
--- a/src/modules/custom_config.c
+++ b/src/modules/custom_config.c
@@ -30,9 +30,6 @@
  */
 
 #include <mtev_defines.h>
-
-#include <assert.h>
-
 #include <mtev_hash.h>
 
 #include "noit_module.h"

--- a/src/modules/dns.c
+++ b/src/modules/dns.c
@@ -90,7 +90,9 @@ static void dns_module_dns_ctx_handle_free(void *vh) {
   free(h->hkey);
   dns_close(h->ctx);
   dns_free(h->ctx);
-  assert(h->timeout == NULL);
+  if (h->timeout != NULL) {
+    mtevFatal(mtev_error, "dns_module_dns_ctx_handle_free: h->timeout not null\n");
+  }
   free(h);
 }
 static void dns_module_dns_ctx_acquire(dns_ctx_handle_t *h) {
@@ -322,7 +324,9 @@ static int dns_interpolate_inaddr_arpa(char *buff, int len, const char *key,
     if(e >= ip) *o++ = '.'; /* we must be at . */
   }
   *o = '\0';
-  assert((o - buff) == il);
+  if ((o - buff) != il) {
+    mtevFatal(mtev_error, "dns_interpolate_inaddr_arpa: (o - buff) != il\n");
+  }
   return o - buff;
 }
 static int dns_interpolate_reverse_ip(char *buff, int len, const char *key,
@@ -382,7 +386,9 @@ register_console_dns_commands() {
 
   tl = mtev_console_state_initial();
   showcmd = mtev_console_state_get_cmd(tl, "show");
-  assert(showcmd && showcmd->dstate);
+  if (!showcmd || !showcmd->dstate) {
+    mtevFatal(mtev_error, "register_console_dns_commands: loading commands failed\n");
+  }
   mtev_console_state_add_cmd(showcmd->dstate,
     NCSCMD("dns_module", noit_console_show_dns, NULL, NULL, NULL));
 }
@@ -476,7 +482,10 @@ static void dns_module_eventer_dns_utm_fn(struct dns_ctx *ctx,
     if(h && h->timeout) e = eventer_remove(h->timeout);
   }
   else {
-    assert(h->ctx == ctx);
+    if (h->ctx != ctx) {
+      mtevFatal(mtev_error, "dns_module_eventer_dns_utm_fn: h->ctx != ctx (0x%08x != 0x%08x)\n",
+              h->ctx, ctx);
+    }
     if(h->timeout) e = eventer_remove(h->timeout);
     if(timeout > 0) {
       newe = eventer_alloc();

--- a/src/modules/external_proc.c
+++ b/src/modules/external_proc.c
@@ -36,7 +36,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <signal.h>
-#include <assert.h>
 #include <sys/mman.h>
 #include <poll.h>
 #include <errno.h>
@@ -163,7 +162,9 @@ static void fetch_and_kill_by_check(int64_t check_no) {
       if (read_bytes >= l) break; \
     } \
   } \
-  assert(read_bytes == l); \
+  if (read_bytes != l) { \
+    mtevFatal(mtev_error, "assert_read: read_bytes != l (%d != %d)\n", read_bytes, l); \
+  }\
 } while (0)
 
 #define assert_write(fd, s, l) do { \
@@ -186,7 +187,9 @@ static void fetch_and_kill_by_check(int64_t check_no) {
       if (written_bytes >= l) break; \
     } \
   } \
-  assert(written_bytes == l); \
+  if (written_bytes != l) { \
+    mtevFatal(mtev_error, "assert_write: written_bytes != l (%d != %d)\n", written_bytes, l); \
+  }\
 } while (0)
 
 int write_out_backing_fd(int ofd, int bfd) {
@@ -327,7 +330,9 @@ int external_child(external_data_t *data) {
       fetch_and_kill_by_check(check_no);
       continue;
     }
-    assert(argcnt > 1);
+    if (!(argcnt > 1)) {
+      mtevFatal(mtev_error, "external_child: argcnt is not greater than 1 (%d)\n", argcnt);
+    }
     proc_state = calloc(1, sizeof(*proc_state));
     proc_state->stdout_fd = -1;
     proc_state->stderr_fd = -1;

--- a/src/modules/librabbitmq/amqp_socket.c
+++ b/src/modules/librabbitmq/amqp_socket.c
@@ -122,7 +122,8 @@ static amqp_bytes_t sasl_method_name(amqp_sasl_method_enum method) {
     default:
       amqp_assert(0, "Invalid SASL method: %d", (int) method);
   }
-  abort(); /* unreachable */
+  /* should be unreachable */
+  mtevFatal(mtev_error, "sasl_method_name: got unknown method - 0x%04x\n", method);
 }
 
 static amqp_bytes_t sasl_response(amqp_pool_t *pool,

--- a/src/modules/mysql.c
+++ b/src/modules/mysql.c
@@ -352,7 +352,7 @@ static int mysql_drive_session(eventer_t e, int mask, void *closure,
       e->mask = EVENTER_READ | EVENTER_WRITE;
       break;
     default:
-      abort();
+      mtevFatal(mtev_error, "mtev_drive_session (mysql): got unknown mask (0x%04x)\n", mask);
   }
   return 0;
 }

--- a/src/modules/postgres.c
+++ b/src/modules/postgres.c
@@ -284,7 +284,7 @@ static int postgres_drive_session(eventer_t e, int mask, void *closure,
       e->mask = EVENTER_READ | EVENTER_WRITE;
       break;
     default:
-      abort();
+      mtevFatal(mtev_error, "postgres_drive_session: got unknown mask (0x%04x)\n", mask);
   }
   return 0;
 }

--- a/src/modules/selfcheck.c
+++ b/src/modules/selfcheck.c
@@ -213,7 +213,7 @@ static int selfcheck_log_size(eventer_t e, int mask, void *closure,
       e->mask = EVENTER_READ | EVENTER_WRITE;
       break;
     default:
-      abort();
+      mtevFatal(mtev_error, "selfcheck_log_size: got unknown mask (0x%04x)\n", mask);
   }
   return 0;
 }

--- a/src/modules/ssh2.c
+++ b/src/modules/ssh2.c
@@ -225,7 +225,7 @@ static int ssh2_drive_session(eventer_t e, int mask, void *closure,
       ci->state = WANT_CLOSE;
       break;
     default:
-      abort();
+      mtevFatal(mtev_error, "ssh2_drive_session: got unknown mask (0x%04x)\n", mask);
   }
   return 0;
 }

--- a/src/modules/test_abort.c
+++ b/src/modules/test_abort.c
@@ -146,7 +146,7 @@ static int test_abort_drive_session(eventer_t e, int mask, void *closure,
       e->mask = EVENTER_READ | EVENTER_WRITE;
       break;
     default:
-      abort();
+      mtevFatal(mtev_error, "test_abort_drive_session: got unknown mask (0x%04x)\n", mask);
   }
   return 0;
 }

--- a/src/noit_check_tools.c
+++ b/src/noit_check_tools.c
@@ -166,8 +166,7 @@ noit_check_schedule_next(noit_module_t *self,
     diffms = (int64_t)diff.tv_sec * 1000 + diff.tv_usec / 1000;
   }
   else {
-    mtevL(noit_error, "time is going backwards. abort.\n");
-    abort();
+    mtevFatal(mtev_error, "noit_check_schedule_next: time is going backwards. abort.\n");
   }
   /* determine the offset from initial schedule time that would place
    * us at the next period-aligned point past "now" */

--- a/src/noit_metric_rollup.c
+++ b/src/noit_metric_rollup.c
@@ -29,6 +29,7 @@
  */
 
 #include "noit_metric_rollup.h"
+#include "mtev_log.h"
 #include <assert.h>
 #define private_nan 0
 #if defined(__APPLE__) && defined(__MACH__)
@@ -57,7 +58,7 @@ metric_value_int64(noit_metric_value_t *v) {
     case METRIC_INT64: return v->value.v_int64;
     default: ;
   }
-  abort();
+  mtevFatal(mtev_error, "metric_value_int64: got unknown v->type (0x%04x)\n", v->type);
 }
 static uint64_t
 metric_value_uint64(noit_metric_value_t *v) {
@@ -72,7 +73,7 @@ metric_value_uint64(noit_metric_value_t *v) {
     case METRIC_UINT64: return v->value.v_uint64;
     default: ;
   }
-  abort();
+  mtevFatal(mtev_error, "metric_value_uint64: got unknown v->type (0x%04x)\n", v->type);
 }
 static int
 metric_value_is_negative(noit_metric_value_t *v) {
@@ -87,7 +88,7 @@ metric_value_is_negative(noit_metric_value_t *v) {
       return (v->value.v_double < 0);
     default: ;
   }
-  abort();
+  mtevFatal(mtev_error, "metric_value_is_negative: got unknown v->type (0x%04x)\n", v->type);
 }
 
 static void


### PR DESCRIPTION
Replaces tons of assert/abort calls with calls to mtevFatal, which logs
synchronously before exiting. This is better for debugging - it makes
sure that we get errors in logs before we abort/assert out.

I didn't replace every single instance, since there are tons of them,
but I replaced a bunch of the more important ones.