### PR TITLE
Make Lua SNMP Loading Safer

### DIFF
--- a/src/modules-lua/noit/module/jezebel.lua
+++ b/src/modules-lua/noit/module/jezebel.lua
@@ -84,7 +84,9 @@ end
 local snmp = require("snmp")
 
 function init(module)
-  snmp.init_snmp()
+  if (module.name() == "snmp") then
+    snmp.init_snmp()
+  end
   return 0
 end
 


### PR DESCRIPTION
Two changes:

* Only load lua_snmp if there's a jezebel snmp lua module defined
* Lock around the lua_snmp initialization to make sure that multiple
  threads don't call it at once, make sure that we only init once