### PR TITLE
Use mtevAssert and mtevFatal Instead Of assert() and abort()

### DIFF
--- a/src/modules/check_test.c
+++ b/src/modules/check_test.c
@@ -31,8 +31,6 @@
 
 #include <mtev_defines.h>
 
-#include <assert.h>
-
 #include <mtev_rest.h>
 #include <mtev_log.h>
 #include <mtev_memory.h>
@@ -369,7 +367,7 @@ rest_test_check(mtev_http_rest_closure_t *restc,
 
 static int
 check_test_init(mtev_dso_generic_t *self) {
-  assert(mtev_http_rest_register(
+  mtevAssert(mtev_http_rest_register(
     "POST", "/checks/", "^test(\\.xml|\\.json)?$",
     rest_test_check
   ) == 0);

--- a/src/modules/collectd.c
+++ b/src/modules/collectd.c
@@ -27,7 +27,6 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
-#include <assert.h>
 #include <math.h>
 #include <ctype.h>
 #ifdef HAVE_SYS_FILIO_H
@@ -450,7 +449,7 @@ static EVP_CIPHER_CTX* network_get_aes256_cypher (collectd_closure_t *ccl, /* {{
     EVP_DigestFinal(&ctx_md, password_hash, &length); 
     EVP_MD_CTX_cleanup(&ctx_md);
 
-    assert(length <= 32);
+    mtevAssert(length <= 32);
 
     success = EVP_DecryptInit(ctx_ptr, EVP_aes_256_ofb(), password_hash, iv);
     if (success != 1)
@@ -499,7 +498,7 @@ static int parse_part_values (void **ret_buffer, size_t *ret_buffer_len,
   buffer += sizeof (tmp16);
   pkg_numval = ntohs (tmp16);
 
-  assert (pkg_type == TYPE_VALUES);
+  mtevAssert (pkg_type == TYPE_VALUES);
 
   exp_size = 3 * sizeof (uint16_t)
     + pkg_numval * (sizeof (uint8_t) + sizeof (value_t));
@@ -776,7 +775,7 @@ static int parse_part_sign_sha256 (collectd_closure_t *ccl, noit_module_t *self,
   BUFFER_READ (pss.username, username_len);
   pss.username[username_len] = 0;
 
-  assert (buffer_offset == pss_head_length);
+  mtevAssert (buffer_offset == pss_head_length);
 
   /* Match up the username with the expected username */
   if (strcmp(ccl->username, pss.username) != 0)
@@ -875,7 +874,7 @@ static int parse_part_encr_aes256 (collectd_closure_t *ccl, noit_module_t *self,
     return (-1);
   }
 
-  assert (username_len > 0);
+  mtevAssert (username_len > 0);
   pea.username = malloc (username_len + 1);
   if (pea.username == NULL)
     return (-ENOMEM);
@@ -886,7 +885,7 @@ static int parse_part_encr_aes256 (collectd_closure_t *ccl, noit_module_t *self,
   BUFFER_READ (pea.iv, sizeof (pea.iv));
 
   /* Make sure we are at the right position */
-  assert (buffer_offset == (username_len +
+  mtevAssert (buffer_offset == (username_len +
         PART_ENCRYPTION_AES256_SIZE - sizeof (pea.hash)));
 
   /* Match up the username with the expected username */
@@ -903,7 +902,7 @@ static int parse_part_encr_aes256 (collectd_closure_t *ccl, noit_module_t *self,
     return (-1);
 
   payload_len = part_size - (PART_ENCRYPTION_AES256_SIZE + username_len);
-  assert (payload_len > 0);
+  mtevAssert (payload_len > 0);
   tmpbuf = malloc(part_size - buffer_offset);
 
   /* Decrypt the packet */
@@ -917,7 +916,7 @@ static int parse_part_encr_aes256 (collectd_closure_t *ccl, noit_module_t *self,
     return (-1);
   }
 
-  assert(part_size - buffer_offset == tmpbufsize);
+  mtevAssert(part_size - buffer_offset == tmpbufsize);
   /* Make it appear to be in place */
   memcpy(buffer + buffer_offset, tmpbuf, part_size - buffer_offset);
   sfree(tmpbuf);
@@ -926,8 +925,8 @@ static int parse_part_encr_aes256 (collectd_closure_t *ccl, noit_module_t *self,
   BUFFER_READ (pea.hash, sizeof (pea.hash));
 
   /* Make sure we're at the right position - again */
-  assert (buffer_offset == (username_len + PART_ENCRYPTION_AES256_SIZE));
-  assert (buffer_offset == (part_size - payload_len));
+  mtevAssert (buffer_offset == (username_len + PART_ENCRYPTION_AES256_SIZE));
+  mtevAssert (buffer_offset == (part_size - payload_len));
 
   /* Check hash sum */
   memset (hash, 0, sizeof (hash));
@@ -1210,7 +1209,7 @@ static int infer_type(char *buffer, int buffer_len, value_list_t *vl, int index)
   int len = strlen(buffer);
   strcat(buffer, "`");
   if (cmp_type(vl, "load", "load")) {
-    assert(vl->values_len == 3);
+    mtevAssert(vl->values_len == 3);
     switch (index) {
       case 0:
         strcat(buffer, "1min"); break;
@@ -1220,7 +1219,7 @@ static int infer_type(char *buffer, int buffer_len, value_list_t *vl, int index)
         strcat(buffer, "15min"); break;
     }
   } else if (cmp_plugin(vl, "interface")) {
-    assert(vl->values_len == 2);
+    mtevAssert(vl->values_len == 2);
     switch (index) {
       case 0:
         strcat(buffer, "rx"); break;

--- a/src/modules/custom_config.c
+++ b/src/modules/custom_config.c
@@ -31,8 +31,6 @@
 
 #include <mtev_defines.h>
 
-#include <assert.h>
-
 #include <mtev_hash.h>
 
 #include "noit_module.h"

--- a/src/modules/dns.c
+++ b/src/modules/dns.c
@@ -37,7 +37,6 @@
 #include <unistd.h>
 #include <netdb.h>
 #include <errno.h>
-#include <assert.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <udns.h>
@@ -90,7 +89,7 @@ static void dns_module_dns_ctx_handle_free(void *vh) {
   free(h->hkey);
   dns_close(h->ctx);
   dns_free(h->ctx);
-  assert(h->timeout == NULL);
+  mtevAssert(h->timeout == NULL);
   free(h);
 }
 static void dns_module_dns_ctx_acquire(dns_ctx_handle_t *h) {
@@ -193,7 +192,7 @@ static int dns_module_dns_ctx_release(dns_ctx_handle_t *h) {
   last = mtev_atomic_dec32(&h->refcnt);
   if(last == 0) {
     /* I was the last one */
-    assert(mtev_hash_delete(&dns_ctx_store, h->hkey, strlen(h->hkey),
+    mtevAssert(mtev_hash_delete(&dns_ctx_store, h->hkey, strlen(h->hkey),
                             NULL, dns_module_dns_ctx_handle_free));
     rv = 1;
   }
@@ -234,12 +233,12 @@ static void __activate_ci(struct dns_check_info *ci) {
   holder = calloc(1, sizeof(*holder));
   *holder = ci;
   pthread_mutex_lock(&active_events_lock);
-  assert(mtev_hash_store(&active_events, (void *)holder, sizeof(*holder), ci));
+  mtevAssert(mtev_hash_store(&active_events, (void *)holder, sizeof(*holder), ci));
   pthread_mutex_unlock(&active_events_lock);
 }
 static void __deactivate_ci(struct dns_check_info *ci) {
   pthread_mutex_lock(&active_events_lock);
-  assert(mtev_hash_delete(&active_events, (void *)&ci, sizeof(ci), free, NULL));
+  mtevAssert(mtev_hash_delete(&active_events, (void *)&ci, sizeof(ci), free, NULL));
   pthread_mutex_unlock(&active_events_lock);
   ci->check->flags &= ~NP_RUNNING;
   if(ci->h != NULL) {
@@ -322,7 +321,7 @@ static int dns_interpolate_inaddr_arpa(char *buff, int len, const char *key,
     if(e >= ip) *o++ = '.'; /* we must be at . */
   }
   *o = '\0';
-  assert((o - buff) == il);
+  mtevAssert((o - buff) == il);
   return o - buff;
 }
 static int dns_interpolate_reverse_ip(char *buff, int len, const char *key,
@@ -382,7 +381,7 @@ register_console_dns_commands() {
 
   tl = mtev_console_state_initial();
   showcmd = mtev_console_state_get_cmd(tl, "show");
-  assert(showcmd && showcmd->dstate);
+  mtevAssert(showcmd && showcmd->dstate);
   mtev_console_state_add_cmd(showcmd->dstate,
     NCSCMD("dns_module", noit_console_show_dns, NULL, NULL, NULL));
 }
@@ -476,7 +475,7 @@ static void dns_module_eventer_dns_utm_fn(struct dns_ctx *ctx,
     if(h && h->timeout) e = eventer_remove(h->timeout);
   }
   else {
-    assert(h->ctx == ctx);
+    mtevAssert(h->ctx == ctx);
     if(h->timeout) e = eventer_remove(h->timeout);
     if(timeout > 0) {
       newe = eventer_alloc();

--- a/src/modules/external.c
+++ b/src/modules/external.c
@@ -38,7 +38,6 @@
 #include <netdb.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <assert.h>
 #include <sys/uio.h>
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>
@@ -358,7 +357,7 @@ static int external_handler(eventer_t e, int mask,
         }
       }
 
-      assert(inlen == expectlen);
+      mtevAssert(inlen == expectlen);
       r.check_no = h.check_no;
       r.exit_code = h.exit_code;
       r.stdoutlen = h.stdoutlen;
@@ -382,7 +381,7 @@ static int external_handler(eventer_t e, int mask,
         goto widowed; /* overflow */
       data->cr->stdoutlen_sofar += inlen;
     }
-    assert(data->cr->stdoutbuff[data->cr->stdoutlen-1] == '\0');
+    mtevAssert(data->cr->stdoutbuff[data->cr->stdoutlen-1] == '\0');
     if(!data->cr->stderrbuff) {
       while((inlen = read(e->fd, &data->cr->stderrlen,
                           sizeof(data->cr->stderrlen))) == -1 &&
@@ -390,7 +389,7 @@ static int external_handler(eventer_t e, int mask,
       if(inlen == -1 && errno == EAGAIN)
         return EVENTER_READ | EVENTER_EXCEPTION;
       if(inlen == 0) goto widowed;
-      assert(inlen == sizeof(data->cr->stderrlen));
+      mtevAssert(inlen == sizeof(data->cr->stderrlen));
       /* We know that the strderrlen we read is taintet, but it comes
        * from our parent process and is well controlled, so we can
        * forgive that transgression.
@@ -415,8 +414,8 @@ static int external_handler(eventer_t e, int mask,
         goto widowed; /* overflow */
       data->cr->stderrlen_sofar += inlen;
     }
-    assert(data->cr && data->cr->stdoutbuff && data->cr->stderrbuff);
-    assert(data->cr->stderrbuff[data->cr->stderrlen-1] == '\0');
+    mtevAssert(data->cr && data->cr->stdoutbuff && data->cr->stderrbuff);
+    mtevAssert(data->cr->stderrbuff[data->cr->stderrlen-1] == '\0');
 
     gettimeofday(now, NULL); /* set it, as we care about accuracy */
 
@@ -598,8 +597,7 @@ static void external_cleanup(noit_module_t *self, noit_check_t *check) {
     } \
   } \
   if (written_bytes != l) { \
-    mtevL(noit_error, "written_bytes not equal to write length in external.c assert_write, aborting...\n"); \
-    abort(); \
+    mtevFatal(noit_error, "written_bytes not equal to write length in external.c assert_write, aborting...\n"); \
   } \
 } while (0)
 static int external_enqueue(eventer_t e, int mask, void *closure,

--- a/src/modules/external_proc.c
+++ b/src/modules/external_proc.c
@@ -36,7 +36,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <signal.h>
-#include <assert.h>
 #include <sys/mman.h>
 #include <poll.h>
 #include <errno.h>
@@ -163,7 +162,7 @@ static void fetch_and_kill_by_check(int64_t check_no) {
       if (read_bytes >= l) break; \
     } \
   } \
-  assert(read_bytes == l); \
+  mtevAssert(read_bytes == l); \
 } while (0)
 
 #define assert_write(fd, s, l) do { \
@@ -186,7 +185,7 @@ static void fetch_and_kill_by_check(int64_t check_no) {
       if (written_bytes >= l) break; \
     } \
   } \
-  assert(written_bytes == l); \
+  mtevAssert(written_bytes == l); \
 } while (0)
 
 int write_out_backing_fd(int ofd, int bfd) {
@@ -327,7 +326,7 @@ int external_child(external_data_t *data) {
       fetch_and_kill_by_check(check_no);
       continue;
     }
-    assert(argcnt > 1);
+    mtevAssert(argcnt > 1);
     proc_state = calloc(1, sizeof(*proc_state));
     proc_state->stdout_fd = -1;
     proc_state->stderr_fd = -1;

--- a/src/modules/fq_driver.c
+++ b/src/modules/fq_driver.c
@@ -34,8 +34,6 @@
 #endif
 
 #include <mtev_defines.h>
-
-#include <assert.h>
 #include <fq.h>
 
 #include <mtev_dso.h>
@@ -539,7 +537,7 @@ register_console_fq_commands() {
 
   tl = mtev_console_state_initial();
   showcmd = mtev_console_state_get_cmd(tl, "show");
-  assert(showcmd && showcmd->dstate);
+  mtevAssert(showcmd && showcmd->dstate);
   mtev_console_state_add_cmd(showcmd->dstate,
     NCSCMD("fq", noit_console_show_fq, NULL, NULL, NULL));
 }

--- a/src/modules/handoff_ingestor.c
+++ b/src/modules/handoff_ingestor.c
@@ -40,7 +40,6 @@
 #include <dirent.h>
 #include <arpa/inet.h>
 #include <sys/mman.h>
-#include <assert.h>
 #include <errno.h>
 
 #include <mtev_dso.h>
@@ -296,7 +295,7 @@ static int handoff_ingestor_init(mtev_dso_generic_t *self) {
     exit(-1);
   }
   mtevL(mtev_error, "registering /handoff/journals REST endpoint\n");
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/handoff/", "^journals$", handoff_stream,
     mtev_http_rest_client_cert_auth
   ) == 0);

--- a/src/modules/histogram.c
+++ b/src/modules/histogram.c
@@ -31,8 +31,6 @@
 #include <inttypes.h>
 #include <mtev_defines.h>
 
-#include <assert.h>
-
 #include <mtev_log.h>
 #include <mtev_b64.h>
 
@@ -262,7 +260,7 @@ sweep_roll_tensec(histotier *ht) {
   int tgt_bucket = ht->last_second / 10;
   int sidx;
   /* We can't very well rollup the same bucket twice */
-  assert(tgt_bucket >= 0 && tgt_bucket < 6 && ht->tensecs[tgt_bucket] == NULL);
+  mtevAssert(tgt_bucket >= 0 && tgt_bucket < 6 && ht->tensecs[tgt_bucket] == NULL);
   for(sidx=0;sidx<10;sidx++) {
     if(NULL != (tgt = ht->secs[sidx])) {
       ht->secs[sidx] = NULL;

--- a/src/modules/histogram_impl.c
+++ b/src/modules/histogram_impl.c
@@ -33,10 +33,12 @@
 #ifndef SKIP_LIBMTEV
 #include <mtev_log.h>
 #include <mtev_b64.h>
+#else
+#include <assert.h>
+#define mtevAssert assert
 #endif
 
 #include <errno.h>
-#include <assert.h>
 #include <sys/socket.h>
 #include <math.h>
 #include <arpa/inet.h>
@@ -142,7 +144,7 @@ bv_read(histogram_t *h, int idx, const void *buff, ssize_t len) {
   bvdatum_t tgt_type;
   int i;
 
-  assert(idx == h->used);
+  mtevAssert(idx == h->used);
   if(len < 3) return -1;
   cp = buff;
   tgt_type = cp[2];
@@ -286,7 +288,7 @@ int hist_bucket_cmp(hist_bucket_t h1, hist_bucket_t h2) {
 double
 hist_bucket_to_double(hist_bucket_t hb) {
   u_int8_t *pidx;
-  assert(private_nan != 0);
+  mtevAssert(private_nan != 0);
   pidx = (u_int8_t *)&hb.exp;
   if(hb.val > 99 || hb.val < -99) return private_nan;
   if(hb.val < 10 && hb.val > -10) return 0.0;
@@ -428,7 +430,7 @@ hist_bucket_t
 double_to_hist_bucket(double d) {
   double d_copy = d;
   hist_bucket_t hb = { (int8_t)0xff, 0 }; // NaN
-  assert(private_nan != 0);
+  mtevAssert(private_nan != 0);
   if(isnan(d) || isinf(d)) return hb;
   else if(d==0) hb.val = 0;
   else {
@@ -509,7 +511,7 @@ hist_internal_find(histogram_t *hist, hist_bucket_t hb, int *idx) {
   if(rv == 0) return 1;   /* this is it */
   if(rv < 0) return 0;    /* it goes here (before) */
   (*idx)++;               /* it goes after here */
-  assert(*idx >= 0 && *idx <= hist->used);
+  mtevAssert(*idx >= 0 && *idx <= hist->used);
   return 0;
 }
 
@@ -642,12 +644,12 @@ static void
 internal_bucket_accum(histogram_t *tgt, int tgtidx,
                       histogram_t *src, int srcidx) {
   u_int64_t newval;
-  assert(tgtidx < tgt->allocd);
+  mtevAssert(tgtidx < tgt->allocd);
   if(tgt->used == tgtidx) {
     tgt->bvs[tgtidx].bucket = src->bvs[srcidx].bucket;
     tgt->used++;
   }
-  assert(hist_bucket_cmp(tgt->bvs[tgtidx].bucket,
+  mtevAssert(hist_bucket_cmp(tgt->bvs[tgtidx].bucket,
                          src->bvs[srcidx].bucket) == 0);
   newval = tgt->bvs[tgtidx].count + src->bvs[srcidx].count;
   if(newval < tgt->bvs[tgtidx].count) newval = ~(u_int64_t)0;

--- a/src/modules/httptrap.c
+++ b/src/modules/httptrap.c
@@ -35,7 +35,6 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
-#include <assert.h>
 #include <math.h>
 #include <ctype.h>
 #include <yajl/yajl_parse.h>

--- a/src/modules/librabbitmq/amqp_api.c
+++ b/src/modules/librabbitmq/amqp_api.c
@@ -13,8 +13,7 @@
 #include "amqp.h"
 #include "amqp_framing.h"
 #include "amqp_private.h"
-
-#include <assert.h>
+#include "mtev_log.h"
 
 #define RPC_REPLY(replytype)					\
   (amqp_rpc_reply->reply_type == AMQP_RESPONSE_NORMAL		\
@@ -73,7 +72,7 @@ int amqp_basic_publish(amqp_connection_state_t state,
   body_offset = 0;
   while (1) {
     int remaining = body.len - body_offset;
-    assert(remaining >= 0);
+    mtevAssert(remaining >= 0);
 
     if (remaining == 0)
       break;

--- a/src/modules/librabbitmq/amqp_connection.c
+++ b/src/modules/librabbitmq/amqp_connection.c
@@ -162,7 +162,7 @@ int amqp_handle_input(amqp_connection_state_t state,
   state->inbound_offset += bytes_consumed;
   total_bytes_consumed += bytes_consumed;
 
-  assert(state->inbound_offset <= state->target_size);
+  mtevAssert(state->inbound_offset <= state->target_size);
 
   if (state->inbound_offset < state->target_size) {
     return total_bytes_consumed;

--- a/src/modules/librabbitmq/amqp_mem.c
+++ b/src/modules/librabbitmq/amqp_mem.c
@@ -5,10 +5,10 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <errno.h>
-#include <assert.h>
 
 #include "amqp.h"
 #include "amqp_config.h"
+#include "mtev_log.h"
 
 char const *amqp_version(void) {
   return VERSION; /* defined in config.h */
@@ -93,7 +93,7 @@ void *amqp_pool_alloc(amqp_pool_t *pool, size_t amount) {
   }
 
   if (pool->alloc_block != NULL) {
-    assert(pool->alloc_used <= pool->pagesize);
+    mtevAssert(pool->alloc_used <= pool->pagesize);
 
     if (pool->alloc_used + amount <= pool->pagesize) {
       void *result = pool->alloc_block + pool->alloc_used;

--- a/src/modules/librabbitmq/amqp_socket.c
+++ b/src/modules/librabbitmq/amqp_socket.c
@@ -182,7 +182,7 @@ static int wait_frame_inner(amqp_connection_state_t state,
       }
 
       /* Incomplete or ignored frame. Keep processing input. */
-      assert(result != 0);
+      mtevAssert(result != 0);
     }	
 
     result = eintr_safe_read(state->sockfd,

--- a/src/modules/librabbitmq/amqp_table.c
+++ b/src/modules/librabbitmq/amqp_table.c
@@ -8,8 +8,6 @@
 #include "amqp.h"
 #include "amqp_private.h"
 
-#include <assert.h>
-
 #define INITIAL_TABLE_SIZE 16
 
 int amqp_decode_table(amqp_bytes_t encoded,

--- a/src/modules/lua_check.c
+++ b/src/modules/lua_check.c
@@ -34,7 +34,6 @@
 #ifdef HAVE_ALLOCA_H
 #include <alloca.h>
 #endif
-#include <assert.h>
 
 #include <mtev_conf.h>
 #include <mtev_dso.h>
@@ -196,7 +195,7 @@ noit_module_index_func(lua_State *L) {
   const char *k;
   int n;
   n = lua_gettop(L);    /* number of arguments */
-  assert(n == 2);
+  mtevAssert(n == 2);
   if(!luaL_checkudata(L, 1, "noit_module_t")) {
     luaL_error(L, "metatable error, arg1 not a noit_module_t!");
   }
@@ -519,7 +518,7 @@ noit_check_index_func(lua_State *L) {
   const char *k;
   noit_check_t **udata, *check;
   n = lua_gettop(L);    /* number of arguments */
-  assert(n == 2);
+  mtevAssert(n == 2);
   if(!luaL_checkudata(L, 1, "noit_check_t")) {
     luaL_error(L, "metatable error, arg1 not a noit_check_t!");
   }
@@ -777,7 +776,7 @@ noit_lua_module_config(noit_module_t *mod,
 
   mc = noit_module_get_userdata(mod);
   if(options) {
-    assert(mc->options == NULL);
+    mtevAssert(mc->options == NULL);
     mc->options = calloc(1, sizeof(*mc->options));
     mtev_hash_init(mc->options);
     mtev_hash_merge_as_dict(mc->options, options);
@@ -870,7 +869,7 @@ noit_lua_check_resume(mtev_lua_resume_info_t *ri, int nargs) {
   noit_check_t *check = NULL;
   noit_lua_resume_check_info_t *ci = ri->context_data;
 
-  assert(pthread_equal(pthread_self(), ri->bound_thread));
+  mtevAssert(pthread_equal(pthread_self(), ri->bound_thread));
 
   mtevL(nldeb, "lua: %p resuming(%d)\n", ri->coro_state, nargs);
 #if LUA_VERSION_NUM >= 502

--- a/src/modules/lua_check.h
+++ b/src/modules/lua_check.h
@@ -36,7 +36,6 @@
 
 #include <mtev_defines.h>
 
-#include <assert.h>
 #include <lua.h>
 #include <lauxlib.h>
 #include <lualib.h>

--- a/src/modules/mysql.c
+++ b/src/modules/mysql.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
-#include <assert.h>
 #include <math.h>
 
 #include <mtev_hash.h>
@@ -352,7 +351,7 @@ static int mysql_drive_session(eventer_t e, int mask, void *closure,
       e->mask = EVENTER_READ | EVENTER_WRITE;
       break;
     default:
-      abort();
+      mtevFatal(mtev_error, "Unknown mask: 0x%04x\n", mask);
   }
   return 0;
 }

--- a/src/modules/noit_lua_noit_binding.c
+++ b/src/modules/noit_lua_noit_binding.c
@@ -144,7 +144,7 @@ static int noit_metric_id_index_func(lua_State *L) {
   const char *k;
   noit_metric_id_t **udata, *metric_id;
   n = lua_gettop(L); /* number of arguments */
-  assert(n == 2);
+  mtevAssert(n == 2);
   if(!luaL_checkudata(L, 1, "metric_id_t")) {
     luaL_error(L, "metatable error, arg1 not a metric_id_t!");
     return 1;
@@ -204,7 +204,7 @@ noit_message_index_func(lua_State *L) {
   const char *k;
   noit_metric_message_t **udata, *msg;
   n = lua_gettop(L);    /* number of arguments */
-  assert(n == 2);
+  mtevAssert(n == 2);
   if(!luaL_checkudata(L, 1, "metric_message_t")) {
     luaL_error(L, "metatable error, arg1 not a metric_message_t!");
     return 1;

--- a/src/modules/postgres.c
+++ b/src/modules/postgres.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
-#include <assert.h>
 #include <math.h>
 #include <libpq-fe.h>
 
@@ -284,7 +283,7 @@ static int postgres_drive_session(eventer_t e, int mask, void *closure,
       e->mask = EVENTER_READ | EVENTER_WRITE;
       break;
     default:
-      abort();
+      mtevFatal(mtev_error, "Unknown mask: 0x%04x\n", mask);
   }
   return 0;
 }

--- a/src/modules/postgres_ingestor.c
+++ b/src/modules/postgres_ingestor.c
@@ -42,7 +42,6 @@
 #include <sys/mman.h>
 #include <libpq-fe.h>
 #include <zlib.h>
-#include <assert.h>
 #include <errno.h>
 
 #include <eventer/eventer.h>
@@ -336,7 +335,7 @@ get_conn_q_for_remote(const char *remote_str,
   pthread_mutex_lock(&cpool->lock);
  again:
   if(cpool->head) {
-    assert(cpool->in_pool > 0);
+    mtevAssert(cpool->in_pool > 0);
     cq = cpool->head;
     cpool->head = cq->next;
     cpool->in_pool--;
@@ -967,7 +966,7 @@ stratcon_ingest_asynch_lookup(eventer_t e, int mask, void *closure,
   if(!(mask & EVENTER_ASYNCH_WORK)) return 0;
   if(mask & EVENTER_ASYNCH_CLEANUP) return 0;
 
-  assert(dsjd->rt);
+  mtevAssert(dsjd->rt);
   stratcon_ingest_find(dsjd);
   if(dsjd->completion_event)
     eventer_add(dsjd->completion_event);
@@ -1078,14 +1077,14 @@ build_insert_batch(pg_interim_journal_t *ij) {
     if(ij->fd < 0) {
       mtevL(noit_error, "Cannot open interim journal '%s': %s\n",
             ij->filename, strerror(errno));
-      assert(ij->fd >= 0);
+      mtevAssert(ij->fd >= 0);
     }
   }
   while((rv = fstat(ij->fd, &st)) == -1 && errno == EINTR);
   if(rv == -1) {
       mtevL(noit_error, "Cannot stat interim journal '%s': %s\n",
             ij->filename, strerror(errno));
-    assert(rv != -1);
+    mtevAssert(rv != -1);
   }
   len = st.st_size;
   if(len > 0) {
@@ -1093,7 +1092,7 @@ build_insert_batch(pg_interim_journal_t *ij) {
     if(buff == (void *)-1) {
       mtevL(noit_error, "mmap(%d, %d)(%s) => %s\n", (int)len, ij->fd,
             ij->filename, strerror(errno));
-      assert(buff != (void *)-1);
+      mtevAssert(buff != (void *)-1);
     }
     lcp = buff;
     while(lcp < (buff + len) &&
@@ -1359,7 +1358,7 @@ storage_node_quick_lookup(const char *uuid_str, const char *remote_cn,
 
   if(fqdn_out) *fqdn_out = info ? info->fqdn : NULL;
   if(dsn_out) *dsn_out = info ? info->dsn : NULL;
-  assert(uuidinfo);
+  mtevAssert(uuidinfo);
   if(remote_cn_out) *remote_cn_out = uuidinfo->remote_cn;
   if(storagenode_id_out) *storagenode_id_out = uuidinfo->storagenode_id;
   if(sid_out) *sid_out = uuidinfo->sid;

--- a/src/modules/rabbitmq_driver.c
+++ b/src/modules/rabbitmq_driver.c
@@ -33,7 +33,6 @@
 
 #include <poll.h>
 #include <unistd.h>
-#include <assert.h>
 #include <errno.h>
 
 #include <mtev_dso.h>
@@ -456,7 +455,7 @@ register_console_rabbitmq_commands() {
 
   tl = mtev_console_state_initial();
   showcmd = mtev_console_state_get_cmd(tl, "show");
-  assert(showcmd && showcmd->dstate);
+  mtevAssert(showcmd && showcmd->dstate);
   mtev_console_state_add_cmd(showcmd->dstate,
     NCSCMD("rabbitmq", noit_console_show_rabbitmq, NULL, NULL, NULL));
 }

--- a/src/modules/resolver_cache.c
+++ b/src/modules/resolver_cache.c
@@ -31,7 +31,6 @@
 
 #include <mtev_defines.h>
 
-#include <assert.h>
 #include <libgen.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/src/modules/reverse_check.c
+++ b/src/modules/reverse_check.c
@@ -30,9 +30,6 @@
  */
 
 #include <mtev_defines.h>
-
-#include <assert.h>
-
 #include <mtev_hash.h>
 #include <mtev_reverse_socket.h>
 

--- a/src/modules/selfcheck.c
+++ b/src/modules/selfcheck.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
-#include <assert.h>
 #include <math.h>
 
 #include <mtev_hash.h>
@@ -213,7 +212,7 @@ static int selfcheck_log_size(eventer_t e, int mask, void *closure,
       e->mask = EVENTER_READ | EVENTER_WRITE;
       break;
     default:
-      abort();
+      mtevFatal(mtev_error, "Unknown mask: 0x%04x\n", mask);
   }
   return 0;
 }

--- a/src/modules/snmp.c
+++ b/src/modules/snmp.c
@@ -37,7 +37,6 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <errno.h>
-#include <assert.h>
 #include <math.h>
 #include <ctype.h>
 #include <arpa/inet.h>
@@ -1098,7 +1097,7 @@ static int noit_snmp_fill_oidinfo(noit_check_t *check) {
       i++;
     }
   }
-  assert(info->noids == i);
+  mtevAssert(info->noids == i);
   mtev_hash_destroy(&check_attrs_hash, NULL, NULL);
   return info->noids;
 }
@@ -1112,7 +1111,7 @@ static int noit_snmp_fill_req(struct snmp_pdu *req, noit_check_t *check, int idx
     return info->noids;
   }
 
-  assert(idx >= 0 && idx <info->noids);
+  mtevAssert(idx >= 0 && idx <info->noids);
   snmp_add_null_var(req, info->oids[idx].oid, info->oids[idx].oidlen);
   return 1;
 }
@@ -1532,7 +1531,7 @@ register_console_snmp_commands(snmp_mod_config_t *conf) {
 
   tl = mtev_console_state_initial();
   showcmd = mtev_console_state_get_cmd(tl, "show");
-  assert(showcmd && showcmd->dstate);
+  mtevAssert(showcmd && showcmd->dstate);
   mtev_console_state_add_cmd(showcmd->dstate,
     NCSCMD("snmp", noit_console_show_snmp, NULL, NULL, conf));
 }
@@ -1624,7 +1623,7 @@ static int noit_snmp_init(noit_module_t *self) {
 
     FD_ZERO(&fdset);
     snmp_sess_select_info(ts->slp, &fds, &fdset, &timeout, &block);
-    assert(fds > 0);
+    mtevAssert(fds > 0);
     for(i=0; i<fds; i++) {
       if(FD_ISSET(i, &fdset)) {
         ts->refcnt++;

--- a/src/modules/ssh2.c
+++ b/src/modules/ssh2.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
-#include <assert.h>
 #include <math.h>
 #ifdef HAVE_SYS_FILIO_H
 #include <sys/filio.h>
@@ -225,7 +224,7 @@ static int ssh2_drive_session(eventer_t e, int mask, void *closure,
       ci->state = WANT_CLOSE;
       break;
     default:
-      abort();
+      mtevFatal(mtev_error, "Unknown mask: 0x%04x\n", mask);
   }
   return 0;
 }
@@ -247,9 +246,9 @@ static int ssh2_needs_bytes_as_libssh2_is_impatient(eventer_t e, int mask, void 
   }
 
   /* We steal the timeout_event as it has the exact timeout we want. */
-  assert(ci->timeout_event);
+  mtevAssert(ci->timeout_event);
   asynch_e = eventer_remove(ci->timeout_event);
-  assert(asynch_e);
+  mtevAssert(asynch_e);
   ci->timeout_event = NULL;
 
   ci->synch_fd_event = NULL;

--- a/src/modules/statsd.c
+++ b/src/modules/statsd.c
@@ -35,7 +35,6 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
-#include <assert.h>
 #include <math.h>
 #include <ctype.h>
 #include <arpa/inet.h>

--- a/src/modules/test_abort.c
+++ b/src/modules/test_abort.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
-#include <assert.h>
 #include <math.h>
 
 #include <mtev_hash.h>
@@ -146,7 +145,7 @@ static int test_abort_drive_session(eventer_t e, int mask, void *closure,
       e->mask = EVENTER_READ | EVENTER_WRITE;
       break;
     default:
-      abort();
+      mtevFatal(mtev_error, "Unknown mask: 0x%04x\n", mask);
   }
   return 0;
 }

--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -38,7 +38,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <ctype.h>
-#include <assert.h>
 #include <errno.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -290,7 +289,7 @@ noit_check_add_to_list(noit_check_t *new_check, const char *newname) {
   }
   pthread_mutex_lock(&polls_lock);
   if(!(new_check->flags & NP_TRANSIENT)) {
-    assert(new_check->name || newname);
+    mtevAssert(new_check->name || newname);
     /* This remove could fail -- no big deal */
     if(new_check->name != NULL)
       mtev_skiplist_remove(&polls_by_name, new_check, NULL);
@@ -1110,7 +1109,7 @@ noit_check_set_ip(noit_check_t *new_check,
   }
 
   if(new_check->name == NULL && newname != NULL) {
-    assert(new_check->flags & NP_TRANSIENT);
+    mtevAssert(new_check->flags & NP_TRANSIENT);
     new_check->name = strdup(newname);
   }
 
@@ -1146,7 +1145,7 @@ noit_check_update(noit_check_t *new_check,
   char uuid_str[37];
   int mask = NP_DISABLED | NP_UNCONFIG;
 
-  assert(name);
+  mtevAssert(name);
   uuid_unparse_lower(new_check->checkid, uuid_str);
   if(!new_check->statistics) new_check->statistics = noit_check_stats_set_calloc();
   if(seq < 0) new_check->config_seq = seq = 0;
@@ -1294,7 +1293,7 @@ noit_poller_schedule(const char *target,
   new_check->statistics = noit_check_stats_set_calloc();
   noit_check_update(new_check, target, name, filterset, config, mconfigs,
                     period, timeout, oncheck, seq, flags);
-  assert(mtev_hash_store(&polls,
+  mtevAssert(mtev_hash_store(&polls,
                          (char *)new_check->checkid, UUID_SIZE,
                          new_check));
   uuid_copy(out, new_check->checkid);
@@ -1411,8 +1410,8 @@ noit_poller_deschedule(uuid_t in, mtev_boolean log) {
 
   if(log) noit_check_log_delete(checker);
 
-  assert(mtev_skiplist_remove(&polls_by_name, checker, NULL));
-  assert(mtev_hash_delete(&polls, (char *)in, UUID_SIZE, NULL, NULL));
+  mtevAssert(mtev_skiplist_remove(&polls_by_name, checker, NULL));
+  mtevAssert(mtev_hash_delete(&polls, (char *)in, UUID_SIZE, NULL, NULL));
 
   noit_poller_free_check(checker);
   return 0;
@@ -1642,7 +1641,7 @@ bad_check_initiate(noit_module_t *self, noit_check_t *check,
   char buff[256];
   if(!once) return -1;
   if(!check) return -1;
-  assert(!(check->flags & NP_RUNNING));
+  mtevAssert(!(check->flags & NP_RUNNING));
   check->flags |= NP_RUNNING;
   inp = noit_check_get_stats_inprogress(check);
   gettimeofday(&now, NULL);
@@ -1696,7 +1695,7 @@ noit_metric_sizes(metric_type_t type, const void *value) {
     case METRIC_GUESS:
       break;
   }
-  assert(type != type);
+  mtevAssert(type != type);
   return 0;
 }
 static metric_type_t
@@ -1949,7 +1948,7 @@ noit_stats_set_metric_coerce(noit_check_t *check,
       break;
     case METRIC_ABSENT:
     case METRIC_NULL:
-      assert(0 && "ABSENT and NULL metrics may not be passed to noit_stats_set_metric_coerce");
+      mtevAssert(0 && "ABSENT and NULL metrics may not be passed to noit_stats_set_metric_coerce");
   }
   check_stats_set_metric_coerce_hook_invoke(check, c, name, t, v, mtev_true);
 }
@@ -2319,7 +2318,7 @@ register_console_check_commands() {
 
   tl = mtev_console_state_initial();
   showcmd = mtev_console_state_get_cmd(tl, "show");
-  assert(showcmd && showcmd->dstate);
+  mtevAssert(showcmd && showcmd->dstate);
 
   mtev_console_state_add_cmd(showcmd->dstate,
     NCSCMD("timing_slots", noit_console_show_timing_slots, NULL, NULL, NULL));
@@ -2369,7 +2368,7 @@ noit_check_registered_module_cnt() {
 const char *
 noit_check_registered_module(int idx) {
   if(reg_module_used < 0) reg_module_used = reg_module_id;
-  assert(reg_module_used == reg_module_id);
+  mtevAssert(reg_module_used == reg_module_id);
   if(idx >= reg_module_id || idx < 0) return NULL;
   return reg_module_names[idx];
 }
@@ -2378,7 +2377,7 @@ void
 noit_check_set_module_metadata(noit_check_t *c, int idx, void *md, void (*freefunc)(void *)) {
   struct vp_w_free *tuple;
   if(reg_module_used < 0) reg_module_used = reg_module_id;
-  assert(reg_module_used == reg_module_id);
+  mtevAssert(reg_module_used == reg_module_id);
   if(idx >= reg_module_id || idx < 0) return;
   if(!c->module_metadata) c->module_metadata = calloc(reg_module_id, sizeof(void *));
   c->module_metadata[idx] = calloc(1, sizeof(struct vp_w_free));
@@ -2389,7 +2388,7 @@ noit_check_set_module_metadata(noit_check_t *c, int idx, void *md, void (*freefu
 void
 noit_check_set_module_config(noit_check_t *c, int idx, mtev_hash_table *config) {
   if(reg_module_used < 0) reg_module_used = reg_module_id;
-  assert(reg_module_used == reg_module_id);
+  mtevAssert(reg_module_used == reg_module_id);
   if(idx >= reg_module_id || idx < 0) return;
   if(!c->module_configs) c->module_configs = calloc(reg_module_id, sizeof(mtev_hash_table *));
   c->module_configs[idx] = config;
@@ -2398,7 +2397,7 @@ void *
 noit_check_get_module_metadata(noit_check_t *c, int idx) {
   struct vp_w_free *tuple;
   if(reg_module_used < 0) reg_module_used = reg_module_id;
-  assert(reg_module_used == reg_module_id);
+  mtevAssert(reg_module_used == reg_module_id);
   if(idx >= reg_module_id || idx < 0 || !c->module_metadata) return NULL;
   tuple = c->module_metadata[idx];
   return tuple ? tuple->ptr : NULL;
@@ -2406,7 +2405,7 @@ noit_check_get_module_metadata(noit_check_t *c, int idx) {
 mtev_hash_table *
 noit_check_get_module_config(noit_check_t *c, int idx) {
   if(reg_module_used < 0) reg_module_used = reg_module_id;
-  assert(reg_module_used == reg_module_id);
+  mtevAssert(reg_module_used == reg_module_id);
   if(idx >= reg_module_id || idx < 0 || !c->module_configs) return NULL;
   return c->module_configs[idx];
 }

--- a/src/noit_check_resolver.c
+++ b/src/noit_check_resolver.c
@@ -39,7 +39,6 @@
 #include <unistd.h>
 #include <time.h>
 #include <ctype.h>
-#include <assert.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
@@ -462,9 +461,9 @@ void noit_check_resolver_maintain() {
 
   now = time(NULL);
   sn = mtev_skiplist_getlist(nc_dns_cache.index);
-  assert(sn);
+  mtevAssert(sn);
   tlist = sn->data;
-  assert(tlist);
+  mtevAssert(tlist);
   sn = mtev_skiplist_getlist(tlist);
   while(sn) {
     dns_cache_node *n = sn->data;
@@ -632,10 +631,10 @@ register_console_dns_cache_commands() {
 
   tl = mtev_console_state_initial();
   showcmd = mtev_console_state_get_cmd(tl, "show");
-  assert(showcmd && showcmd->dstate);
+  mtevAssert(showcmd && showcmd->dstate);
 
   nocmd = mtev_console_state_get_cmd(tl, "no");
-  assert(nocmd && nocmd->dstate);
+  mtevAssert(nocmd && nocmd->dstate);
 
   mtev_console_state_add_cmd(showcmd->dstate,
     NCSCMD("dns_cache", noit_console_show_dns_cache, NULL, NULL, NULL));

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -33,7 +33,6 @@
 
 #include <mtev_defines.h>
 
-#include <assert.h>
 #include <errno.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
@@ -995,23 +994,23 @@ rest_show_config(mtev_http_rest_closure_t *restc,
 
 void
 noit_check_rest_init() {
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/", "^config(/.*)?$",
     rest_show_config, mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/checks/", "^show(\\.json)?$",
     rest_show_checks, mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/checks/", "^show(/.*)(?<=/)(" UUID_REGEX ")(\\.json)?$",
     rest_show_check, mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "PUT", "/checks/", "^set(/.*)(?<=/)(" UUID_REGEX ")$",
     rest_set_check, mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "DELETE", "/checks/", "^delete(/.*)(?<=/)(" UUID_REGEX ")$",
     rest_delete_check, mtev_http_rest_client_cert_auth
   ) == 0);

--- a/src/noit_check_tools.c
+++ b/src/noit_check_tools.c
@@ -40,8 +40,6 @@
 #include "noit_check_tools.h"
 #include "noit_check_tools_shared.h"
 
-#include <assert.h>
-
 MTEV_HOOK_IMPL(check_preflight,
   (noit_module_t *self, noit_check_t *check, noit_check_t *cause),
   void *, closure,
@@ -120,7 +118,7 @@ noit_check_schedule_next(noit_module_t *self,
   recur_closure_t *rcl;
   int initial = last_check ? 1 : 0;
 
-  assert(cause == NULL);
+  mtevAssert(cause == NULL);
   if(check->period == 0) return 0;
 
   /* if last_check is not passed, we use the initial_schedule_time
@@ -166,8 +164,7 @@ noit_check_schedule_next(noit_module_t *self,
     diffms = (int64_t)diff.tv_sec * 1000 + diff.tv_usec / 1000;
   }
   else {
-    mtevL(noit_error, "time is going backwards. abort.\n");
-    abort();
+    mtevFatal(noit_error, "time is going backwards. abort.\n");
   }
   /* determine the offset from initial schedule time that would place
    * us at the next period-aligned point past "now" */
@@ -180,7 +177,7 @@ noit_check_schedule_next(noit_module_t *self,
 
   sub_timeval(newe->whence, earliest, &diff);
   diffms = (int64_t)diff.tv_sec * 1000 + (int)diff.tv_usec / 1000;
-  assert(compare_timeval(newe->whence, earliest) > 0);
+  mtevAssert(compare_timeval(newe->whence, earliest) > 0);
   newe->mask = EVENTER_TIMER;
   newe->callback = noit_check_recur_handler;
   rcl = calloc(1, sizeof(*rcl));

--- a/src/noit_conf_checks.c
+++ b/src/noit_conf_checks.c
@@ -37,7 +37,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <assert.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <libxml/xpath.h>
@@ -1028,7 +1027,7 @@ replace_config(mtev_console_closure_t ncct,
     }
     else confignode = xmlXPathNodeSetItem(pobj->nodesetval, 0);
 
-    assert(confignode);
+    mtevAssert(confignode);
     /* Now we create a child */
     xmlNewChild(confignode, NULL, (xmlChar *)name, (xmlChar *)value);
     CONF_DIRTY(confignode);

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -33,6 +33,7 @@
 
 #include <mtev_defines.h>
 
+#include <mtev_log.h>
 #include <mtev_hash.h>
 #include <mtev_atomic.h>
 #include <mtev_watchdog.h>
@@ -45,7 +46,6 @@
 #include "noit_filters.h"
 
 #include <pcre.h>
-#include <assert.h>
 #include <libxml/tree.h>
 
 static mtev_hash_table *filtersets = NULL;
@@ -714,10 +714,10 @@ register_console_filter_commands() {
 
   tl = mtev_console_state_initial();
   confcmd = mtev_console_state_get_cmd(tl, "configure");
-  assert(confcmd && confcmd->dstate);
+  mtevAssert(confcmd && confcmd->dstate);
 
   conf_t_cmd = mtev_console_state_get_cmd(confcmd->dstate, "terminal");
-  assert(conf_t_cmd && conf_t_cmd->dstate);
+  mtevAssert(conf_t_cmd && conf_t_cmd->dstate);
 
   nostate = mtev_console_state_alloc();
   mtev_console_state_add_cmd(nostate,
@@ -745,7 +745,7 @@ register_console_filter_commands() {
            NULL, NULL, NULL));
 
   no_cmd = mtev_console_state_get_cmd(conf_t_cmd->dstate, "no");
-  assert(no_cmd && no_cmd->dstate);
+  mtevAssert(no_cmd && no_cmd->dstate);
   mtev_console_state_add_cmd(no_cmd->dstate,
     NCSCMD("filterset", noit_console_filter_configure, NULL, NULL, (void *)1));
 }

--- a/src/noit_filters_rest.c
+++ b/src/noit_filters_rest.c
@@ -33,7 +33,6 @@
 
 #include <mtev_defines.h>
 
-#include <assert.h>
 #include <errno.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
@@ -260,19 +259,19 @@ rest_set_filter(mtev_http_rest_closure_t *restc,
 
 void
 noit_filters_rest_init() {
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/filters/", "^show(/.*)(?<=/)([^/]+)$",
     rest_show_filter, mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "PUT", "/filters/", "^set(/.*)(?<=/)([^/]+)$",
     rest_set_filter, mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "DELETE", "/filters/", "^delete(/.*)(?<=/)([^/]+)$",
     rest_delete_filter, mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "POST", "/filters/", "^cull$",
     rest_cull_filter, mtev_http_rest_client_cert_auth
   ) == 0);

--- a/src/noit_jlog_listener.c
+++ b/src/noit_jlog_listener.c
@@ -50,7 +50,6 @@
 
 #include <unistd.h>
 #include <poll.h>
-#include <assert.h>
 
 static int MAX_ROWS_AT_ONCE = 10000;
 static int DEFAULT_MSECONDS_BETWEEN_BATCHES = 10000;
@@ -81,15 +80,15 @@ noit_jlog_listener_init() {
     mtev_conf_get_int(node, "//jlog/default_mseconds_between_batches", &DEFAULT_MSECONDS_BETWEEN_BATCHES);
     mtev_conf_get_int(node, "//jlog/default_transient_mseconds_between_batches", &DEFAULT_TRANSIENT_MSECONDS_BETWEEN_BATCHES);
   }
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/", "^feed$",
     rest_show_feed, mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "DELETE", "/feed/", "^(.+)$",
     rest_delete_feed, mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "PUT", "/", "^feed$",
     rest_add_feed, mtev_http_rest_client_cert_auth
   ) == 0);

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -64,7 +64,7 @@ get_my_lane() {
     for(new_thread=0;new_thread<nthreads;new_thread++) {
       if(mtev_atomic_casptr(&thread_queues[new_thread], my_lane.fifo, NULL) == NULL) break;
     }
-    assert(new_thread<nthreads);
+    mtevAssert(new_thread<nthreads);
     my_lane.id = new_thread;
     mtevL(mtev_debug, "Assigning thread(%p) to %d\n", (void*)pthread_self(), my_lane.id);
   }
@@ -80,7 +80,7 @@ noit_adjust_checks_interest(short cnt) {
   icnt = check_interests[thread_id];
   icnt += cnt;
   if(icnt < 0) icnt = 0;
-  assert(icnt <= 0xffff);
+  mtevAssert(icnt <= 0xffff);
   check_interests[thread_id] = icnt;
 }
 
@@ -104,7 +104,7 @@ noit_adjust_metric_interest(uuid_t id, const char *metric, short cnt) {
       free(level2);
     }
     found = mtev_hash_retrieve(&id_level, (const char *)id, UUID_SIZE, &vhash);
-    assert(found);
+    mtevAssert(found);
   }
   level2 = vhash;
 
@@ -118,14 +118,14 @@ noit_adjust_metric_interest(uuid_t id, const char *metric, short cnt) {
       free(vinterests);
     }
     found = mtev_hash_retrieve(level2, metric, strlen(metric), &vinterests);
-    assert(found);
+    mtevAssert(found);
   }
   interests = vinterests;
   /* This is fine because thread_id is only ours */
   icnt = interests[thread_id];
   icnt += cnt;
   if(icnt < 0) icnt = 0;
-  assert(icnt <= 0xffff);
+  mtevAssert(icnt <= 0xffff);
   interests[thread_id] = icnt;
 }
 
@@ -258,7 +258,7 @@ handle_log_line(void *closure, mtev_log_stream_t ls, struct timeval *whence,
 
 void noit_metric_director_init() {
   nthreads = eventer_loop_concurrency();
-  assert(nthreads > 0);
+  mtevAssert(nthreads > 0);
   thread_queues = calloc(sizeof(*thread_queues),nthreads);
   check_interests = calloc(sizeof(*check_interests),nthreads);
   if(mtev_fq_handle_message_hook_register_available())

--- a/src/noit_metric_rollup.c
+++ b/src/noit_metric_rollup.c
@@ -29,7 +29,7 @@
  */
 
 #include "noit_metric_rollup.h"
-#include <assert.h>
+#include "mtev_log.h"
 #define private_nan 0
 #if defined(__APPLE__) && defined(__MACH__)
 #define isnanf(a) __inline_isnanf((float)(a))
@@ -57,22 +57,22 @@ metric_value_int64(noit_metric_value_t *v) {
     case METRIC_INT64: return v->value.v_int64;
     default: ;
   }
-  abort();
+  mtevFatal(mtev_error, "Unknown int type: %d\n", v->type);
 }
 static uint64_t
 metric_value_uint64(noit_metric_value_t *v) {
   switch(v->type) {
     case METRIC_INT32:
-      assert(v->value.v_int32 >= 0);
+      mtevAssert(v->value.v_int32 >= 0);
       return (uint64_t)v->value.v_int32;
     case METRIC_UINT32: return (uint64_t)v->value.v_uint32;
     case METRIC_INT64:
-      assert(v->value.v_int64 >= 0);
+      mtevAssert(v->value.v_int64 >= 0);
       return (uint64_t)v->value.v_int64;
     case METRIC_UINT64: return v->value.v_uint64;
     default: ;
   }
-  abort();
+  mtevFatal(mtev_error, "Unknown int type: %d\n", v->type);
 }
 static int
 metric_value_is_negative(noit_metric_value_t *v) {
@@ -87,7 +87,7 @@ metric_value_is_negative(noit_metric_value_t *v) {
       return (v->value.v_double < 0);
     default: ;
   }
-  abort();
+  mtevFatal(mtev_error, "Unknown metric type: %d\n", v->type);
 }
 
 static void

--- a/src/noitd.c
+++ b/src/noitd.c
@@ -35,7 +35,6 @@
 #include "noit_version.h"
 #include <mtev_defines.h>
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -90,7 +89,7 @@ static char *glider = NULL;
 static void usage(const char *progname) {
   printf("Usage for %s:\n", progname);
 #ifdef NOITD_USAGE
-  assert(write(STDOUT_FILENO,
+  mtevAssert(write(STDOUT_FILENO,
                NOITD_USAGE,
                sizeof(NOITD_USAGE)-1) == sizeof(NOITD_USAGE)-1);
 #else
@@ -272,7 +271,7 @@ static int child_main() {
   noit_metric_director_init();
 
   /* Allow the noit web dashboard to be served (only if document_root is set) */
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/", "^(.*)$", mtev_rest_simple_file_handler,
            mtev_http_rest_client_cert_auth
   ) == 0);

--- a/src/stratcon_datastore.c
+++ b/src/stratcon_datastore.c
@@ -41,7 +41,6 @@
 #include <arpa/inet.h>
 #include <sys/mman.h>
 #include <zlib.h>
-#include <assert.h>
 #include <errno.h>
 
 #include <eventer/eventer.h>
@@ -456,7 +455,7 @@ stratcon_datastore_init() {
                                  is_raw_ingestion_file,
                                  stratcon_ingest);
 
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/noits/", "^config$", rest_get_noit_config,
              mtev_http_rest_client_cert_auth
   ) == 0);

--- a/src/stratcon_iep.c
+++ b/src/stratcon_iep.c
@@ -46,7 +46,6 @@
 #endif
 #include <signal.h>
 #include <errno.h>
-#include <assert.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <libxml/xpath.h>
@@ -145,7 +144,7 @@ mq_command_free(void *command) {
 static int
 stmt_mark_dag(struct statement_node *stmt, int mgen) {
   int i;
-  assert(stmt->marked <= mgen);
+  mtevAssert(stmt->marked <= mgen);
   if(stmt->marked == mgen) return -1;
   if(stmt->marked > 0) return 0; /* validated in a previous sweep */
   stmt->marked = mgen;
@@ -575,7 +574,7 @@ stratcon_iep_err_handler(eventer_t e, int mask, void *closure,
     if(len == -1 && (errno == EAGAIN || errno == EINTR))
       return newmask | EVENTER_EXCEPTION;
     if(len <= 0) goto read_error;
-    assert(len < sizeof(buff));
+    mtevAssert(len < sizeof(buff));
     buff[len] = '\0';
     mtevL(noit_iep_debug, "%s", buff);
   }
@@ -854,7 +853,7 @@ stratcon_iep_init() {
   eventer_jobq_init(&iep_jobq, "iep_submitter");
   eventer_jobq_increase_concurrency(&iep_jobq);
 
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "PUT", "/", "^mq_filters$",
     rest_set_filters, mtev_http_rest_client_cert_auth
   ) == 0);

--- a/src/stratcon_jlog_streamer.c
+++ b/src/stratcon_jlog_streamer.c
@@ -34,7 +34,6 @@
 #include <mtev_defines.h>
 
 #include <unistd.h>
-#include <assert.h>
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -259,7 +258,7 @@ __read_on_ctx(eventer_t e, jlog_streamer_ctx_t *ctx, int *newmask) {
     ctx->total_bytes_read += len;
     ctx->bytes_read += len;
   }
-  assert(ctx->bytes_read == ctx->bytes_expected);
+  mtevAssert(ctx->bytes_read == ctx->bytes_expected);
   return ctx->bytes_read;
 }
 #define FULLREAD(e,ctx,size) do { \
@@ -1335,7 +1334,7 @@ register_console_streamer_commands() {
 
   tl = mtev_console_state_initial();
   showcmd = mtev_console_state_get_cmd(tl, "show");
-  assert(showcmd && showcmd->dstate);
+  mtevAssert(showcmd && showcmd->dstate);
   confcmd = mtev_console_state_get_cmd(tl, "configure");
   conftcmd = mtev_console_state_get_cmd(confcmd->dstate, "terminal");
   conftnocmd = mtev_console_state_get_cmd(conftcmd->dstate, "no");
@@ -1384,23 +1383,23 @@ stratcon_jlog_streamer_init(const char *toplevel) {
   register_console_streamer_commands();
   stratcon_jlog_streamer_reload(toplevel);
   stratcon_streamer_connection(toplevel, "", "noit", NULL, NULL, NULL, NULL);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/noits/", "^show(.json)?$", rest_show_noits,
              mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "PUT", "/noits/", "^set/([^/:]+)$", rest_set_noit,
              mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "PUT", "/noits/", "^set/([^/:]*):(\\d+)$", rest_set_noit,
              mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "DELETE", "/noits/", "^delete/([^/:]+)$", rest_delete_noit,
              mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "DELETE", "/noits/", "^delete/([^/:]*):(\\d+)$", rest_delete_noit,
              mtev_http_rest_client_cert_auth
   ) == 0);

--- a/src/stratcon_realtime_http.c
+++ b/src/stratcon_realtime_http.c
@@ -55,7 +55,6 @@
 
 #include <ctype.h>
 #include <unistd.h>
-#include <assert.h>
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -368,7 +367,7 @@ __read_on_ctx(eventer_t e, realtime_recv_ctx_t *ctx, int *newmask) {
      */
     ctx->bytes_read += len;
   }
-  assert(ctx->bytes_read == ctx->bytes_expected);
+  mtevAssert(ctx->bytes_read == ctx->bytes_expected);
   return ctx->bytes_read;
 }
 #define FULLREAD(e,ctx,size) do { \
@@ -631,12 +630,12 @@ stratcon_realtime_http_init(const char *toplevel) {
                         stratcon_realtime_http_handler);
   eventer_name_callback("stratcon_realtime_recv",
                         stratcon_realtime_recv_handler);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/data/",
            "^((?:" UUID_REGEX "(?:@\\d+)?)(?:/" UUID_REGEX "(?:@\\d+)?)*)$",
     rest_stream_data, mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/", "^(.*)$", mtev_rest_simple_file_handler,
            mtev_http_rest_client_cert_auth
   ) == 0);

--- a/src/stratcond.c
+++ b/src/stratcond.c
@@ -34,7 +34,6 @@
 #include <mtev_defines.h>
 #include "noit_version.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -80,7 +79,7 @@ static char *glider = NULL;
 static void usage(const char *progname) {
   printf("Usage for %s:\n", progname);
 #ifdef STRATCOND_USAGE
-  assert(write(STDOUT_FILENO,
+  mtevAssert(write(STDOUT_FILENO,
               STRATCOND_USAGE,
               sizeof(STRATCOND_USAGE)-1) == sizeof(STRATCOND_USAGE)-1);
 #else


### PR DESCRIPTION
Use libmtev calls to safely flush logs and abort rather than calling
the assert and abort calls directly.