### PR TITLE
Fix So We Don't Have A Use-After-Free On Passive Checks

### DIFF
--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -1325,7 +1325,7 @@ noit_poller_free_check(noit_check_t *checker) {
     struct timeval current_time;
     gettimeofday(&current_time, NULL);
     if (checker->last_fire_time.tv_sec == 0) {
-      gettimeofday(&checker->last_fire_time, NULL);
+      memcpy(&checker->last_fire_time, &current_time, sizeof(struct timeval));
     }
     /* If NP_RUNNING is set for some reason or we've fired recently, recycle
      * the check.... we don't want to free it */

--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -1324,10 +1324,13 @@ noit_poller_free_check(noit_check_t *checker) {
   if (checker->flags & NP_PASSIVE_COLLECTION) {
     struct timeval current_time;
     gettimeofday(&current_time, NULL);
+    if (checker->last_fire_time.tv_sec == 0) {
+      gettimeofday(&checker->last_fire_time, NULL);
+    }
     /* If NP_RUNNING is set for some reason or we've fired recently, recycle
      * the check.... we don't want to free it */
     if ((checker->flags & NP_RUNNING) ||
-        ((current_time.tv_sec - checker->last_fire_time.tv_sec) < (checker->period*2))) {
+        (sub_timeval_ms(current_time,checker->last_fire_time) < (checker->period*2))) {
       recycle_check(checker);
     }
   }

--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -1321,7 +1321,18 @@ void
 noit_poller_free_check(noit_check_t *checker) {
   noit_module_t *mod;
 
-  if(checker->flags & NP_RUNNING) {
+  if (checker->flags & NP_PASSIVE_COLLECTION) {
+    struct timeval current_time;
+    gettimeofday(&current_time, NULL);
+    /* If NP_RUNNING is set for some reason or we've fired recently, recycle
+     * the check.... we don't want to free it */
+    if ((checker->flags & NP_RUNNING) ||
+        ((current_time.tv_sec - checker->last_fire_time.tv_sec) < (checker->period*2))) {
+      recycle_check(checker);
+    }
+  }
+  else if(checker->flags & NP_RUNNING) {
+    /* If the check is running, don't free it - will clean it up later */
     recycle_check(checker);
     return;
   }


### PR DESCRIPTION
If a check is passive, recycle it unless it's either:

* Flagged as running for some reason (shouldn't happen)
or....
* Last ran (period*2) seconds ago

This will prevent freeing a check that's in-flight and causing possible
memory errors.