### PR TITLE
Free Histotier Object When Done With It

### DIFF
--- a/src/modules/histogram.c
+++ b/src/modules/histogram.c
@@ -330,6 +330,7 @@ static void free_histotier(void *vht) {
   for(i=0;i<6;i++)
     if(ht->tensecs[i]) hist_free(ht->tensecs[i]);
   if(ht->last_aggr) hist_free(ht->last_aggr);
+  free(ht);
 }
 static void free_hash_o_histotier(void *vh) {
   mtev_hash_table *h = vh;


### PR DESCRIPTION
We were freeing the contents of the histotier object, but not the object
itself. Free it.