### PR TITLE
Explicitly Use mtev_hash_init To Init Hashes

### DIFF
--- a/src/modules/dns.c
+++ b/src/modules/dns.c
@@ -758,7 +758,7 @@ static int dns_check_send(noit_module_t *self, noit_check_t *check,
   char interpolated_query[1024];
   mtev_hash_table check_attrs_hash;
 
-  mtev_hash_init_locks(&check_attrs_hash, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init(&check_attrs_hash);
 
   BAIL_ON_RUNNING_CHECK(check);
   check->flags |= NP_RUNNING;

--- a/src/modules/dns.c
+++ b/src/modules/dns.c
@@ -395,10 +395,10 @@ static int dns_module_init(noit_module_t *self) {
 
   conf = noit_module_get_userdata(self);
 
-  mtev_hash_init(&dns_rtypes);
-  mtev_hash_init(&dns_ctypes);
-  mtev_hash_init(&dns_ctx_store);
-  mtev_hash_init(&active_events);
+  mtev_hash_init_locks(&dns_rtypes, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&dns_ctypes, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&dns_ctx_store, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&active_events, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   pthread_mutex_init(&dns_ctx_store_lock, NULL);
   pthread_mutex_init(&active_events_lock, NULL);
@@ -758,7 +758,7 @@ static int dns_check_send(noit_module_t *self, noit_check_t *check,
   char interpolated_query[1024];
   mtev_hash_table check_attrs_hash;
 
-  mtev_hash_init(&check_attrs_hash);
+  mtev_hash_init_locks(&check_attrs_hash, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   BAIL_ON_RUNNING_CHECK(check);
   check->flags |= NP_RUNNING;

--- a/src/modules/dns.c
+++ b/src/modules/dns.c
@@ -64,10 +64,10 @@ static void register_console_dns_commands();
 static mtev_log_stream_t nlerr = NULL;
 static mtev_log_stream_t nldeb = NULL;
 
-static mtev_hash_table dns_rtypes = MTEV_HASH_EMPTY;
-static mtev_hash_table dns_ctypes = MTEV_HASH_EMPTY;
+static mtev_hash_table dns_rtypes;
+static mtev_hash_table dns_ctypes;
 
-static mtev_hash_table dns_ctx_store = MTEV_HASH_EMPTY;
+static mtev_hash_table dns_ctx_store;
 static pthread_mutex_t dns_ctx_store_lock;
 typedef struct dns_ctx_handle {
   char *ns; /* name server */
@@ -200,7 +200,7 @@ static int dns_module_dns_ctx_release(dns_ctx_handle_t *h) {
   return rv;
 }
 
-static mtev_hash_table active_events = MTEV_HASH_EMPTY;
+static mtev_hash_table active_events;
 static pthread_mutex_t active_events_lock;
 
 typedef struct dns_check_info {
@@ -394,6 +394,11 @@ static int dns_module_init(noit_module_t *self) {
   dns_mod_config_t *conf;
 
   conf = noit_module_get_userdata(self);
+
+  mtev_hash_init(&dns_rtypes);
+  mtev_hash_init(&dns_ctypes);
+  mtev_hash_init(&dns_ctx_store);
+  mtev_hash_init(&active_events);
 
   pthread_mutex_init(&dns_ctx_store_lock, NULL);
   pthread_mutex_init(&active_events_lock, NULL);
@@ -751,7 +756,9 @@ static int dns_check_send(noit_module_t *self, noit_check_t *check,
   const char *query = NULL;
   char interpolated_nameserver[1024];
   char interpolated_query[1024];
-  mtev_hash_table check_attrs_hash = MTEV_HASH_EMPTY;
+  mtev_hash_table check_attrs_hash;
+
+  mtev_hash_init(&check_attrs_hash);
 
   BAIL_ON_RUNNING_CHECK(check);
   check->flags |= NP_RUNNING;

--- a/src/modules/external.c
+++ b/src/modules/external.c
@@ -653,7 +653,7 @@ static int external_invoke(noit_module_t *self, noit_check_t *check,
   char interp_fmt[4096], interp_buff[4096];
   char* rp;
 
-  mtev_hash_init_locks(&check_attrs_hash, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init(&check_attrs_hash);
 
   data = noit_module_get_userdata(self);
 

--- a/src/modules/external.c
+++ b/src/modules/external.c
@@ -645,13 +645,15 @@ static int external_invoke(noit_module_t *self, noit_check_t *check,
   struct check_info *ci = (struct check_info *)check->closure;
   eventer_t newe;
   external_data_t *data;
-  mtev_hash_table check_attrs_hash = MTEV_HASH_EMPTY;
+  mtev_hash_table check_attrs_hash;
   int i, klen;
   mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
   const char *name, *value, *command;
   char resolved_path[PATH_MAX];
   char interp_fmt[4096], interp_buff[4096];
   char* rp;
+
+  mtev_hash_init(&check_attrs_hash);
 
   data = noit_module_get_userdata(self);
 

--- a/src/modules/external.c
+++ b/src/modules/external.c
@@ -653,7 +653,7 @@ static int external_invoke(noit_module_t *self, noit_check_t *check,
   char interp_fmt[4096], interp_buff[4096];
   char* rp;
 
-  mtev_hash_init(&check_attrs_hash);
+  mtev_hash_init_locks(&check_attrs_hash, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   data = noit_module_get_userdata(self);
 

--- a/src/modules/fq_driver.c
+++ b/src/modules/fq_driver.c
@@ -452,7 +452,7 @@ static void noit_fq_set_filters(mq_command_t *commands, int count) {
   for (i=0; i<count; i++) {
     if (commands[i].action == MQ_ACTION_SET) {
       mtev_hash_table *metric_table = calloc(1, sizeof(mtev_hash_table));
-      mtev_hash_init(metric_table);
+      mtev_hash_init_locks(metric_table, 256, MTEV_HASH_LOCK_MODE_MUTEX);
       for (j=0; j<commands[i].check.metric_count; j++) {
         mtev_hash_store(metric_table, strdup(commands[i].check.metrics[j]), strlen(commands[i].check.metrics[j]), NULL);
         filtered_metrics_exist = true;
@@ -577,7 +577,7 @@ fq_status_checker(eventer_t e, int mask, void *closure, struct timeval *now) {
 static int noit_fq_driver_init(mtev_dso_generic_t *self) {
   if(!nlerr) nlerr = mtev_log_stream_find("error/fq_driver");
   if(!nlerr) nlerr = mtev_error;
-  mtev_hash_init(&filtered_checks_hash);
+  mtev_hash_init_locks(&filtered_checks_hash, 256, MTEV_HASH_LOCK_MODE_MUTEX);
   stratcon_iep_mq_driver_register("fq", &mq_driver_fq);
   register_console_fq_commands();
   eventer_add_in_s_us(fq_status_checker, NULL, 0, 0);

--- a/src/modules/fq_driver.c
+++ b/src/modules/fq_driver.c
@@ -452,7 +452,7 @@ static void noit_fq_set_filters(mq_command_t *commands, int count) {
   for (i=0; i<count; i++) {
     if (commands[i].action == MQ_ACTION_SET) {
       mtev_hash_table *metric_table = calloc(1, sizeof(mtev_hash_table));
-      mtev_hash_init_locks(metric_table, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+      mtev_hash_init(metric_table);
       for (j=0; j<commands[i].check.metric_count; j++) {
         mtev_hash_store(metric_table, strdup(commands[i].check.metrics[j]), strlen(commands[i].check.metrics[j]), NULL);
         filtered_metrics_exist = true;

--- a/src/modules/fq_driver.c
+++ b/src/modules/fq_driver.c
@@ -45,7 +45,7 @@
 #include "fq_driver.xmlh"
 
 static mtev_log_stream_t nlerr = NULL;
-static mtev_hash_table filtered_checks_hash = MTEV_HASH_EMPTY;
+static mtev_hash_table filtered_checks_hash;
 static bool filtered_metrics_exist = false;
 
 typedef struct {

--- a/src/modules/handoff_ingestor.c
+++ b/src/modules/handoff_ingestor.c
@@ -287,7 +287,7 @@ static int handoff_ingestor_init(mtev_dso_generic_t *self) {
   ds_err = mtev_log_stream_find("error/datastore");
   ds_deb = mtev_log_stream_find("debug/datastore");
   ingest_err = mtev_log_stream_find("error/ingest");
-  mtev_hash_init(&uuid_map);
+  mtev_hash_init_locks(&uuid_map, 256, MTEV_HASH_LOCK_MODE_MUTEX);
   if(!ds_err) ds_err = mtev_error;
   if(!ingest_err) ingest_err = mtev_error;
   if(!mtev_conf_get_string(NULL, "/stratcon/database/journal/path",

--- a/src/modules/handoff_ingestor.c
+++ b/src/modules/handoff_ingestor.c
@@ -72,7 +72,7 @@ static int storage_node_quick_lookup(const char *uuid_str,
                                      const char **dsn_out);
 
 static char *basejpath = NULL;
-static mtev_hash_table uuid_map = MTEV_HASH_EMPTY;
+static mtev_hash_table uuid_map;
 
 static void
 stratcon_ingest_iep_check_preload() {
@@ -287,6 +287,7 @@ static int handoff_ingestor_init(mtev_dso_generic_t *self) {
   ds_err = mtev_log_stream_find("error/datastore");
   ds_deb = mtev_log_stream_find("debug/datastore");
   ingest_err = mtev_log_stream_find("error/ingest");
+  mtev_hash_init(&uuid_map);
   if(!ds_err) ds_err = mtev_error;
   if(!ingest_err) ingest_err = mtev_error;
   if(!mtev_conf_get_string(NULL, "/stratcon/database/journal/path",

--- a/src/modules/ip_acl.c
+++ b/src/modules/ip_acl.c
@@ -47,7 +47,7 @@
 
 static int ip_acl_module_id = -1;
 
-static mtev_hash_table acls = MTEV_HASH_EMPTY;
+static mtev_hash_table acls;
 
 static void
 free_btrie(void *vb) {
@@ -165,6 +165,7 @@ ip_acl_hook_impl(void *closure, noit_module_t *self,
 }
 static int
 ip_acl_init(mtev_dso_generic_t *self) {
+  mtev_hash_init(&acls);
   check_preflight_hook_register("ip_acl", ip_acl_hook_impl, NULL);
   return 0;
 }

--- a/src/modules/ip_acl.c
+++ b/src/modules/ip_acl.c
@@ -165,7 +165,7 @@ ip_acl_hook_impl(void *closure, noit_module_t *self,
 }
 static int
 ip_acl_init(mtev_dso_generic_t *self) {
-  mtev_hash_init(&acls);
+  mtev_hash_init_locks(&acls, 256, MTEV_HASH_LOCK_MODE_MUTEX);
   check_preflight_hook_register("ip_acl", ip_acl_hook_impl, NULL);
   return 0;
 }

--- a/src/modules/lua_check.c
+++ b/src/modules/lua_check.c
@@ -476,7 +476,7 @@ noit_lua_interpolate(lua_State *L) {
   mtev_hash_table check_attrs_hash;
   char buff[8192];
 
-  mtev_hash_init(&check_attrs_hash);
+  mtev_hash_init_locks(&check_attrs_hash, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   if(lua_gettop(L) != 1) luaL_error(L, "wrong number of arguments");
   check = lua_touserdata(L, lua_upvalueindex(1));
@@ -780,7 +780,7 @@ noit_lua_module_config(noit_module_t *mod,
   if(options) {
     mtevAssert(mc->options == NULL);
     mc->options = calloc(1, sizeof(*mc->options));
-    mtev_hash_init(mc->options);
+    mtev_hash_init_locks(mc->options, 256, MTEV_HASH_LOCK_MODE_MUTEX);
     mtev_hash_merge_as_dict(mc->options, options);
   }
   else options = mc->options;

--- a/src/modules/lua_check.c
+++ b/src/modules/lua_check.c
@@ -476,7 +476,7 @@ noit_lua_interpolate(lua_State *L) {
   mtev_hash_table check_attrs_hash;
   char buff[8192];
 
-  mtev_hash_init_locks(&check_attrs_hash, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init(&check_attrs_hash);
 
   if(lua_gettop(L) != 1) luaL_error(L, "wrong number of arguments");
   check = lua_touserdata(L, lua_upvalueindex(1));

--- a/src/modules/lua_check.c
+++ b/src/modules/lua_check.c
@@ -473,8 +473,10 @@ noit_lua_log_immediate_metric(lua_State *L) {
 static int
 noit_lua_interpolate(lua_State *L) {
   noit_check_t *check;
-  mtev_hash_table check_attrs_hash = MTEV_HASH_EMPTY;
+  mtev_hash_table check_attrs_hash;
   char buff[8192];
+
+  mtev_hash_init(&check_attrs_hash);
 
   if(lua_gettop(L) != 1) luaL_error(L, "wrong number of arguments");
   check = lua_touserdata(L, lua_upvalueindex(1));

--- a/src/modules/mysql.c
+++ b/src/modules/mysql.c
@@ -255,7 +255,7 @@ static int mysql_drive_session(eventer_t e, int mask, void *closure,
   unsigned long client_flag = CLIENT_IGNORE_SIGPIPE;
   unsigned int timeout;
 
-  mtev_hash_init(&dsn_h);
+  mtev_hash_init_locks(&dsn_h, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   if(mask & (EVENTER_READ | EVENTER_WRITE)) {
     /* this case is impossible from the eventer.  It is called as

--- a/src/modules/mysql.c
+++ b/src/modules/mysql.c
@@ -255,7 +255,7 @@ static int mysql_drive_session(eventer_t e, int mask, void *closure,
   unsigned long client_flag = CLIENT_IGNORE_SIGPIPE;
   unsigned int timeout;
 
-  mtev_hash_init_locks(&dsn_h, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init(&dsn_h);
 
   if(mask & (EVENTER_READ | EVENTER_WRITE)) {
     /* this case is impossible from the eventer.  It is called as

--- a/src/modules/mysql.c
+++ b/src/modules/mysql.c
@@ -243,7 +243,7 @@ static int mysql_drive_session(eventer_t e, int mask, void *closure,
   mysql_check_info_t *ci = closure;
   noit_check_t *check = ci->check;
   struct timeval t1, t2, diff;
-  mtev_hash_table dsn_h = MTEV_HASH_EMPTY;
+  mtev_hash_table dsn_h;
   const char *host=NULL;
   const char *user=NULL;
   const char *password=NULL;
@@ -254,6 +254,8 @@ static int mysql_drive_session(eventer_t e, int mask, void *closure,
   u_int32_t port;
   unsigned long client_flag = CLIENT_IGNORE_SIGPIPE;
   unsigned int timeout;
+
+  mtev_hash_init(&dsn_h);
 
   if(mask & (EVENTER_READ | EVENTER_WRITE)) {
     /* this case is impossible from the eventer.  It is called as

--- a/src/modules/snmp.c
+++ b/src/modules/snmp.c
@@ -1011,7 +1011,7 @@ static int noit_snmp_fill_oidinfo(noit_check_t *check) {
   struct check_info *info = check->closure;
   mtev_hash_table check_attrs_hash;
 
-  mtev_hash_init(&check_attrs_hash);
+  mtev_hash_init_locks(&check_attrs_hash, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   /* Toss the old set and bail if we have zero */
   if(info->oids) {
@@ -1564,7 +1564,7 @@ static int noit_snmp_init(noit_module_t *self) {
   const char *opt;
   snmp_mod_config_t *conf;
 
-  mtev_hash_init(&active_checks);
+  mtev_hash_init_locks(&active_checks, 256, MTEV_HASH_LOCK_MODE_MUTEX);
   conf = noit_module_get_userdata(self);
   if(mtev_hash_retr_str(conf->options, "debugging", strlen("debugging"), &opt)) {
     snmp_set_do_debugging(atoi(opt));

--- a/src/modules/snmp.c
+++ b/src/modules/snmp.c
@@ -1011,7 +1011,7 @@ static int noit_snmp_fill_oidinfo(noit_check_t *check) {
   struct check_info *info = check->closure;
   mtev_hash_table check_attrs_hash;
 
-  mtev_hash_init_locks(&check_attrs_hash, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init(&check_attrs_hash);
 
   /* Toss the old set and bail if we have zero */
   if(info->oids) {

--- a/src/modules/snmp.c
+++ b/src/modules/snmp.c
@@ -182,7 +182,7 @@ struct check_info {
  *   then we know we can remove the timeout and  complete the check. 
  *   If we don't find them, the timeout fired and removed the check.
  */
-mtev_hash_table active_checks = MTEV_HASH_EMPTY;
+mtev_hash_table active_checks;
 static void add_check(struct check_info *c) {
   int i;
   for(i=0; i<c->noids; i++)
@@ -1009,7 +1009,9 @@ static int noit_snmp_fill_oidinfo(noit_check_t *check) {
   mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
   const char *name, *value;
   struct check_info *info = check->closure;
-  mtev_hash_table check_attrs_hash = MTEV_HASH_EMPTY;
+  mtev_hash_table check_attrs_hash;
+
+  mtev_hash_init(&check_attrs_hash);
 
   /* Toss the old set and bail if we have zero */
   if(info->oids) {
@@ -1562,6 +1564,7 @@ static int noit_snmp_init(noit_module_t *self) {
   const char *opt;
   snmp_mod_config_t *conf;
 
+  mtev_hash_init(&active_checks);
   conf = noit_module_get_userdata(self);
   if(mtev_hash_retr_str(conf->options, "debugging", strlen("debugging"), &opt)) {
     snmp_set_do_debugging(atoi(opt));

--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -235,8 +235,8 @@ static u_int64_t check_completion_count = 0ULL;
 static u_int64_t check_metrics_seen = 0ULL;
 static pthread_mutex_t polls_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t recycling_lock = PTHREAD_MUTEX_INITIALIZER;
-static mtev_hash_table polls = MTEV_HASH_EMPTY;
-static mtev_hash_table dns_ignore_list = MTEV_HASH_EMPTY;
+static mtev_hash_table polls;
+static mtev_hash_table dns_ignore_list;
 static mtev_skiplist watchlist = { 0 };
 static mtev_skiplist polls_by_name = { 0 };
 static u_int32_t __config_load_generation = 0;
@@ -857,6 +857,8 @@ noit_check_poller_scheduling_init() {
 void
 noit_poller_init() {
   srand48((getpid() << 16) ^ time(NULL));
+  mtev_hash_init(&polls);
+  mtev_hash_init(&dns_ignore_list);
   noit_check_poller_scheduling_init();
   noit_check_resolver_init();
   noit_check_tools_init();

--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -203,7 +203,7 @@ noit_check_stats_alloc() {
   stats_t *n;
   n = mtev_memory_safe_malloc_cleanup(sizeof(*n), noit_check_safe_free_stats);
   memset(n, 0, sizeof(*n));
-  mtev_hash_init(&n->metrics);
+  mtev_hash_init_locks(&n->metrics, 256, MTEV_HASH_LOCK_MODE_MUTEX);
   return n;
 }
 static void *
@@ -857,8 +857,8 @@ noit_check_poller_scheduling_init() {
 void
 noit_poller_init() {
   srand48((getpid() << 16) ^ time(NULL));
-  mtev_hash_init(&polls);
-  mtev_hash_init(&dns_ignore_list);
+  mtev_hash_init_locks(&polls, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&dns_ignore_list, 256, MTEV_HASH_LOCK_MODE_MUTEX);
   noit_check_poller_scheduling_init();
   noit_check_resolver_init();
   noit_check_tools_init();

--- a/src/noit_check_resolver.c
+++ b/src/noit_check_resolver.c
@@ -809,7 +809,7 @@ void noit_check_resolver_init() {
   noit_check_resolver_loop(NULL, 0, NULL, NULL);
   register_console_dns_cache_commands();
 
-  mtev_hash_init(&etc_hosts_cache);
+  mtev_hash_init_locks(&etc_hosts_cache, 256, MTEV_HASH_LOCK_MODE_MUTEX);
   noit_check_etc_hosts_cache_refresh(NULL, 0, NULL, NULL);
 }
 

--- a/src/noit_check_tools_shared.c
+++ b/src/noit_check_tools_shared.c
@@ -217,7 +217,7 @@ interpolate_oper_random(char *buff, int len, const char *key,
 
 void
 noit_check_tools_shared_init() {
-  mtev_hash_init(&interpolation_operators);
+  mtev_hash_init_locks(&interpolation_operators, 256, MTEV_HASH_LOCK_MODE_MUTEX);
   noit_check_interpolate_register_oper_fn("copy", interpolate_oper_copy);
   noit_check_interpolate_register_oper_fn("ccns", interpolate_oper_ccns);
   noit_check_interpolate_register_oper_fn("random", interpolate_oper_random);

--- a/src/noit_check_tools_shared.c
+++ b/src/noit_check_tools_shared.c
@@ -39,7 +39,7 @@
 
 #include "noit_check_tools.h"
 
-static mtev_hash_table interpolation_operators = MTEV_HASH_EMPTY;
+static mtev_hash_table interpolation_operators;
 
 static int
 interpolate_oper_copy(char *buff, int len, const char *key,
@@ -217,6 +217,7 @@ interpolate_oper_random(char *buff, int len, const char *key,
 
 void
 noit_check_tools_shared_init() {
+  mtev_hash_init(&interpolation_operators);
   noit_check_interpolate_register_oper_fn("copy", interpolate_oper_copy);
   noit_check_interpolate_register_oper_fn("ccns", interpolate_oper_ccns);
   noit_check_interpolate_register_oper_fn("random", interpolate_oper_random);

--- a/src/noit_conf_checks.c
+++ b/src/noit_conf_checks.c
@@ -91,10 +91,11 @@ mtev_console_state_add_check_attrs(mtev_console_state_t *state,
              NULL, &valid_attrs[i]));
   }
 }
-static mtev_hash_table check_attrs = MTEV_HASH_EMPTY;
+static mtev_hash_table check_attrs;
 
 void noit_console_conf_checks_init() {
   int i;
+  mtev_hash_init(&check_attrs);
   for(i=0;i<sizeof(valid_attrs)/sizeof(*valid_attrs);i++) {
     mtev_hash_store(&check_attrs,
                     valid_attrs[i].name, strlen(valid_attrs[i].name),

--- a/src/noit_conf_checks.c
+++ b/src/noit_conf_checks.c
@@ -95,7 +95,7 @@ static mtev_hash_table check_attrs;
 
 void noit_console_conf_checks_init() {
   int i;
-  mtev_hash_init(&check_attrs);
+  mtev_hash_init_locks(&check_attrs, 256, MTEV_HASH_LOCK_MODE_MUTEX);
   for(i=0;i<sizeof(valid_attrs)/sizeof(*valid_attrs);i++) {
     mtev_hash_store(&check_attrs,
                     valid_attrs[i].name, strlen(valid_attrs[i].name),

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -179,7 +179,7 @@ noit_filter_compile_add(mtev_conf_section_t setinfo) {
       rule->rname##_auto_hash_max = auto_max; \
       rule->rname##_ht = calloc(1, sizeof(*(rule->rname##_ht))); \
       while(tablesize < hte_cnt) tablesize <<= 1; \
-      mtev_hash_init_size(rule->rname##_ht, tablesize); \
+      mtev_hash_init_locks(rule->rname##_ht, tablesize, MTEV_HASH_LOCK_MODE_MUTEX); \
       for(hti=0; hti<hte_cnt; hti++) { \
         if(!mtev_conf_get_string(htentries[hti], "self::node()", &htstr)) \
           mtevL(noit_error, "Error fetching text content from filter match.\n"); \
@@ -630,7 +630,7 @@ noit_filtersets_cull_unused() {
   int i, n_uses = 0, n_declares = 0, removed = 0;
   const char *declare_xpath = "//filterset[@name and not (@cull='false')]";
 
-  mtev_hash_init(&active);
+  mtev_hash_init_locks(&active, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   declares = mtev_conf_get_sections(NULL, declare_xpath, &n_declares);
   if(declares) {

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -624,11 +624,13 @@ filterset_accum(noit_check_t *check, void *closure) {
 
 int
 noit_filtersets_cull_unused() {
-  mtev_hash_table active = MTEV_HASH_EMPTY;
+  mtev_hash_table active;
   char *buffer = NULL;
   mtev_conf_section_t *declares;
   int i, n_uses = 0, n_declares = 0, removed = 0;
   const char *declare_xpath = "//filterset[@name and not (@cull='false')]";
+
+  mtev_hash_init(&active);
 
   declares = mtev_conf_get_sections(NULL, declare_xpath, &n_declares);
   if(declares) {

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -630,7 +630,7 @@ noit_filtersets_cull_unused() {
   int i, n_uses = 0, n_declares = 0, removed = 0;
   const char *declare_xpath = "//filterset[@name and not (@cull='false')]";
 
-  mtev_hash_init_locks(&active, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init(&active);
 
   declares = mtev_conf_get_sections(NULL, declare_xpath, &n_declares);
   if(declares) {

--- a/src/noit_jlog_listener.c
+++ b/src/noit_jlog_listener.c
@@ -68,7 +68,7 @@ static int rest_add_feed(mtev_http_rest_closure_t *restc,
 void
 noit_jlog_listener_init() {
   xmlNodePtr node;
-  mtev_hash_init(&feed_stats);
+  mtev_hash_init_locks(&feed_stats, 256, MTEV_HASH_LOCK_MODE_MUTEX);
   eventer_name_callback("log_transit/1.0", noit_jlog_handler);
   mtev_control_dispatch_delegate(mtev_control_dispatch,
                                  NOIT_JLOG_DATA_FEED,

--- a/src/noit_jlog_listener.c
+++ b/src/noit_jlog_listener.c
@@ -56,6 +56,7 @@ static int DEFAULT_MSECONDS_BETWEEN_BATCHES = 10000;
 static int DEFAULT_TRANSIENT_MSECONDS_BETWEEN_BATCHES = 500;
 
 static mtev_atomic32_t tmpfeedcounter = 0;
+static mtev_hash_table feed_stats;
 
 static int rest_show_feed(mtev_http_rest_closure_t *restc,
                           int npats, char **pats);
@@ -67,6 +68,7 @@ static int rest_add_feed(mtev_http_rest_closure_t *restc,
 void
 noit_jlog_listener_init() {
   xmlNodePtr node;
+  mtev_hash_init(&feed_stats);
   eventer_name_callback("log_transit/1.0", noit_jlog_handler);
   mtev_control_dispatch_delegate(mtev_control_dispatch,
                                  NOIT_JLOG_DATA_FEED,
@@ -124,8 +126,6 @@ noit_jlog_closure_free(noit_jlog_closure_t *jcl) {
   }
   free(jcl);
 }
-
-static mtev_hash_table feed_stats = MTEV_HASH_EMPTY;
 
 jlog_feed_stats_t *
 noit_jlog_feed_stats(const char *sub) {

--- a/src/noit_module.c
+++ b/src/noit_module.c
@@ -246,7 +246,7 @@ void noit_module_init() {
   mtev_conf_section_t *sections;
   int i, cnt = 0;
 
-  mtev_hash_init(&modules);
+  mtev_hash_init_locks(&modules, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   mtev_dso_add_type("module", noit_module_list_modules);
   mtev_console_add_help("module", noit_module_help, noit_module_options);

--- a/src/noit_module.c
+++ b/src/noit_module.c
@@ -66,7 +66,7 @@ mtev_dso_loader_t __noit_module_loader = {
   noit_load_module_image
 };
 
-static mtev_hash_table modules = MTEV_HASH_EMPTY;
+static mtev_hash_table modules;
 static int noit_module_load_failure_count = 0;
 
 int noit_module_load_failures() {
@@ -245,6 +245,8 @@ noit_module_help(mtev_console_closure_t ncct,
 void noit_module_init() {
   mtev_conf_section_t *sections;
   int i, cnt = 0;
+
+  mtev_hash_init(&modules);
 
   mtev_dso_add_type("module", noit_module_list_modules);
   mtev_console_add_help("module", noit_module_help, noit_module_options);

--- a/src/stratcon_iep.c
+++ b/src/stratcon_iep.c
@@ -69,7 +69,7 @@ static mtev_log_stream_t noit_iep_debug = NULL;
 static mtev_spinlock_t iep_conn_cnt = 0;
 static mtev_boolean inject_remote_cn = mtev_false;
 
-static mtev_hash_table mq_drivers = MTEV_HASH_EMPTY;
+static mtev_hash_table mq_drivers;
 struct driver_thread_data {
   mq_driver_t *mq_driver;
   struct iep_thread_driver *driver_data;
@@ -181,11 +181,14 @@ void stratcon_iep_submit_statements() {
   char path[256];
   struct statement_node *stmt;
   void *vstmt;
-  mtev_hash_table stmt_by_id = MTEV_HASH_EMPTY;
-  mtev_hash_table stmt_by_provider = MTEV_HASH_EMPTY;
+  mtev_hash_table stmt_by_id;
+  mtev_hash_table stmt_by_provider;
   mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
   const char *key;
   int klen, mgen = 0;
+
+  mtev_hash_init(&stmt_by_id);
+  mtev_hash_init(&stmt_by_provider);
 
   snprintf(path, sizeof(path), "/stratcon/iep/queries[@master=\"stratcond\"]//statement");
   statement_configs = mtev_conf_get_sections(NULL, path, &cnt);
@@ -801,6 +804,8 @@ stratcon_iep_init() {
   char remote[32] = "ip";
   struct driver_list *newdriver;
   void *vdriver;
+
+  mtev_hash_init(&mq_drivers);
 
   noit_iep = mtev_log_stream_find("error/iep");
   noit_iep_debug = mtev_log_stream_find("debug/iep");

--- a/src/stratcon_iep.c
+++ b/src/stratcon_iep.c
@@ -187,8 +187,8 @@ void stratcon_iep_submit_statements() {
   const char *key;
   int klen, mgen = 0;
 
-  mtev_hash_init_locks(&stmt_by_id, 256, MTEV_HASH_LOCK_MODE_MUTEX);
-  mtev_hash_init_locks(&stmt_by_provider, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init(&stmt_by_id);
+  mtev_hash_init(&stmt_by_provider);
 
   snprintf(path, sizeof(path), "/stratcon/iep/queries[@master=\"stratcond\"]//statement");
   statement_configs = mtev_conf_get_sections(NULL, path, &cnt);

--- a/src/stratcon_iep.c
+++ b/src/stratcon_iep.c
@@ -187,8 +187,8 @@ void stratcon_iep_submit_statements() {
   const char *key;
   int klen, mgen = 0;
 
-  mtev_hash_init(&stmt_by_id);
-  mtev_hash_init(&stmt_by_provider);
+  mtev_hash_init_locks(&stmt_by_id, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&stmt_by_provider, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   snprintf(path, sizeof(path), "/stratcon/iep/queries[@master=\"stratcond\"]//statement");
   statement_configs = mtev_conf_get_sections(NULL, path, &cnt);
@@ -805,7 +805,7 @@ stratcon_iep_init() {
   struct driver_list *newdriver;
   void *vdriver;
 
-  mtev_hash_init(&mq_drivers);
+  mtev_hash_init_locks(&mq_drivers, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   noit_iep = mtev_log_stream_find("error/iep");
   noit_iep_debug = mtev_log_stream_find("debug/iep");

--- a/src/stratcon_jlog_streamer.c
+++ b/src/stratcon_jlog_streamer.c
@@ -60,9 +60,9 @@
 #include "stratcon_iep.h"
 
 pthread_mutex_t noits_lock;
-mtev_hash_table noits = MTEV_HASH_EMPTY;
+mtev_hash_table noits;
 pthread_mutex_t noit_ip_by_cn_lock;
-mtev_hash_table noit_ip_by_cn = MTEV_HASH_EMPTY;
+mtev_hash_table noit_ip_by_cn;
 static uuid_t self_stratcon_id;
 static char self_stratcon_hostname[256] = "\0";
 static struct sockaddr_in self_stratcon_ip;
@@ -525,7 +525,8 @@ stratcon_console_noit_opts(mtev_console_closure_t ncct,
     int klen, i = 0;
     void *vconn, *vcn;
     mtev_connection_ctx_t *ctx;
-    mtev_hash_table dedup = MTEV_HASH_EMPTY;
+    mtev_hash_table dedup;
+    mtev_hash_init(&dedup);
 
     pthread_mutex_lock(&noits_lock);
     while(mtev_hash_next(&noits, &iter, &key_id, &klen, &vconn)) {
@@ -747,7 +748,7 @@ rest_show_noits_json(mtev_http_rest_closure_t *restc,
                      int npats, char **pats) {
   const char *jsonstr;
   struct json_object *doc, *nodes, *node;
-  mtev_hash_table seen = MTEV_HASH_EMPTY;
+  mtev_hash_table seen;
   mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
   char path[256];
   const char *key_id;
@@ -758,6 +759,8 @@ rest_show_noits_json(mtev_http_rest_closure_t *restc,
   mtev_conf_section_t *noit_configs;
   struct timeval now, diff, last;
   mtev_http_request *req = mtev_http_session_request(restc->http_ctx);
+
+  mtev_hash_init(&seen);
 
   mtev_http_process_querystring(req);
   type = mtev_http_request_querystring(req, "type");
@@ -940,7 +943,7 @@ rest_show_noits(mtev_http_rest_closure_t *restc,
                 int npats, char **pats) {
   xmlDocPtr doc;
   xmlNodePtr root;
-  mtev_hash_table *hdrs, seen = MTEV_HASH_EMPTY;
+  mtev_hash_table *hdrs, seen;
   mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
   char path[256];
   const char *key_id, *accepthdr;
@@ -952,6 +955,8 @@ rest_show_noits(mtev_http_rest_closure_t *restc,
   struct timeval now, diff, last;
   xmlNodePtr node;
   mtev_http_request *req = mtev_http_session_request(restc->http_ctx);
+
+  mtev_hash_init(&seen);
 
   if(npats == 1 && !strcmp(pats[0], ".json"))
     return rest_show_noits_json(restc, npats, pats);
@@ -1374,6 +1379,9 @@ stratcon_jlog_streamer_init(const char *toplevel) {
   struct timeval whence = DEFAULT_NOIT_PERIOD_TV;
   struct in_addr remote;
   char uuid_str[UUID_STR_LEN + 1];
+
+  mtev_hash_init(&noits);
+  mtev_hash_init(&noit_ip_by_cn);
 
   mtev_reverse_socket_acl(mtev_reverse_socket_allow_noits);
   pthread_mutex_init(&noits_lock, NULL);

--- a/src/stratcon_jlog_streamer.c
+++ b/src/stratcon_jlog_streamer.c
@@ -59,10 +59,10 @@
 #include "stratcon_jlog_streamer.h"
 #include "stratcon_iep.h"
 
-pthread_mutex_t noits_lock;
-mtev_hash_table noits;
-pthread_mutex_t noit_ip_by_cn_lock;
-mtev_hash_table noit_ip_by_cn;
+static pthread_mutex_t noits_lock;
+static mtev_hash_table noits;
+static pthread_mutex_t noit_ip_by_cn_lock;
+static mtev_hash_table noit_ip_by_cn;
 static uuid_t self_stratcon_id;
 static char self_stratcon_hostname[256] = "\0";
 static struct sockaddr_in self_stratcon_ip;
@@ -526,7 +526,7 @@ stratcon_console_noit_opts(mtev_console_closure_t ncct,
     void *vconn, *vcn;
     mtev_connection_ctx_t *ctx;
     mtev_hash_table dedup;
-    mtev_hash_init_locks(&dedup, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+    mtev_hash_init(&dedup);
 
     pthread_mutex_lock(&noits_lock);
     while(mtev_hash_next(&noits, &iter, &key_id, &klen, &vconn)) {
@@ -760,7 +760,7 @@ rest_show_noits_json(mtev_http_rest_closure_t *restc,
   struct timeval now, diff, last;
   mtev_http_request *req = mtev_http_session_request(restc->http_ctx);
 
-  mtev_hash_init_locks(&seen, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init(&seen);
 
   mtev_http_process_querystring(req);
   type = mtev_http_request_querystring(req, "type");
@@ -956,7 +956,7 @@ rest_show_noits(mtev_http_rest_closure_t *restc,
   xmlNodePtr node;
   mtev_http_request *req = mtev_http_session_request(restc->http_ctx);
 
-  mtev_hash_init_locks(&seen, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init(&seen);
 
   if(npats == 1 && !strcmp(pats[0], ".json"))
     return rest_show_noits_json(restc, npats, pats);

--- a/src/stratcon_jlog_streamer.c
+++ b/src/stratcon_jlog_streamer.c
@@ -526,7 +526,7 @@ stratcon_console_noit_opts(mtev_console_closure_t ncct,
     void *vconn, *vcn;
     mtev_connection_ctx_t *ctx;
     mtev_hash_table dedup;
-    mtev_hash_init(&dedup);
+    mtev_hash_init_locks(&dedup, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
     pthread_mutex_lock(&noits_lock);
     while(mtev_hash_next(&noits, &iter, &key_id, &klen, &vconn)) {
@@ -760,7 +760,7 @@ rest_show_noits_json(mtev_http_rest_closure_t *restc,
   struct timeval now, diff, last;
   mtev_http_request *req = mtev_http_session_request(restc->http_ctx);
 
-  mtev_hash_init(&seen);
+  mtev_hash_init_locks(&seen, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   mtev_http_process_querystring(req);
   type = mtev_http_request_querystring(req, "type");
@@ -956,7 +956,7 @@ rest_show_noits(mtev_http_rest_closure_t *restc,
   xmlNodePtr node;
   mtev_http_request *req = mtev_http_session_request(restc->http_ctx);
 
-  mtev_hash_init(&seen);
+  mtev_hash_init_locks(&seen, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   if(npats == 1 && !strcmp(pats[0], ".json"))
     return rest_show_noits_json(restc, npats, pats);
@@ -1380,8 +1380,8 @@ stratcon_jlog_streamer_init(const char *toplevel) {
   struct in_addr remote;
   char uuid_str[UUID_STR_LEN + 1];
 
-  mtev_hash_init(&noits);
-  mtev_hash_init(&noit_ip_by_cn);
+  mtev_hash_init_locks(&noits, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&noit_ip_by_cn, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   mtev_reverse_socket_acl(mtev_reverse_socket_allow_noits);
   pthread_mutex_init(&noits_lock, NULL);

--- a/src/stratcon_realtime_http.c
+++ b/src/stratcon_realtime_http.c
@@ -129,10 +129,12 @@ stratcon_line_to_javascript(mtev_http_session_ctx *ctx, char *in_buff,
   char *scp, *ecp, *token, *buff;
   int i, len, cnt;
   const char *v, *cb = NULL;
-  mtev_hash_table json = MTEV_HASH_EMPTY;
+  mtev_hash_table json;
   mtev_http_request *req = mtev_http_session_request(ctx);
   char s_inc_id[42];
   char **outrows = NULL;
+
+  mtev_hash_init(&json);
 
   cb = mtev_http_request_querystring(req, "cb"); 
   for(v = cb; v && *v; v++)

--- a/src/stratcon_realtime_http.c
+++ b/src/stratcon_realtime_http.c
@@ -134,7 +134,7 @@ stratcon_line_to_javascript(mtev_http_session_ctx *ctx, char *in_buff,
   char s_inc_id[42];
   char **outrows = NULL;
 
-  mtev_hash_init(&json);
+  mtev_hash_init_locks(&json, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   cb = mtev_http_request_querystring(req, "cb"); 
   for(v = cb; v && *v; v++)

--- a/src/stratcon_realtime_http.c
+++ b/src/stratcon_realtime_http.c
@@ -134,7 +134,7 @@ stratcon_line_to_javascript(mtev_http_session_ctx *ctx, char *in_buff,
   char s_inc_id[42];
   char **outrows = NULL;
 
-  mtev_hash_init_locks(&json, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init(&json);
 
   cb = mtev_http_request_querystring(req, "cb"); 
   for(v = cb; v && *v; v++)


### PR DESCRIPTION
Rather than initializing to MTEV_HASH_EMPTY, explicitly call
mtev_hash_init() to initialize hash tables.