### PR TITLE
Call noit_check_tools_shared_init() Much Earlier

### DIFF
--- a/src/noit_check_tools.c
+++ b/src/noit_check_tools.c
@@ -222,7 +222,6 @@ noit_check_run_full_asynch(noit_check_t *check, eventer_func_t callback) {
 
 void
 noit_check_tools_init() {
-  noit_check_tools_shared_init();
   eventer_name_callback_ext("noit_check_recur_handler",
                             noit_check_recur_handler,
                             noit_check_recur_name_details, NULL);

--- a/src/noitd.c
+++ b/src/noitd.c
@@ -71,6 +71,7 @@
 #include "noit_conf_checks.h"
 #include "noit_filters.h"
 #include "noit_metric_director.h"
+#include "noit_check_tools_shared.h"
 
 #define APPNAME "noit"
 #define CHILD_WATCHDOG_TIMEOUT 5 /*seconds*/
@@ -233,6 +234,9 @@ static int child_main() {
   e->mask = EVENTER_RECURRENT;
   e->callback = notice_hup;
   eventer_add_recurrent(e);
+
+  /* Initialized shared tools */
+  noit_check_tools_shared_init();
 
   /* Initialize all of our listeners */
   mtev_console_init(APPNAME);


### PR DESCRIPTION
We need to call this to initialize the hash table before we start
loading checks.