### PR TITLE
Fixed undefined symbol issue and cleared compiler warning

### DIFF
--- a/src/modules/Makefile.in
+++ b/src/modules/Makefile.in
@@ -74,8 +74,8 @@ LUA_MODULE_OBJS=lua_check.lo
 
 lua_check.lo:	lua.xmlh
 
-lua.@MODULEEXT@:	$(LUA_MODULE_OBJS)
-	$(Q)$(MODULELD) $(SHLDFLAGS) -o $@ $(LUA_MODULE_OBJS) $(LUALIBS)
+lua.@MODULEEXT@:  $(LUA_MODULE_OBJS)
+	$(Q)$(MODULELD) $(SHLDFLAGS) -o $@ $(LUA_MODULE_OBJS)	$(LUALIBS)
 	@echo "- linking $@"
 
 # luajit always uses .so
@@ -86,9 +86,9 @@ noit_binding.so:	noit_lua/noit_binding.so
 snmp.so:	noit_lua/snmp.so
 	$(Q)$(LN_S) $< $@
 
-noit_lua/noit_binding.so:	noit_lua_noit_binding.lo
+noit_lua/noit_binding.so:	noit_lua_noit_binding.lo $(LUA_MODULE_OBJS)
 	$(Q)mkdir -p noit_lua
-	$(Q)$(MODULELD) $(SHLDFLAGS) -o noit_lua/noit_binding.@MODULEEXT@ noit_lua_noit_binding.lo
+	$(Q)$(MODULELD) $(SHLDFLAGS) -o noit_lua/noit_binding.@MODULEEXT@ noit_lua_noit_binding.lo $(LUA_MODULE_OBJS)
 	$(Q)if [ "noit_lua/noit_binding.so" != "noit_lua/noit_binding.@MODULEEXT@" ]; then \
 		rm -f noit_lua/noit_binding.so; \
 		mv noit_lua/noit_binding.@MODULEEXT@ noit_lua/noit_binding.so; \

--- a/src/modules/lua_check.c
+++ b/src/modules/lua_check.c
@@ -455,6 +455,9 @@ noit_lua_set_metric_f(lua_State *L,
       __n = luaL_optnumber(L, 2, 0);
       set(check, metric_name, metric_type, &__n);
       break;
+    case METRIC_NULL:
+    case METRIC_ABSENT:
+      luaL_error(L, "illegal metric type: %d", metric_type);
   }
   lua_pushboolean(L, 1);
   return 1;


### PR DESCRIPTION
I'm not sure if it's a good idea to let lua.so AND noit_lua/noit_binding.so depend on $(LUA_MODULE_OBJS) but this at least fixed my issues with undefined symbols in either lua.so or noit_binding.so