### PR TITLE
Call noit_mtev_bridge_init After libmtev Init

### DIFF
--- a/src/noitd.c
+++ b/src/noitd.c
@@ -192,6 +192,8 @@ static int child_main() {
 
   /* Send out a birth notice. */
   mtev_watchdog_child_heartbeat();
+
+  noit_mtev_bridge_init();
   mtev_override_console_stopword(noit_console_stopword);
 
   /* Load our config...
@@ -291,7 +293,6 @@ static int child_main() {
 
 int main(int argc, char **argv) {
   int lock = MTEV_LOCK_OP_LOCK;
-  noit_mtev_bridge_init();
   mtev_memory_init();
   parse_clargs(argc, argv);
   if (xpath) lock = MTEV_LOCK_OP_NONE;

--- a/src/stratcond.c
+++ b/src/stratcond.c
@@ -182,6 +182,7 @@ static int child_main() {
   char stratcon_version[80];
 
   mtev_watchdog_child_heartbeat();
+  noit_mtev_bridge_init();
 
   /* Next (re)load the configs */
   if(mtev_conf_load(config_file) == -1) {
@@ -261,7 +262,6 @@ static int child_main() {
 }
 
 int main(int argc, char **argv) {
-  noit_mtev_bridge_init();
   mtev_memory_init();
   parse_clargs(argc, argv);
   return mtev_main(APPNAME, config_file, debug, foreground,


### PR DESCRIPTION
noit_mtev_bridge_init uses hash tables initialized in libmtev's init
function.... we need to make sure we call this AFTER we initialize
those, not before.