### PR TITLE
Support { "_fl": "+|~" } operations to accumulate and average.

### DIFF
--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -268,6 +268,9 @@ API_EXPORT(void)
 API_EXPORT(metric_t *)
   noit_stats_get_metric(noit_check_t *check, stats_t *, const char *);
 
+API_EXPORT(metric_t *)
+  noit_stats_get_last_metric(noit_check_t *check, const char *);
+
 API_EXPORT(void)
   noit_stats_set_metric(noit_check_t *check,
                         const char *, metric_type_t, const void *);

--- a/src/noit_metric.c
+++ b/src/noit_metric.c
@@ -5,6 +5,25 @@
 
 #include <stdio.h>
 
+mtev_boolean
+noit_metric_as_double(metric_t *metric, double *out) {
+  if(metric == NULL || metric->metric_value.vp == NULL) return mtev_false;
+  switch (metric->metric_type) {
+  case METRIC_INT32:
+    if(out) *out = (double)*(metric->metric_value.i); break;
+  case METRIC_UINT32:
+    if(out) *out = (double)*(metric->metric_value.I); break;
+  case METRIC_INT64:
+    if(out) *out = (double)*(metric->metric_value.l); break;
+  case METRIC_UINT64:
+    if(out) *out = (double)*(metric->metric_value.L); break;
+  case METRIC_DOUBLE:
+    if(out) *out = *(metric->metric_value.n); break;
+  default: return mtev_false;
+  }
+  return true;
+}
+
 void
 noit_metric_to_json(noit_metric_message_t *metric, char **json, size_t *len, mtev_boolean include_original)
 {

--- a/src/noit_metric.h
+++ b/src/noit_metric.h
@@ -49,6 +49,10 @@ typedef enum {
   METRIC_STRING = 's'
 } metric_type_t;
 
+#define IS_METRIC_TYPE_NUMERIC(t) \
+  ((t) == METRIC_INT32 || (t) == METRIC_UINT32 || \
+   (t) == METRIC_INT64 || (t) == METRIC_UINT64 || (t) == METRIC_DOUBLE)
+
 typedef struct {
   char *metric_name;
   metric_type_t metric_type;
@@ -62,6 +66,7 @@ typedef struct {
     void *vp; /* used for clever assignments */
   } metric_value;
   mtev_boolean logged;
+  unsigned long accumulator; /* used to track divisor of averages */
 } metric_t;
 
 typedef enum {
@@ -101,5 +106,9 @@ typedef struct {
 } noit_metric_message_t;
 
 void noit_metric_to_json(noit_metric_message_t *metric, char **json, size_t *len, mtev_boolean include_original);
+
+
+/* If possible coerce the metric to a double, return success */
+API_EXPORT(mtev_boolean) noit_metric_as_double(metric_t *m, double *);
 
 #endif


### PR DESCRIPTION
If httptrap submissions contain an extended value with _fl, it
will attempt to accumulate (+) continuously or average (~) over
the period.  If the logging is immediate, averaging over the
period is avoided for replacement as individually reported
values will be averaged upstream.