### PR TITLE
Bugfix: rollup has to access last value even if it's in the last window

### DIFF
--- a/src/noit_metric_rollup.c
+++ b/src/noit_metric_rollup.c
@@ -297,11 +297,10 @@ noit_metric_rollup_accumulate_numeric(noit_numeric_rollup_accu* accu, noit_metri
     w1_drun = &accu->drun;
     w1_crun = &accu->crun;
 
-    if (accu->accumulated.type != METRIC_NULL
-        && accu->first_value_time_ms >= value->whence_ms) {
+    if (accu->first_value_time_ms >= value->whence_ms) {
       /* It's older! */
       return;
-    } else if (accu->accumulated.type != METRIC_NULL) {
+    } else if (last_value.type != METRIC_ABSENT && last_value.type != METRIC_NULL) {
       /* here we have last_value and value */
       /* Handle the numeric case */
       int drun = 0;


### PR DESCRIPTION
The derivative is calculated based on the last value seen, even if it's not in the current window. Hence, even if the current window is empty (accu->accumulated.type == METRIC_NULL) the derivative can be calculated.