### PR TITLE
Timed immediate metric

### DIFF
--- a/src/modules/histogram.h
+++ b/src/modules/histogram.h
@@ -39,9 +39,9 @@
 #include "noit_check.h"
 
 MTEV_RUNTIME_RESOLVE(noit_log_histo_encoded, noit_log_histo_encoded_function, void,
-                     (noit_check_t *check, u_int64_t whence_s,
+                     (noit_check_t *check, struct timeval *whence,
                          const char *metric_name, const char *hist_encode, ssize_t hist_encode_len,
-                         mtev_boolean live_feed), (check, whence_s, metric_name, hist_encode, hist_encode_len, live_feed))
+                         mtev_boolean live_feed), (check, whence, metric_name, hist_encode, hist_encode_len, live_feed))
 MTEV_RUNTIME_AVAIL(noit_log_histo_encoded, noit_log_histo_encoded_function)
 
 #endif

--- a/src/modules/lua_check.c
+++ b/src/modules/lua_check.c
@@ -397,10 +397,11 @@ static int
 noit_lua_set_metric_f(lua_State *L,
                       void(*set)(noit_check_t *,
                                  const char *, metric_type_t,
-                                 const void *)) {
+                                 const void *, const struct timeval *)) {
   noit_check_t *check;
   const char *metric_name;
   metric_type_t metric_type;
+  struct timeval whence;
 
   double __n = 0.0;
   int32_t __i = 0;
@@ -408,13 +409,23 @@ noit_lua_set_metric_f(lua_State *L,
   int64_t __l = 0;
   u_int64_t __L = 0;
 
-  if(lua_gettop(L) != 2) luaL_error(L, "wrong number of arguments");
+  if(lua_gettop(L) < 2 || lua_gettop(L) > 4) luaL_error(L, "need 2-4 arguments: <metric_name> <value> [whence_s] [whence_us]");
   check = lua_touserdata(L, lua_upvalueindex(1));
   if(!lua_isstring(L, 1)) luaL_error(L, "argument #1 must be a string");
   metric_name = lua_tostring(L, 1);
   metric_type = lua_tointeger(L, lua_upvalueindex(2));
+
+  if(lua_gettop(L) >= 3) {
+    whence.tv_sec = lua_tointeger(L, 3);
+    if(lua_gettop(L) == 4) {
+      whence.tv_sec = lua_tointeger(L, 4);
+    }
+  } else {
+    gettimeofday(&whence, NULL);
+  }
+
   if(lua_isnil(L, 2)) {
-    set(check, metric_name, metric_type, NULL);
+    set(check, metric_name, metric_type, NULL, &whence);
     lua_pushboolean(L, 1);
     return 1;
   }
@@ -425,7 +436,7 @@ noit_lua_set_metric_f(lua_State *L,
     case METRIC_UINT64:
     case METRIC_DOUBLE:
       if(!lua_isnumber(L, 2)) {
-        set(check, metric_name, metric_type, NULL);
+        set(check, metric_name, metric_type, NULL, &whence);
         lua_pushboolean(L, 0);
         return 1;
       }
@@ -436,27 +447,27 @@ noit_lua_set_metric_f(lua_State *L,
     case METRIC_GUESS:
     case METRIC_STRING:
       set(check, metric_name, metric_type,
-                            (void *)lua_tostring(L, 2));
+                            (void *)lua_tostring(L, 2), &whence);
       break;
     case METRIC_INT32:
       __i = strtol(lua_tostring(L, 2), NULL, 10);
-      set(check, metric_name, metric_type, &__i);
+      set(check, metric_name, metric_type, &__i, &whence);
       break;
     case METRIC_UINT32:
       __I = strtoul(lua_tostring(L, 2), NULL, 10);
-      set(check, metric_name, metric_type, &__I);
+      set(check, metric_name, metric_type, &__I, &whence);
       break;
     case METRIC_INT64:
       __l = strtoll(lua_tostring(L, 2), NULL, 10);
-      set(check, metric_name, metric_type, &__l);
+      set(check, metric_name, metric_type, &__l, &whence);
       break;
     case METRIC_UINT64:
       __L = strtoull(lua_tostring(L, 2), NULL, 10);
-      set(check, metric_name, metric_type, &__L);
+      set(check, metric_name, metric_type, &__L, &whence);
       break;
     case METRIC_DOUBLE:
       __n = luaL_optnumber(L, 2, 0);
-      set(check, metric_name, metric_type, &__n);
+      set(check, metric_name, metric_type, &__n, &whence);
       break;
     case METRIC_NULL:
     case METRIC_ABSENT:
@@ -500,12 +511,12 @@ noit_lua_set_histo_metric(lua_State *L) {
 
 static int
 noit_lua_set_metric(lua_State *L) {
-  return noit_lua_set_metric_f(L, noit_stats_set_metric);
+  return noit_lua_set_metric_f(L, noit_stats_set_metric_timed);
 }
 
 static int
 noit_lua_log_immediate_metric(lua_State *L) {
-  return noit_lua_set_metric_f(L, noit_stats_log_immediate_metric);
+  return noit_lua_set_metric_f(L, noit_stats_log_immediate_metric_timed);
 }
 
 static int

--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -1958,7 +1958,7 @@ noit_stats_get_last_metric(noit_check_t *check, const char *name) {
   return m;
 }
 
-stats_t*
+void
 noit_stats_set_metric(noit_check_t *check,
                       const char *name, metric_type_t type,
                       const void *value) {
@@ -1973,18 +1973,8 @@ noit_stats_set_metric(noit_check_t *check,
   c = noit_check_get_stats_inprogress(check);
   check_stats_set_metric_hook_invoke(check, c, m);
   __stats_add_metric(c, m);
-  return c;
 }
-void
-noit_stats_set_metric_timed(noit_check_t *check,
-                      const char *name, metric_type_t type,
-                      const void *value, const struct timeval *time) {
-  stats_t *c;
-  c = noit_stats_set_metric(check, name, type, value);
-  if(c) {
-    noit_check_stats_whence(c, time);
-  }
-}
+
 void
 noit_stats_set_metric_coerce(noit_check_t *check,
                              const char *name, metric_type_t t,

--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -271,14 +271,9 @@ API_EXPORT(metric_t *)
 API_EXPORT(metric_t *)
   noit_stats_get_last_metric(noit_check_t *check, const char *);
 
-API_EXPORT(stats_t*)
+API_EXPORT(void)
   noit_stats_set_metric(noit_check_t *check,
                         const char *, metric_type_t, const void *);
-
-API_EXPORT(void)
-  noit_stats_set_metric_timed(noit_check_t *check,
-                        const char *, metric_type_t, const void *,
-                        const struct timeval *whence);
 
 API_EXPORT(void)
   noit_stats_set_metric_coerce(noit_check_t *check,

--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -271,9 +271,14 @@ API_EXPORT(metric_t *)
 API_EXPORT(metric_t *)
   noit_stats_get_last_metric(noit_check_t *check, const char *);
 
-API_EXPORT(void)
+API_EXPORT(stats_t*)
   noit_stats_set_metric(noit_check_t *check,
                         const char *, metric_type_t, const void *);
+
+API_EXPORT(void)
+  noit_stats_set_metric_timed(noit_check_t *check,
+                        const char *, metric_type_t, const void *,
+                        const struct timeval *whence);
 
 API_EXPORT(void)
   noit_stats_set_metric_coerce(noit_check_t *check,
@@ -284,6 +289,10 @@ API_EXPORT(void)
   noit_stats_log_immediate_metric(noit_check_t *check,
                                   const char *name, metric_type_t type,
                                   const void *value);
+API_EXPORT(void)
+  noit_stats_log_immediate_metric_timed(noit_check_t *check,
+                                  const char *name, metric_type_t type,
+                                  const void *value, const struct timeval *whence);
 API_EXPORT(mtev_boolean)
   noit_stats_log_immediate_histo(noit_check_t *check, const char *name,
                                   const char *hist_encoded,
@@ -350,7 +359,7 @@ API_EXPORT(void) noit_check_log_delete(noit_check_t *check);
 API_EXPORT(void) noit_check_log_bundle(noit_check_t *check);
 API_EXPORT(void) noit_check_log_metrics(noit_check_t *check);
 API_EXPORT(void) noit_check_log_metric(noit_check_t *check,
-                                       struct timeval *whence, metric_t *m);
+                                       const struct timeval *whence, metric_t *m);
 API_EXPORT(void) noit_check_log_histo(noit_check_t *check, u_int64_t whence_s,
           const char *metric_name, const char *b64_histo, ssize_t b64_histo_len);
 API_EXPORT(void) noit_check_extended_id_split(const char *in, int len,
@@ -358,7 +367,6 @@ API_EXPORT(void) noit_check_extended_id_split(const char *in, int len,
                                               char *module, int module_len,
                                               char *name, int name_len,
                                               char *uuid, int uuid_len);
-
 
 API_EXPORT(char *)
   noit_console_check_opts(mtev_console_closure_t ncct,
@@ -375,7 +383,7 @@ API_EXPORT(void) check_slots_inc_tv(struct timeval *tv);
 API_EXPORT(void) check_slots_dec_tv(struct timeval *tv);
 
 API_EXPORT(struct timeval *)
-  noit_check_stats_whence(stats_t *s, struct timeval *n);
+  noit_check_stats_whence(stats_t *s, const struct timeval *n);
 API_EXPORT(int8_t)
   noit_check_stats_available(stats_t *s, int8_t *n);
 API_EXPORT(int8_t)

--- a/src/noit_check_log.c
+++ b/src/noit_check_log.c
@@ -224,7 +224,7 @@ noit_check_log_status(noit_check_t *check) {
 static int
 noit_check_log_bundle_metric_serialize(mtev_log_stream_t ls,
                                        noit_check_t *check,
-                                       struct timeval *whence,
+                                       const struct timeval *whence,
                                        metric_t *m) {
   int size, rv = 0;
   unsigned int out_size;
@@ -295,7 +295,7 @@ noit_check_log_bundle_metric_serialize(mtev_log_stream_t ls,
 static int
 _noit_check_log_metric(mtev_log_stream_t ls, noit_check_t *check,
                        const char *uuid_str,
-                       struct timeval *whence, metric_t *m) {
+                       const struct timeval *whence, metric_t *m) {
   return noit_check_log_bundle_metric_serialize(ls, check, whence, m);
 }
 static int
@@ -557,7 +557,7 @@ noit_check_log_bundle(noit_check_t *check) {
 }
 
 void
-noit_check_log_metric(noit_check_t *check, struct timeval *whence,
+noit_check_log_metric(noit_check_t *check, const struct timeval *whence,
                       metric_t *m) {
   char uuid_str[256*3+37];
 #if defined(NOIT_CHECK_LOG_M)


### PR DESCRIPTION
This allows the following lua code:
check.immediate_metric_double('name', 1.0, 123, 456)

This value should then be distributed at the timestamp 123.456
NOTE: currently for some reason the usecs are ignored. So the actual M message stores the time 123.000