### PR TITLE
Fix Crash When NULL Item Found In Array

### DIFF
--- a/src/noit_check_tools.c
+++ b/src/noit_check_tools.c
@@ -301,7 +301,12 @@ populate_stats_from_resmon_formatted_json(noit_check_t *check,
           int i, alen = json_object_array_length(has_value);
           for(i=0;i<alen;i++) {
             struct json_object *item = json_object_array_get_idx(has_value, i);
-            COERCE_JSON_OBJECT(*type_str, item);
+            if (item) {
+              COERCE_JSON_OBJECT(*type_str, item);
+            }
+            else {
+              mtevL(mtev_error, "WARNING: Got NULL item in JSON array: %s\n", check->name);
+            }
           }
         }
         else {

--- a/src/noit_check_tools.c
+++ b/src/noit_check_tools.c
@@ -305,7 +305,8 @@ populate_stats_from_resmon_formatted_json(noit_check_t *check,
               COERCE_JSON_OBJECT(*type_str, item);
             }
             else {
-              mtevL(mtev_error, "WARNING: Got NULL item in JSON array: %s\n", check->name);
+              noit_stats_set_metric_coerce(check, prefix, (metric_type_t)*type_str, NULL);
+              count++;
             }
           }
         }


### PR DESCRIPTION
We were crashing on a null JSON array object.... check for the
condition, log, and move on when we hit it.