### PR TITLE
mark ping_icmp noit-module as thread-unsafe.

### DIFF
--- a/src/modules/ping_icmp.c
+++ b/src/modules/ping_icmp.c
@@ -708,6 +708,10 @@ noit_module_t ping_icmp = {
   ping_icmp_config,
   ping_icmp_init,
   ping_icmp_initiate_check,
-  ping_check_cleanup
+  ping_check_cleanup,
+  /* all ping checks share a single socket, so we're operationally
+   * mostly single-threaded already. no benefit to having checks
+   * run in multiple threads. */
+  .thread_unsafe = 1
 };
 


### PR DESCRIPTION
It only uses two FD sockets for ICMP responses, so it is mostly
single-threaded already. There is no benefit to having the
noit check infrastructure itself in another thread, and some risk
to doing so. So, make the ping_icmp's noit_module single-threaded.