### PR TITLE
Have cloudwatch treat missing data like all other checks

### DIFF
--- a/src/modules-lua/noit/module/cloudwatch.lua
+++ b/src/modules-lua/noit/module/cloudwatch.lua
@@ -231,14 +231,6 @@ function initiate(module, check)
             stat_table = namespace_table[name]
           end
         end
-        for k, v in ipairs(stat_table) do
-          local met_name = name
-          if v ~= 'Average' then
-            met_name = name .. "_" .. v
-          end
-          check.metric_double(met_name, nil)
-          metric_count = metric_count + 1
-        end
       end
     end
   end


### PR DESCRIPTION
Currently, cloudwatch pushes missing metrics into the response with
a null value.  This is unlike other checks that omit them entirely
and causes confusion further down the line.

We should just treat them line any other check would, and not put
them in the response