### PR TITLE
removed non thread safe check.path from lua

### DIFF
--- a/src/modules/lua_check.c
+++ b/src/modules/lua_check.c
@@ -695,11 +695,6 @@ noit_check_index_func(lua_State *L) {
       return 1;
     case 'p':
       if(!strcmp(k, "period")) lua_pushinteger(L, check->period);
-      else if(!strcmp(k, "path")) {
-        char *path = noit_check_path(check);
-        lua_pushstring(L, path);
-        free(path);
-      }
       else break;
       return 1;
     case 's':

--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -69,8 +69,6 @@
 #define CHECKS_XPATH_PARENT "checks"
 #define CHECKS_XPATH_BASE CHECKS_XPATH_ROOT "/" CHECKS_XPATH_PARENT
 
-static pthread_mutex_t conf_lock = PTHREAD_MUTEX_INITIALIZER;
-
 MTEV_HOOK_IMPL(check_config_fixup,
   (noit_check_t *check),
   void *, closure,
@@ -1672,9 +1670,7 @@ noit_get_check_xml_node(noit_check_t *check) {
   xmlNodePtr node;
   noit_check_xpath_check(xpath, sizeof(xpath), check);
 
-  pthread_mutex_lock(&conf_lock);
   node = mtev_conf_get_section(NULL, xpath);
-  pthread_mutex_unlock(&conf_lock);
   return node;
 }
 


### PR DESCRIPTION
This reverts some parts of https://github.com/JonasKunze/reconnoiter/commit/97c5c2142634286fde3578e79cc2af284c45ee38
I've left some parts of this commit (essentially noit_check_path) as I'm using it in another feature branch