### PR TITLE
Bugfix: wrong logic checking seq of filtersets

### DIFF
--- a/src/noit_filters_rest.c
+++ b/src/noit_filters_rest.c
@@ -255,7 +255,7 @@ rest_set_filter(mtev_http_rest_closure_t *restc,
   }
 
   if((newfilter = validate_filter_post(indoc, pats[1], &seq)) == NULL) goto error;
-  if(exists && (old_seq >= seq || seq == 0)) {
+  if(exists && (old_seq >= seq && seq != 0)) {
     error_code = 403;
     goto error;
   }


### PR DESCRIPTION
It seems like while splitting #321 to #324 and #325 I've made a copy paste error. in #325 it says if(old_seq >= seq && seq != 0) which is correct: If the seq was zero it may stay zero.