### PR TITLE
Protect TS conversion from very precise timestamps

### DIFF
--- a/src/java/src/com/omniti/reconnoiter/StratconMessage.java
+++ b/src/java/src/com/omniti/reconnoiter/StratconMessage.java
@@ -100,8 +100,10 @@ public abstract class StratconMessage {
         ms = Long.valueOf(time).longValue() * 1000;
       }
       else {
+        // protect against abnormally precise timestamps by setting the ending offset for the ms
+        int msendoff = (time.length() >= off+4) ? off+4 : time.length();
         ms = Long.valueOf(time.substring(0,off)).longValue() * 1000;
-        ms = ms + Long.valueOf(time.substring(off+1)).longValue();
+        ms = ms + Long.valueOf(time.substring(off+1,msendoff)).longValue();
       }
     }
     catch (NumberFormatException e) {


### PR DESCRIPTION
Its possible we can get a timestamp in that has more preceision than
ms, so in that event, make sure we are only pulling out 3 digits
to convert and not the entire value