### PR TITLE
metric_director dedupes incoming messages

### DIFF
--- a/src/noit_metric.h
+++ b/src/noit_metric.h
@@ -102,6 +102,7 @@ typedef struct {
   noit_metric_value_t value;
   noit_message_type type;
   char* original_message;
+  size_t original_message_len;
   mtev_atomic32_t refcnt;
 } noit_metric_message_t;
 

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -208,7 +208,6 @@ get_dedupe_hash(uint64_t whence)
     hash = &hash_with_time->hash;
   } else {
     hash_with_time = calloc(1, sizeof(struct hash_and_time));
-    hash = &hash_with_time->hash;
 
     mtev_hash_init_locks(&hash_with_time->hash, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
     uint64_t *stored_ts = calloc(1, sizeof(uint64_t));
@@ -222,6 +221,7 @@ get_dedupe_hash(uint64_t whence)
         return NULL;
       }
     }
+    hash = &hash_with_time->hash;
   }
 
   hash_with_time->last_touched_s = mtev_gethrtime() / 1000000000;
@@ -428,8 +428,6 @@ noit_metric_director_dedupe(mtev_boolean d)
 {
   dedupe = d;
 }
-
-
 
 void noit_metric_director_init() {
   nthreads = eventer_loop_concurrency();

--- a/src/noit_metric_director.h
+++ b/src/noit_metric_director.h
@@ -34,7 +34,20 @@
 #include <uuid/uuid.h>
 #include "noit_message_decoder.h"
 
+/**
+ * Funnel metrics to certain threads for processing.
+ * 
+ * The director will de-duplicate the incoming messages on a 10 second window based on an md5 of the incoming
+ * message contents.  If you don't want messages de-deplicated, switch it off using the noit_metric_director_dedupe(mtev_false)
+ * call.
+ * 
+ */
 void noit_metric_director_init();
+
+/**
+ * see init(), will dedupe by default.  Pass mtev_false to switch it off 
+ */
+void noit_metric_directory_dedupe(mtev_boolean dedupe);
 
 /* Tells noit to funnel all observed lines matching this id-metric
  * back to this thread */


### PR DESCRIPTION
The timeout is 10s. Windows are cleared every 5s -> a duplicate is found if two messages are arriving within 10s up to 15s depending on the timing of the prune event