### PR TITLE
Set "null" cloudwatch values to 0

### DIFF
--- a/src/modules-lua/noit/AWSClient.lua
+++ b/src/modules-lua/noit/AWSClient.lua
@@ -386,8 +386,21 @@ function AWSClient:perform(target, cache_table)
               --billing
               if count == 1 or namespace == "AWS/Billing" then
                 cache_table[metric] = most_recent
-              else
+              elseif next_most_recent["timestamp"] ~= nil then
                 cache_table[metric] = next_most_recent
+              else
+                -- We didn't get back a value for this metric, because AWS didn't have any recent values
+                -- which then one can assume that means there were 0 request or whatever, so just mark it 0
+                cache_table[metric] = { timestamp = os.time(), value = 0, results = { } }
+                for k,v in pairs(statistics) do
+                  cache_table[metric]["results"][v] = 0
+                end
+              end
+            else
+              -- if there was no datapoints section, I guess still set a value of 0
+              cache_table[metric] = { timestamp = os.time(), value = 0, results = { } }
+              for k,v in pairs(statistics) do
+                cache_table[metric]["results"][v] = 0
               end
             end
           end


### PR DESCRIPTION
Cloudwatch is super annoying in that if they don't have a value for
something, they simply don't return it.

I haven't looked at every single metric, but I think in most every
case this would mean the value is 0 (like requests, etc) because if
there was a value, it would be returned.

So, when we get back a datapoints section that is empty, loop over
the stats we requested, and return a 0 value instead of nothing for
that metric