### PR TITLE
Make Truncated A Standalone Metric For External

### DIFF
--- a/src/modules/external.c
+++ b/src/modules/external.c
@@ -75,6 +75,8 @@ struct check_info {
   char **envs;
   noit_check_t *check;
   int exit_code;
+  int16_t stdout_truncated;
+  int16_t stderr_truncated;
   external_special_t type;
 
   int errortype;
@@ -167,6 +169,20 @@ static void external_log_results(noit_module_t *self, noit_check_t *check) {
     noit_stats_set_available(check, NP_AVAILABLE);
     noit_stats_set_state(check, (WEXITSTATUS(ci->exit_code) == 0) ? NP_GOOD : NP_BAD);
   }
+
+  /* Set if stdout is truncated... if we're -1, there was an error, so don't
+   * log anything. Otherwise - true for 1, false for 0 */
+  if (ci->stdout_truncated != -1) {
+    noit_stats_set_metric(check, "truncated", METRIC_INT32, &ci->stdout_truncated);
+  }
+  /* NOTE: We can report stderr_truncated if we wish, but there's really no reason
+   * to do so at the moment... leaving the code here in case we wish to enable it
+   * later */
+#if 0
+  if (ci->stderr_truncated != -1) {
+    noit_stats_set_metric(check, "stderr_truncated", METRIC_INT32, &ci->stderr_truncated);
+  }
+#endif
 
   /* Hack the output into metrics */
   if(ci->output && ci->type == EXTERNAL_JSON_TYPE) {
@@ -355,7 +371,7 @@ static int external_handler(eventer_t e, int mask,
         else
         {
           inlen += ret;
-          if (inlen >= 14)
+          if (inlen >= 18)
           {
             break;
           }
@@ -365,6 +381,8 @@ static int external_handler(eventer_t e, int mask,
       mtevAssert(inlen == expectlen);
       r.check_no = h.check_no;
       r.exit_code = h.exit_code;
+      r.stdout_truncated = h.stdout_truncated;
+      r.stderr_truncated = h.stderr_truncated;
       r.stdoutlen = h.stdoutlen;
       data->cr = calloc(sizeof(*data->cr), 1);
       memset(data->cr, 0, sizeof(*data->cr));
@@ -457,6 +475,8 @@ static int external_handler(eventer_t e, int mask,
     ci->exit_code = data->cr->exit_code;
     ci->output = data->cr->stdoutbuff;
     ci->error = data->cr->stderrbuff;
+    ci->stdout_truncated = data->cr->stdout_truncated;
+    ci->stderr_truncated = data->cr->stderr_truncated;
     free(data->cr);
     data->cr = NULL;
     check = ci->check;

--- a/src/modules/external_proc.h
+++ b/src/modules/external_proc.h
@@ -48,6 +48,8 @@ typedef enum {
 struct external_response {
   int64_t check_no;
   int32_t exit_code;
+  int16_t stdout_truncated;
+  int16_t stderr_truncated;
   int stdoutlen_sofar;
   uint32_t stdoutlen;
   char *stdoutbuff;
@@ -74,6 +76,8 @@ typedef struct {
 typedef struct {
   int64_t check_no;
   int32_t exit_code;
+  int16_t stdout_truncated;
+  int16_t stderr_truncated;
   uint32_t stdoutlen;
 } __attribute__((packed)) external_header;
 


### PR DESCRIPTION
The external check should report "truncated" as a stand-alone metric
rather than making it part of the output string; putting it in the
output string can break parsing regexes.

This will cause issues if there is a configured metric called
"truncated", but that's better than the previous solution.