### PR TITLE
Do not include \n in the string value of M records.

### DIFF
--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -1825,7 +1825,8 @@ noit_metric_sizes(metric_type_t type, const void *value) {
     case METRIC_DOUBLE:
       return sizeof(sizer);
     case METRIC_STRING: {
-      int len = strlen((char*)value) + 1;
+      const char *lf = strchr(value, '\n');
+      int len = lf ? lf - (const char *)value + 1 : strlen((char*)value) + 1;
       return ((len >= text_size_limit) ? text_size_limit+1 : len);
     }
     case METRIC_ABSENT:

--- a/src/noit_message_decoder.c
+++ b/src/noit_message_decoder.c
@@ -160,7 +160,9 @@ int noit_message_decoder_parse_line(const char *payload, int payload_len,
         metric->value.v_double = strtod(osnum, NULL);
         break;
       case METRIC_STRING:
-        metric->value.v_string = mtev__strndup(value_str, vlen-1);
+        /* It's possible for M records that the \n is included, it should not be. */
+        if(vlen > 0 && value_str[vlen] == '\n') vlen--;
+        metric->value.v_string = mtev__strndup(value_str, vlen);
         break;
       default:
         return -9;

--- a/src/noit_message_decoder.c
+++ b/src/noit_message_decoder.c
@@ -160,7 +160,7 @@ int noit_message_decoder_parse_line(const char *payload, int payload_len,
         metric->value.v_double = strtod(osnum, NULL);
         break;
       case METRIC_STRING:
-        metric->value.v_string = mtev__strndup(value_str, vlen);
+        metric->value.v_string = mtev__strndup(value_str, vlen-1);
         break;
       default:
         return -9;


### PR DESCRIPTION
The M format is \n terminated and the \n is not supposed to be part
of the value itself.  The vlen of th string included the \n and it
was being copied during the M record decoding process.