### PR TITLE
Jmx object filters

### DIFF
--- a/src/java/src/com/omniti/jezebel/check/jmx.java
+++ b/src/java/src/com/omniti/jezebel/check/jmx.java
@@ -33,6 +33,7 @@
 package com.omniti.jezebel.check;
 
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.Map;
 import java.util.Set;
 import java.util.Arrays;
@@ -98,6 +99,31 @@ public class jmx implements JezebelCheck {
                 JMXConnectorFactory.connect(jmxUrl, jmxEnv);
             final MBeanServerConnection mbsc = connector.getMBeanServerConnection();
 
+            // If the user supplied one or more mbean_properties_(.+) params, we will use them to filter
+            // the mbeans we are able to pull, this is an OR, so any match lets the bean through.
+
+            // Note that to start I'm assumg they will be something like mbean_properties_0, later on we
+            // might want to allow the suffix to be a string, where that string would then be the attribute
+            // or object name.
+            ArrayList<HashMap<String,String>> filters = new ArrayList<HashMap<String,String>>();
+            boolean has_filter = false;
+            for ( Map.Entry<String, String> entry : config.entrySet() ) {
+                if ( entry.getKey().startsWith("mbean_properties_") ) {
+                    // The properties should come to us in the format: prop=value,prop2=value
+                    // So convert each prop + value to a map and then put that on the arraylist
+                    HashMap<String, String> filter = new HashMap<String, String>();
+                    String[] kvs = entry.getValue().split(",");
+                    for ( String kv : kvs ) {
+                        String[] property = kv.split("=");
+                        filter.put(property[0], property[1]);
+                    }
+
+                    filters.add(filter);
+                    has_filter = true;
+                }
+            }
+
+
             rr.set("default_domain", mbsc.getDefaultDomain());
             rr.set("mbean_count", mbsc.getMBeanCount());
 
@@ -115,6 +141,32 @@ public class jmx implements JezebelCheck {
                 for (ObjectName objectName : allObjectNames) {
                     if ( ! domains.isEmpty() && ! domains.contains(objectName.getDomain()) ) {
                         continue;
+                    }
+
+                    if ( has_filter ) {
+                        Hashtable<String, String> property_list = objectName.getKeyPropertyList();
+                        boolean passed_filters = false;
+                        for ( HashMap<String, String> filter : filters ) {
+                            boolean passes = true;
+                            for ( Map.Entry<String, String> entry : filter.entrySet() ) {
+                                if ( 
+                                    ! property_list.containsKey(entry.getKey()) ||
+                                    ! property_list.get(entry.getKey()).equals(entry.getValue()) 
+                                ) {
+                                    passes = false;
+                                }
+                            }
+
+                            if ( passes ) {
+                                passed_filters = true;
+                                break; // as long as we pass one we are good to go
+                            }
+                        }
+
+                        // If we didn't pass the filters, ignore this object
+                        if ( ! passed_filters ) {
+                            continue;
+                        }
                     }
 
                     String oname = objectName.getDomain() + ":" + objectName.getCanonicalKeyPropertyListString();

--- a/src/modules/jmx.xml
+++ b/src/modules/jmx.xml
@@ -1,0 +1,51 @@
+<module>
+  <name>jmx</name>
+  <description><para>Perform checks against a JMX enabled service</para></description>
+  <loader>lua</loader>
+  <object>noit.module.jezebel</object>
+  <checkconfig>
+    <parameter name="port"
+               required="required"
+               allowed="\d+">The TCP port JMX is running on</parameter>
+    <parameter name="username"
+               required="optional"
+               allowed=".+">Username needed to authenticate with</parameter>
+    <parameter name="password"
+               required="optional"
+               allowed=".+">Password needed to authenticate with</parameter>
+    <parameter name="mbean_domains"
+               required="optional"
+               allowed=".+">Space seperated list of domains to extract metrics for.  Default is all domains (no list specified)</parameter>
+    <parameter name="uri"
+               required="optional"
+               default="/jmxrmi"
+               allowed=".+">The JMX URI endpoint to use. Default is "/jmxrmi"</parameter>
+    <parameter name="mbean_properties_(.+)"
+               required="optional"
+               allowed=".+">List of properties in the form type=Foo,name=Bar that will filter out JMX objects that don't match at least one of these settings</parameter>
+  </checkconfig>
+  <examples>
+    <example>
+      <title>JVM Statistics</title>
+      <para></para>
+      <programlisting><![CDATA[
+        <noit>
+          <modules>
+            <module loader="lua" name="jmx" object="noit.module.jezebel"/>
+          </modules>
+          <checks>
+            <check uuid="ddceb610-4615-6a2f-f2d3-c7335f0044f9" module="jmx" target="127.0.0.1" period="60000" timeout="30000">
+              <config>
+                <port>3333</port>
+                <uri>/jmxrmi</uri>
+                <mbean_domains>java.lang java.nio</mbean_domains>
+                <mbean_properties_0>type=Memory</mbean_properties_0>
+                <mbean_properties_1>name=Code Cache,type=MemoryPool</mbean_properties_1>
+              </config>
+            </check>
+          </checks>
+        </noit>
+    ]]></programlisting>
+    </example>
+  </examples>
+</module>


### PR DESCRIPTION
allow users to set mbean_properties_(.+) that will act like an OR filter for mbean objects, if they match the props, let them through.

This means we don't have to pull every object and pass it back to noit, potentially killing it while it tries to parse the large XML docs that can be created.