### PR TITLE
Fix Memory Leak When Compression Disabled

### DIFF
--- a/src/noit_check_log_helpers.c
+++ b/src/noit_check_log_helpers.c
@@ -101,7 +101,7 @@ noit_check_log_bundle_compress_b64(noit_compression_type_t ctype,
   }
   dlen = mtev_b64_encode((unsigned char *)compbuff, dlen,
                          (char *)b64buff, initial_dlen);
-  if(ctype == NOIT_COMPRESS_NONE) free(compbuff);
+  free(compbuff);
   if(dlen == 0) {
     mtevL(noit_error, "Error base64'ing bundled metrics.\n");
     free(b64buff);

--- a/src/noit_check_log_helpers.c
+++ b/src/noit_check_log_helpers.c
@@ -101,7 +101,7 @@ noit_check_log_bundle_compress_b64(noit_compression_type_t ctype,
   }
   dlen = mtev_b64_encode((unsigned char *)compbuff, dlen,
                          (char *)b64buff, initial_dlen);
-  if(ctype != NOIT_COMPRESS_NONE) free(compbuff);
+  if(ctype == NOIT_COMPRESS_NONE) free(compbuff);
   if(dlen == 0) {
     mtevL(noit_error, "Error base64'ing bundled metrics.\n");
     free(b64buff);


### PR DESCRIPTION
We had an instance of inverted logic; we need to free this buffer if
compression is disabled, not the other way around.