### PR TITLE
prevent transient cloudwatch checks from pulling data

### DIFF
--- a/src/modules-lua/noit/module/cloudwatch.lua
+++ b/src/modules-lua/noit/module/cloudwatch.lua
@@ -237,8 +237,12 @@ function initiate(module, check)
 
   --Pull the data once a minute, but don't pull it more frequently than
   --that.
+  --Don't pull at all if we're transient; transient checks timeout too quickly
+  --to succeed and fire frequently enough to prevent the original check from
+  --getting a chance to pull.
   local cache_timeout = 55
-  if current_time - cache_table[uuid]['timestamp'] >= cache_timeout then
+  if check.flags("NP_TRANSIENT") == 0 and
+    current_time - cache_table[uuid]['timestamp'] >= cache_timeout then
     -- We've gone over the cache timeout... get new values
     local dimension_count = 1
     for key, value in pairs(check.config) do


### PR DESCRIPTION
Watching a cloudwatch check would cause all (sometimes excepting the first 1-2) metrics in the check to stop being collected for the lifetime of the watch.

Given that both the original and transient check share a lua state, the transient check would fire frequently enough to beat the original check to updating their shared cache. However, the transient check's timeout was much too low and so would be timed out before it processed more than one or two metrics. The original check would then find the recent but incomplete set of metrics in the cache and use that rather than pulling the full set.