### PR TITLE
Fix Connect Error In SSH Check

### DIFF
--- a/src/modules/ssh2.c
+++ b/src/modules/ssh2.c
@@ -202,8 +202,12 @@ static int ssh2_drive_session(eventer_t e, int mask, void *closure,
       libssh2_session_set_timeout(ci->session, timeout_ms);
 #endif
       if (libssh2_session_startup(ci->session, eventer_get_fd(e))) {
+        char *err = NULL;
+        char *err_buff = malloc(65535);
+        libssh2_session_last_error(ci->session, &err, NULL, 0);
         ci->timed_out = 0;
-        ci->error = strdup("ssh session startup failed");
+        snprintf(err_buff, 65534, "ssh session startup failed: %s\n", (err == NULL) ? "unknown" : err);
+        ci->error = err_buff;
         return 0;
       }
       fingerprint = libssh2_hostkey_hash(ci->session, LIBSSH2_HOSTKEY_HASH_MD5);

--- a/src/modules/ssh2.c
+++ b/src/modules/ssh2.c
@@ -158,7 +158,7 @@ static int ssh2_drive_session(eventer_t e, int mask, void *closure,
   const char *fingerprint;
   ssh2_check_info_t *ci = closure;
   struct timeval diff;
-  int timeout_ms = 2000; /* 2s */
+  int timeout_ms = 3000; /* 3s */
   if(ci->state == WANT_CLOSE) {
     noit_check_t *check = ci->check;
     ssh2_log_results(ci->self, ci->check);

--- a/src/modules/ssh2.c
+++ b/src/modules/ssh2.c
@@ -158,7 +158,7 @@ static int ssh2_drive_session(eventer_t e, int mask, void *closure,
   const char *fingerprint;
   ssh2_check_info_t *ci = closure;
   struct timeval diff;
-  int timeout_ms = 10; /* 10ms, gets set below */
+  int timeout_ms = 2000; /* 2s */
   if(ci->state == WANT_CLOSE) {
     noit_check_t *check = ci->check;
     ssh2_log_results(ci->self, ci->check);
@@ -194,10 +194,6 @@ static int ssh2_drive_session(eventer_t e, int mask, void *closure,
       set_method(mac_sc, LIBSSH2_METHOD_MAC_SC);
       set_method(comp_cs, LIBSSH2_METHOD_COMP_CS);
       set_method(comp_sc, LIBSSH2_METHOD_COMP_SC);
-      if(compare_timeval(*now, eventer_get_whence(e)) < 0) {
-        sub_timeval(eventer_get_whence(e), *now, &diff);
-        timeout_ms = diff.tv_sec * 1000 + diff.tv_usec / 1000;
-      }
 #if LIBSSH2_VERSION_NUM >= 0x010209
       libssh2_session_set_timeout(ci->session, timeout_ms);
 #endif


### PR DESCRIPTION
The logic for setting a timeout in the SSH check was totally busted - we were setting a default timeout of 10ms every time since we could never get into the code that sets it.

Change it for now to remove broken code altogether and give it a larger timeout.