### PR TITLE
Fix Memory Leaks Related To Websockets And Decompression

### DIFF
--- a/src/noit_check_log_helpers.c
+++ b/src/noit_check_log_helpers.c
@@ -155,6 +155,7 @@ noit_check_log_bundle_decompress_b64(noit_compression_type_t ctype,
   }
   if(compbuff) free(compbuff);
 
+  mtev_stream_decompress_finish(ctx);
   mtev_destroy_stream_decompress_ctx(ctx);
 
   return 0;

--- a/src/noit_websocket_handler.c
+++ b/src/noit_websocket_handler.c
@@ -105,9 +105,18 @@ send_individual_metric(noit_websocket_closure_t *wcl, const char *metric_string,
   char *json = NULL;
   size_t json_len = 0;
 
+#define FREE_MESSAGE(message) do { \
+  if(message.value.type == METRIC_STRING && \
+     !message.value.is_null && \
+     message.value.value.v_string) { \
+       free(message.value.value.v_string); \
+  } \
+} while(0)
+
   int rval = noit_message_decoder_parse_line(metric_string, len, &message.id.id, &message.id.name,
                                              &message.id.name_len, NULL, NULL, &message.value, mtev_false);
   if (rval < 0) {
+    FREE_MESSAGE(message);
     return;
   }
 
@@ -132,6 +141,7 @@ send_individual_metric(noit_websocket_closure_t *wcl, const char *metric_string,
                                       (const unsigned char *)json, json_len);
         free(json);
   }
+  FREE_MESSAGE(message);
 #endif
 }
 


### PR DESCRIPTION
There were a couple of significant memory leaks - one related to not
freeing metric data on streaming and one related to not cleaning up
compression data. Fixed both of these.