### PR TITLE
Add Ability To Test For And Unlink Trash Files In Stratcon Sweep

### DIFF
--- a/src/modules/postgres_ingestor.c
+++ b/src/modules/postgres_ingestor.c
@@ -1617,6 +1617,10 @@ static int is_postgres_ingestor_file(const char *file) {
   mtev_watchdog_child_heartbeat();
   return (strlen(file) == 19 && !strcmp(file + 16, ".pg"));
 }
+static int should_unlink_invalid_postgres_file(const char *file) {
+  /* Should never unlink for now */
+  return 0;
+}
 static int postgres_ingestor_init(mtev_dso_generic_t *self) {
   stratcon_datastore_core_init();
   mtev_hash_init(&ds_conns);
@@ -1638,6 +1642,7 @@ static int postgres_ingestor_init(mtev_dso_generic_t *self) {
   stratcon_ingest_all_check_info();
   stratcon_ingest_all_storagenode_info();
   stratcon_ingest_sweep_journals(basejpath, is_postgres_ingestor_file,
+                                 should_unlink_invalid_postgres_file,
                                  stratcon_ingest_launch_file_ingestion);
   return stratcon_datastore_set_ingestor(&postgres_ingestor_api);
 }

--- a/src/stratcon_datastore.c
+++ b/src/stratcon_datastore.c
@@ -424,6 +424,9 @@ stratcon_datastore_saveconfig(void *unused) {
 static int is_raw_ingestion_file(const char *file) {
   return (strlen(file) == 16);
 }
+static int should_unlink_invalid_raw_ingestion_file(const char *file) {
+  return ((strlen(file) == 20) && (!strncmp(file+16, ".tmp", 4)));
+}
 
 void
 stratcon_datastore_core_init() {
@@ -451,6 +454,7 @@ stratcon_datastore_init() {
 
   stratcon_ingest_sweep_journals(basejpath,
                                  is_raw_ingestion_file,
+                                 should_unlink_invalid_raw_ingestion_file,
                                  stratcon_ingest);
 
   mtevAssert(mtev_http_rest_register_auth(

--- a/src/stratcon_ingest.h
+++ b/src/stratcon_ingest.h
@@ -37,6 +37,7 @@
 API_EXPORT(void)
   stratcon_ingest_sweep_journals(const char *base, 
                                  int (*test)(const char *),
+                                 int (*unlink_test)(const char *),
                                  int (*ingest)(const char *fullpath,
                                                const char *remote_str,
                                                const char *remote_cn,


### PR DESCRIPTION
When sweeping through stratcon files, there are occasionally trash files
in the directory that we ignore, but we really need to clean up.

Added a new paramter to the sweep function, "unlink_test", which is a
function that determines if we should unlink an invalid file. If this
returns true, we will attempt to unlink the file.

This is currently hooked up to unlink a valid raw_ingestion file with a
".tmp" extension at the end.