### PR TITLE
Fix Memory Leak In noit_jlog_thread_main

### DIFF
--- a/src/noit_jlog_listener.c
+++ b/src/noit_jlog_listener.c
@@ -313,6 +313,7 @@ noit_jlog_thread_main(void *e_vptr) {
 
  alldone:
   eventer_close(e, &mask);
+  eventer_free(e);
   mtev_atomic_dec32(&jcl->feed_stats->connections);
   noit_jlog_closure_free(jcl);
   mtev_acceptor_closure_free(ac);


### PR DESCRIPTION
When this thread exits, we need to free the eventer pointer that was
passed in.