### PR TITLE
fix reverse-socket ACL false-negatives.

### DIFF
--- a/src/modules/reverse_check.c
+++ b/src/modules/reverse_check.c
@@ -95,13 +95,13 @@ reverse_check_allow(const char *id, mtev_acceptor_closure_t *ac) {
 
 static mtev_hook_return_t
 reverse_check_post_init(void *unused) {
-  check_config_fixup_hook_register("reverse_check", reverse_check_hook_impl, NULL);
+  mtev_reverse_socket_acl(reverse_check_allow);
   return MTEV_HOOK_CONTINUE;
 }
 static int
 reverse_check_init(mtev_dso_generic_t *self) {
   dso_post_init_hook_register("reverse_check", reverse_check_post_init, NULL);
-  mtev_reverse_socket_acl(reverse_check_allow);
+  check_config_fixup_hook_register("reverse_check", reverse_check_hook_impl, NULL);
   return 0;
 }
 


### PR DESCRIPTION
 * move mtev_reverse_socket_acl to `post_init`.
 * move `check_config_fixup_hook_register` back to `dso` init.