### PR TITLE
Add Dedicated Outlet For stratcon_jlog_streamer Errors

### DIFF
--- a/src/stratcon_jlog_streamer.c
+++ b/src/stratcon_jlog_streamer.c
@@ -60,6 +60,8 @@
 #include "stratcon_jlog_streamer.h"
 #include "stratcon_iep.h"
 
+static mtev_log_stream_t jlog_streamer_err = NULL;
+static mtev_log_stream_t jlog_streamer_deb = NULL;
 pthread_mutex_t noits_lock;
 mtev_hash_table noits;
 pthread_mutex_t noit_ip_by_cn_lock;
@@ -271,7 +273,7 @@ __read_on_ctx(eventer_t e, jlog_streamer_ctx_t *ctx, int *newmask) {
     if(ctx->buffer) free(ctx->buffer); \
     ctx->buffer = malloc(size + 1); \
     if(ctx->buffer == NULL) { \
-      mtevL(noit_error, "malloc(%lu) failed.\n", (long unsigned int)size + 1); \
+      mtevL(jlog_streamer_err, "malloc(%lu) failed.\n", (long unsigned int)size + 1); \
       goto socket_error; \
     } \
     ctx->buffer[size] = '\0'; \
@@ -286,7 +288,7 @@ __read_on_ctx(eventer_t e, jlog_streamer_ctx_t *ctx, int *newmask) {
       if(sslctx) error = eventer_ssl_get_last_error(sslctx); \
     } \
     if(! error) error = strerror(errno); \
-    mtevL(noit_error, "[%s] [%s] SSL read error: %s\n", nctx->remote_str ? nctx->remote_str : "(null)", \
+    mtevL(jlog_streamer_err, "[%s] [%s] SSL read error: %s\n", nctx->remote_str ? nctx->remote_str : "(null)", \
           nctx->remote_cn ? nctx->remote_cn : "(null)", \
           error); \
     goto socket_error; \
@@ -294,7 +296,7 @@ __read_on_ctx(eventer_t e, jlog_streamer_ctx_t *ctx, int *newmask) {
   ctx->bytes_read = 0; \
   ctx->bytes_expected = 0; \
   if(len != size) { \
-    mtevL(noit_error, "[%s] [%s] SSL short read [%d] (%d/%lu).  Reseting connection.\n", \
+    mtevL(jlog_streamer_err, "[%s] [%s] SSL short read [%d] (%d/%lu).  Reseting connection.\n", \
           nctx->remote_str ? nctx->remote_str : "(null)", \
           nctx->remote_cn ? nctx->remote_cn : "(null)", \
           ctx->state, len, (long unsigned int)size); \
@@ -318,7 +320,7 @@ stratcon_jlog_recv_handler(eventer_t e, int mask, void *closure,
 
   if(mask & EVENTER_EXCEPTION || nctx->wants_shutdown) {
     if(write(eventer_get_fd(e), e, 0) == -1)
-      mtevL(noit_error, "[%s] [%s] socket error: %s\n", nctx->remote_str ? nctx->remote_str : "(null)", 
+      mtevL(jlog_streamer_err, "[%s] [%s] socket error: %s\n", nctx->remote_str ? nctx->remote_str : "(null)", 
             nctx->remote_cn ? nctx->remote_cn : "(null)", strerror(errno));
  socket_error:
     ctx->state = JLOG_STREAMER_WANT_INITIATE;
@@ -341,12 +343,12 @@ stratcon_jlog_recv_handler(eventer_t e, int mask, void *closure,
                             sizeof(ctx->jlog_feed_cmd), &mask);
         if(len < 0) {
           if(errno == EAGAIN) return mask | EVENTER_EXCEPTION;
-          mtevL(noit_error, "[%s] [%s] initiating stream failed -> %d/%s.\n", 
+          mtevL(jlog_streamer_err, "[%s] [%s] initiating stream failed -> %d/%s.\n", 
                 nctx->remote_str ? nctx->remote_str : "(null)", nctx->remote_cn ? nctx->remote_cn : "(null)", errno, strerror(errno));
           goto socket_error;
         }
         if(len != sizeof(ctx->jlog_feed_cmd)) {
-          mtevL(noit_error, "[%s] [%s] short write [%d/%d] on initiating stream.\n", 
+          mtevL(jlog_streamer_err, "[%s] [%s] short write [%d/%d] on initiating stream.\n", 
                 nctx->remote_str ? nctx->remote_str : "(null)", nctx->remote_cn ? nctx->remote_cn : "(null)",
                 (int)len, (int)sizeof(ctx->jlog_feed_cmd));
           goto socket_error;
@@ -356,7 +358,7 @@ stratcon_jlog_recv_handler(eventer_t e, int mask, void *closure,
 
       case JLOG_STREAMER_WANT_ERROR:
         FULLREAD(e, ctx, 0 - ctx->count);
-        mtevL(noit_error, "[%s] [%s] %.*s\n", nctx->remote_str ? nctx->remote_str : "(null)",
+        mtevL(jlog_streamer_err, "[%s] [%s] %.*s\n", nctx->remote_str ? nctx->remote_str : "(null)",
               nctx->remote_cn ? nctx->remote_cn : "(null)", 0 - ctx->count, ctx->buffer);
         free(ctx->buffer); ctx->buffer = NULL;
         goto socket_error;
@@ -425,7 +427,7 @@ stratcon_jlog_recv_handler(eventer_t e, int mask, void *closure,
           ctx->state = JLOG_STREAMER_IS_ASYNC;
           ctx->push(DS_OP_CHKPT, &nctx->r.remote, nctx->remote_cn,
                     NULL, completion_e);
-          mtevL(noit_debug, "Pushing %s batch async [%s] [%s]: [%u/%u]\n",
+          mtevL(jlog_streamer_deb, "stratcon_jlog_recv_handler: Pushing %s batch async [%s] [%s]: [%u/%u]\n",
                 feed_type_to_str(ntohl(ctx->jlog_feed_cmd)),
                 nctx->remote_str ? nctx->remote_str : "(null)",
                 nctx->remote_cn ? nctx->remote_cn : "(null)",
@@ -442,7 +444,7 @@ stratcon_jlog_recv_handler(eventer_t e, int mask, void *closure,
       case JLOG_STREAMER_IS_ASYNC:
         ctx->state = JLOG_STREAMER_WANT_CHKPT; /* falls through */
       case JLOG_STREAMER_WANT_CHKPT:
-        mtevL(noit_debug, "Pushing %s checkpoint [%s] [%s]: [%u/%u]\n",
+        mtevL(jlog_streamer_deb, "stratcon_jlog_recv_handler: Pushing %s checkpoint [%s] [%s]: [%u/%u]\n",
               feed_type_to_str(ntohl(ctx->jlog_feed_cmd)),
               nctx->remote_str ? nctx->remote_str : "(null)",
               nctx->remote_cn ? nctx->remote_cn : "(null)",
@@ -453,11 +455,16 @@ stratcon_jlog_recv_handler(eventer_t e, int mask, void *closure,
         /* screw short writes.  I'd rather die than not write my data! */
         len = eventer_write(e, &n_chkpt, sizeof(jlog_id), &mask);
         if(len < 0) {
-          if(errno == EAGAIN) return mask | EVENTER_EXCEPTION;
+          if(errno == EAGAIN) {
+            mtevL(jlog_streamer_deb, "stratcon_jlog_recv_handler: failed eventer write: got EAGAIN\n");
+            return mask | EVENTER_EXCEPTION;
+          }
+          mtevL(jlog_streamer_deb, "stratcon_jlog_recv_handler: failed eventer write %d (%s) - goto socket_error\n",
+                errno, strerror(errno));
           goto socket_error;
         }
         if(len != sizeof(jlog_id)) {
-          mtevL(noit_error, "[%s] [%s] short write on checkpointing stream.\n", 
+          mtevL(jlog_streamer_err, "[%s] [%s] short write on checkpointing stream.\n", 
             nctx->remote_str ? nctx->remote_str : "(null)",
             nctx->remote_cn ? nctx->remote_cn : "(null)");
           goto socket_error;
@@ -1349,7 +1356,7 @@ rest_set_noit(mtev_http_rest_closure_t *restc,
   else
     mtev_http_response_standard(ctx, 409, "EXISTS", "text/xml");
   if(mtev_conf_write_file(NULL) != 0)
-    mtevL(noit_error, "local config write failed\n");
+    mtevL(jlog_streamer_err, "local config write failed\n");
   mtev_conf_mark_changed();
   mtev_http_response_end(ctx);
   return 0;
@@ -1370,7 +1377,7 @@ rest_delete_noit(mtev_http_rest_closure_t *restc,
   else
     mtev_http_response_not_found(ctx, "text/xml");
   if(mtev_conf_write_file(NULL) != 0)
-    mtevL(noit_error, "local config write failed\n");
+    mtevL(jlog_streamer_err, "local config write failed\n");
   mtev_conf_mark_changed();
   mtev_http_response_end(ctx);
   return 0;
@@ -1461,6 +1468,11 @@ stratcon_jlog_streamer_init(const char *toplevel) {
   struct timeval whence = DEFAULT_NOIT_PERIOD_TV;
   struct in_addr remote;
   char uuid_str[UUID_STR_LEN + 1];
+
+  jlog_streamer_err = mtev_log_stream_find("error/stratcon_jlog_streamer");
+  jlog_streamer_deb = mtev_log_stream_find("debug/stratcon_jlog_streamer");
+  if(!jlog_streamer_err) jlog_streamer_err = mtev_error;
+  if(!jlog_streamer_deb) jlog_streamer_deb = mtev_debug;
 
   mtev_reverse_socket_acl(mtev_reverse_socket_allow_noits);
   pthread_mutex_init(&noits_lock, NULL);

--- a/src/stratcon_jlog_streamer.c
+++ b/src/stratcon_jlog_streamer.c
@@ -95,7 +95,7 @@ static const char *jlog_state_to_str(int state) {
 }
 
 static void change_state(jlog_streamer_ctx_t *ctx, mtev_connection_ctx_t *nctx, int new_state) {
-  mtevL(jlog_streamer_deb, "changing state from %s to %s - [%s] [%s]\n",
+  mtevL(jlog_streamer_deb, "changing state from \"%s\" to \"%s\" - [%s] [%s]\n",
           jlog_state_to_str(ctx->state),
           jlog_state_to_str(new_state),
           (nctx && nctx->remote_str) ? nctx->remote_str : "(null)",

--- a/src/stratcon_jlog_streamer.c
+++ b/src/stratcon_jlog_streamer.c
@@ -95,11 +95,13 @@ static const char *jlog_state_to_str(int state) {
 }
 
 static void change_state(jlog_streamer_ctx_t *ctx, mtev_connection_ctx_t *nctx, int new_state) {
-  mtevL(jlog_streamer_deb, "changing state from \"%s\" to \"%s\" - [%s] [%s]\n",
+  if (N_L_S_ON(jlog_streamer_deb)) {
+    mtevL(jlog_streamer_deb, "changing state from \"%s\" to \"%s\" - [%s] [%s]\n",
           jlog_state_to_str(ctx->state),
           jlog_state_to_str(new_state),
           (nctx && nctx->remote_str) ? nctx->remote_str : "(null)",
           (nctx && nctx->remote_cn) ? nctx->remote_cn : "(null)");
+  }
   ctx->state = new_state;
 }
 


### PR DESCRIPTION
Take output in stratcon_jlog_streamer and send it to specific outlets
rather than standard noit_error and noit_debug. Will allow logging these
specific errors without turning on the firehose.