### PR TITLE
Make metric names canonical with respect to tags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.a
 *.bundle
 *.lo
+*.hlo
 *.o
 *.so
 *.xmlh

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -1,4 +1,4 @@
-.SUFFIXES: .lo .re .c
+.SUFFIXES: .hlo .lo .re .c
 
 Q=
 ifeq ($(V),)
@@ -30,6 +30,7 @@ CC=@CC@
 SHLD=@SHLD@
 CPPFLAGS=@CPPFLAGS@
 CFLAGS=@CFLAGS@ -DHIDE_EVENTER_ABI
+COPT=-O5
 SHCFLAGS=@SHCFLAGS@
 CLINKFLAGS=@CLINKFLAGS@
 LUACFLAGS=@LUACFLAGS@
@@ -125,7 +126,7 @@ LUALIBS=@LUALIBS@
 
 LIBNOIT_OBJS=noit_check_log_helpers.lo noit_fb.lo bundle.pb-c.lo \
 	noit_check_tools_shared.lo stratcon_ingest.lo noit_metric_rollup.lo \
-	noit_metric_director.lo noit_message_decoder.lo noit_metric.lo \
+	noit_metric_director.lo noit_message_decoder.hlo noit_metric.hlo \
 	noit_metric_tag_search.lo
 
 B2SM_OBJS=noit_b2sm.o noit_check_log_helpers.o bundle.pb-c.o noit_message_decoder.o noit_metric.o
@@ -167,6 +168,15 @@ libnoit-objs/%.lo:	%.lo
 	$(Q)mkdir -p "`dirname $@`"
 	@echo "- making private $@"
 	$(Q)cp $(@:libnoit-objs/%.lo=%.lo) $@
+	$(Q)if test -x "$(CTFCONVERT)" ; then \
+		echo "- making CTF ($@)" ; \
+		$(CTFCONVERT) $(CTFNOSTRIP) -i -l @VERSION@ $@ ; \
+	fi
+
+libnoit-objs/%.hlo:	%.hlo
+	$(Q)mkdir -p "`dirname $@`"
+	@echo "- making private $@"
+	$(Q)cp $(@:libnoit-objs/%.hlo=%.hlo) $@
 	$(Q)if test -x "$(CTFCONVERT)" ; then \
 		echo "- making CTF ($@)" ; \
 		$(CTFCONVERT) $(CTFNOSTRIP) -i -l @VERSION@ $@ ; \
@@ -297,6 +307,14 @@ stratcon_datastore.o:	stratcon_datastore.c
 	  $(CC) $(CPPFLAGS) $(SHCFLAGS) -c $< -o $@ ; \
 	fi
 
+.c.hlo:
+	$(Q)if [ "`dirname $@`" != "." ] ; then \
+		(cd "`dirname $@`" && $(MAKE) "`basename $@`") ; \
+	else \
+		echo "- compiling $<" ; \
+	  $(CC) $(CPPFLAGS) $(COPT) $(SHCFLAGS) -c $< -o $@ ; \
+	fi
+
 .c.o:
 	$(Q)if [ "`dirname $@`" != "." ] ; then \
 		(cd "`dirname $@`" && $(MAKE) "`basename $@`") ; \
@@ -420,7 +438,7 @@ install-docs:
 install:	install-dirs install-docs install-headers install-noitd install-stratcond install-noitd-headers install-stratcond-headers
 
 clean:
-	rm -f *.lo *.o $(TARGETS)
+	rm -f *.hlo *.lo *.o $(TARGETS)
 	rm -f $(LIBNOIT)
 	rm -f module-online.h noit.env
 	rm -rf noit-objs stratcon-objs libnoit-objs

--- a/src/noit.conf.in
+++ b/src/noit.conf.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf8" standalone="yes"?>
-<noit lockfile="/var/run/noitd.lock" text_size_limit="512">
+<noit lockfile="/var/run/noitd.lock" text_size_limit="512" xmlns:histogram="noit://module/histogram">
   <!-- <watchdog glider="/opt/gimli/bin/glider" tracedir="/var/log/noitd.crash"/> -->
   <eventer>
     <config>
@@ -110,6 +110,7 @@
       </config>
     </generic>
     <generic image="ip_acl" name="ip_acl"/>
+    <generic image="histogram" name="histogram"/>
   </modules>
   <listeners>
     <sslconfig>
@@ -155,6 +156,12 @@
       <ip_acl:global/>
     </config>
     <check uuid="f7cea020-f19d-11dd-85a6-cb6d3a2207dc" module="selfcheck" target="127.0.0.1" period="5000" timeout="4000"/>
+    <check uuid="d71484e7-73d3-4dad-a5f7-88879ef43225" module="httptrap" target="127.0.0.1" period="60000" timeout="4000">
+      <config>
+        <secret>foo</secret>
+        <histogram:value name="testing|ST[a:b,c:d]">add</histogram:value>
+      </config>
+    </check>
     <check uuid="a7cea020-a19d-14dd-25a6-cf6d3a2207dc" module="json" target="172.16.244.200" period="5000" timeout="4000">
       <config xmlns:reverse="noit://module/reverse">
         <reverse:key>SoopErS3cr3T</reverse:key>

--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -2023,7 +2023,7 @@ cleanse_metric_name(char *m) {
     *cp = '\0';
 }
 
-int
+static int
 noit_stats_populate_metric(metric_t *m, const char *name, metric_type_t type,
                            const void *value) {
   void *replacement = NULL;
@@ -2036,6 +2036,12 @@ noit_stats_populate_metric(metric_t *m, const char *name, metric_type_t type,
 
   m->metric_name = strdup(name);
   cleanse_metric_name(m->metric_name);
+  if(noit_metric_canonicalize(m->metric_name, strlen(m->metric_name),
+                              m->metric_name, strlen(m->metric_name),
+                              mtev_true) <= 0) {
+    free(m->metric_name);
+    return -1;
+  }
 
   if(type == METRIC_GUESS)
     type = noit_metric_guess_type((char *)value, &replacement);
@@ -2062,9 +2068,16 @@ metric_t *
 noit_stats_get_metric(noit_check_t *check,
                       stats_t *newstate, const char *name) {
   void *v;
+  char name_copy[MAX_METRIC_TAGGED_NAME];
+  if(strlen(name) > sizeof(name_copy)-1) return NULL;
+  memcpy(name_copy, name, strlen(name)+1);
+  cleanse_metric_name(name_copy);
+  if(noit_metric_canonicalize(name_copy, strlen(name_copy),
+                              name_copy, strlen(name_copy), mtev_true) <= 0)
+    return NULL;
   if(newstate == NULL)
     newstate = stats_inprogress(check);
-  if(mtev_hash_retrieve(&newstate->metrics, name, strlen(name), &v))
+  if(mtev_hash_retrieve(&newstate->metrics, name_copy, strlen(name_copy), &v))
     return (metric_t *)v;
   return NULL;
 }
@@ -2109,9 +2122,16 @@ noit_stats_set_metric(noit_check_t *check,
 
 void
 noit_stats_set_metric_coerce_with_timestamp(noit_check_t *check,
-                             const char *name, metric_type_t t,
+                             const char *name_raw, metric_type_t t,
                              const char *v,
                              struct timeval *timestamp) {
+  char name[MAX_METRIC_TAGGED_NAME];
+  if(strlen(name_raw) > sizeof(name)-1) return;
+  memcpy(name, name_raw, strlen(name_raw)+1);
+  cleanse_metric_name(name);
+  if(noit_metric_canonicalize(name, strlen(name),
+                              name, strlen(name), mtev_true) <= 0)
+    return;
   char *endptr;
   stats_t *c;
   c = noit_check_get_stats_inprogress(check);

--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -2014,15 +2014,6 @@ noit_metric_guess_type(const char *s, void **replacement) {
   return type;
 }
 
-static void
-cleanse_metric_name(char *m) {
-  char *cp;
-  for(cp = m; *cp; cp++)
-    if(!isprint(*cp)) *cp=' ';
-  for(cp--; *cp == ' ' && cp > m; cp--) /* always leave first char */
-    *cp = '\0';
-}
-
 static int
 noit_stats_populate_metric(metric_t *m, const char *name, metric_type_t type,
                            const void *value) {
@@ -2035,7 +2026,6 @@ noit_stats_populate_metric(metric_t *m, const char *name, metric_type_t type,
   }
 
   m->metric_name = strdup(name);
-  cleanse_metric_name(m->metric_name);
   if(noit_metric_canonicalize(m->metric_name, strlen(m->metric_name),
                               m->metric_name, strlen(m->metric_name),
                               mtev_true) <= 0) {
@@ -2070,10 +2060,8 @@ noit_stats_get_metric(noit_check_t *check,
   void *v;
   char name_copy[MAX_METRIC_TAGGED_NAME];
   if(strlen(name) > sizeof(name_copy)-1) return NULL;
-  memcpy(name_copy, name, strlen(name)+1);
-  cleanse_metric_name(name_copy);
-  if(noit_metric_canonicalize(name_copy, strlen(name_copy),
-                              name_copy, strlen(name_copy), mtev_true) <= 0)
+  if(noit_metric_canonicalize(name, strlen(name),
+                              name_copy, sizeof(name_copy), mtev_true) <= 0)
     return NULL;
   if(newstate == NULL)
     newstate = stats_inprogress(check);
@@ -2127,10 +2115,8 @@ noit_stats_set_metric_coerce_with_timestamp(noit_check_t *check,
                              struct timeval *timestamp) {
   char name[MAX_METRIC_TAGGED_NAME];
   if(strlen(name_raw) > sizeof(name)-1) return;
-  memcpy(name, name_raw, strlen(name_raw)+1);
-  cleanse_metric_name(name);
-  if(noit_metric_canonicalize(name, strlen(name),
-                              name, strlen(name), mtev_true) <= 0)
+  if(noit_metric_canonicalize(name_raw, strlen(name_raw),
+                              name, sizeof(name), mtev_true) <= 0)
     return;
   char *endptr;
   stats_t *c;

--- a/src/noit_message_decoder.c
+++ b/src/noit_message_decoder.c
@@ -39,6 +39,7 @@
 #include <mtev_str.h>
 
 #include "noit_metric.h"
+#include "noit_metric_private.h"
 
 #define MOVE_TO_NEXT_TAB(cp, lvalue) do { \
   lvalue = memchr(cp, '\t', strlen(cp)); \
@@ -79,19 +80,75 @@ noit_metric_extract_tags(const char *in, int *inlen,
   *inlen = tag_start - in;
   return mtev_true;
 }
-void
-noit_metric_process_tags(noit_metric_message_t *metric) {
+static int
+noit_metric_process_tags_phase(noit_metric_message_t *metric, int phase) {
   noit_metric_tagset_builder_t stream_builder, measurement_builder;
   noit_metric_tagset_builder_start(&stream_builder);
   noit_metric_tagset_builder_start(&measurement_builder);
+  int starting_name_len = metric->id.name_len;
+  char buff[MAX_METRIC_TAGGED_NAME];
+  metric->id.name_len_with_tags = metric->id.name_len;
+  if(starting_name_len > sizeof(buff)) return -1;
   while(
     noit_metric_extract_tags(metric->id.name, &metric->id.name_len,
                              "|ST[", ']', &stream_builder) ||
     noit_metric_extract_tags(metric->id.name, &metric->id.name_len,
                              "|MT{", '}', &measurement_builder)
   );
-  noit_metric_tagset_builder_end(&stream_builder, &metric->id.stream, NULL);
-  noit_metric_tagset_builder_end(&measurement_builder, &metric->id.measurement, NULL);
+  if(phase == 1) {
+    char *stagnm = NULL, *mtagnm = NULL;
+    noit_metric_tagset_builder_end(&stream_builder, &metric->id.stream, &stagnm);
+    noit_metric_tagset_builder_end(&measurement_builder, &metric->id.measurement, &mtagnm);
+    int stagnmlen = stagnm ? strlen(stagnm) : 0;
+    int mtagnmlen = mtagnm ? strlen(mtagnm) : 0;
+    if((stagnm ? stagnmlen + 5 : 0) +
+       (mtagnm ? mtagnmlen + 5 : 0) +
+       metric->id.name_len > starting_name_len) return -1;
+    char *out = buff;
+    memcpy(out, metric->id.name, metric->id.name_len);
+    out += metric->id.name_len;
+    if(stagnm) {
+      memcpy(out, "|ST[", 4);
+      out += 4;
+      memcpy(out, stagnm, stagnmlen);
+      out += stagnmlen;
+      *out++ = ']';
+    }
+    if(mtagnm) {
+      memcpy(out, "|MT{", 4);
+      out += 4;
+      memcpy(out, mtagnm, mtagnmlen);
+      out += mtagnmlen;
+      *out++ = '}';
+    }
+    *out = '\0';
+    free(stagnm);
+    free(mtagnm);
+    if(out-buff != metric->id.name_len_with_tags ||
+       memcmp(buff, metric->id.name, metric->id.name_len_with_tags)) {
+      metric->id.alloc_name = strdup(buff);
+      metric->id.name = metric->id.alloc_name;
+      metric->id.name_len = out-buff;
+      metric->id.name_len_with_tags = metric->id.name_len;
+      free(metric->id.stream.tags);
+      metric->id.stream.tags = NULL;
+      metric->id.stream.tag_count = 0;
+      free(metric->id.measurement.tags);
+      metric->id.measurement.tags = NULL;
+      metric->id.measurement.tag_count = 0;
+      return noit_metric_process_tags_phase(metric, 2);
+    }
+  }
+  else {
+    noit_metric_tagset_builder_end(&stream_builder, &metric->id.stream, NULL);
+    noit_metric_tagset_builder_end(&measurement_builder, &metric->id.measurement, NULL);
+  }
+  return strnstrn("|ST[", 4, metric->id.name, metric->id.name_len) ||
+         strnstrn("|MT{", 4, metric->id.name, metric->id.name_len);
+}
+int
+noit_metric_process_tags(noit_metric_message_t *metric) {
+  return noit_metric_process_tags_phase(metric, 1);
 }
 int noit_is_timestamp(const char *line, int len) {
   int is_ts = 0;
@@ -184,7 +241,12 @@ int noit_message_decoder_parse_line(noit_metric_message_t *message, int has_noit
       return -5;
 
     message->id.name_len = metric_type_str - message->id.name - 1;
-    noit_metric_process_tags(message);
+    if(message->id.name_len > MAX_METRIC_TAGGED_NAME) {
+      return -6;
+    }
+    if(noit_metric_process_tags(message) != 0) {
+      return -7;
+    }
 
     message->value.type = *metric_type_str;
 
@@ -234,7 +296,9 @@ int noit_message_decoder_parse_line(noit_metric_message_t *message, int has_noit
       return -4;
 
     message->id.name_len = value_str - message->id.name - 1;
-    noit_metric_process_tags(message);
+    if(noit_metric_process_tags(message) != 0) {
+      return -7;
+    }
 
     int vstrlen = strlen(value_str);
 
@@ -269,6 +333,7 @@ void noit_metric_message_clear(noit_metric_message_t* message) {
     if(message->original_allocated) free(message->original_message);
     message->original_message = NULL;
   }
+  free(message->id.alloc_name);
   free(message->id.stream.tags);
   message->id.stream.tag_count = 0;
   free(message->id.measurement.tags);
@@ -299,7 +364,7 @@ noit_metric_tags_parse_one(const char *tagnm, size_t tagnmlen,
   size_t cur_size = 0;
   while(cur_size < tagnmlen) {
     char test_char = tagnm[cur_size];
-    if(test_char == ':') {
+    if(test_char == ':' && !colon_pos) {
       if(!cur_size) {
         /* need at least one byte for category name. */
         return 0;
@@ -309,14 +374,12 @@ noit_metric_tags_parse_one(const char *tagnm, size_t tagnmlen,
         return 0;
       }
       colon_pos = cur_size;
+      if(!noit_metric_tagset_is_taggable_key(tagnm, cur_size)) return 0;
     }
     else if(test_char == ',') {
       /* tag-separation char, terminates this loop. */
+      if(!noit_metric_tagset_is_taggable_value(&tagnm[colon_pos+1], cur_size-colon_pos-1)) return 0;
       break;
-    }
-    else {
-      /* expect a valid tag character */
-      if(!noit_metric_tagset_is_taggable_key(&test_char, 1)) return 0;
     }
     cur_size++;
   }
@@ -334,17 +397,15 @@ noit_metric_tags_parse_one(const char *tagnm, size_t tagnmlen,
 }
 
 static int
-noit_metric_tags_compare(const void *v_l, const void *v_r) {
-  const noit_metric_tag_t *l = (noit_metric_tag_t *) v_l;
-  const noit_metric_tag_t *r = (noit_metric_tag_t *) v_r;
-  size_t memcmp_len = l->total_size < r->total_size ? l->total_size : r->total_size;
-  int cmp_rslt = memcmp(l->tag, r->tag, memcmp_len);
-  if(cmp_rslt != 0) return cmp_rslt;
-  if(l->total_size < r->total_size) return -1;
-  if(l->total_size > r->total_size) return 1;
-  return 0;
+tag_canonical_size(noit_metric_tag_t *tag) {
+  int len;
+  char dbuff[NOIT_TAG_MAX_PAIR_LEN], ebuff[NOIT_TAG_MAX_PAIR_LEN];
+  len = noit_metric_tagset_decode_tag(dbuff, sizeof(dbuff), tag->tag, tag->total_size);
+  if(len < 0) return 0;
+  len = noit_metric_tagset_encode_tag(ebuff, sizeof(ebuff), dbuff, len);
+  if(len < 0) return 0;
+  return len;
 }
-
 size_t
 noit_metric_tags_compact(noit_metric_tag_t *tags, size_t tag_count,
                          size_t *canonical_size_out) {
@@ -354,7 +415,7 @@ noit_metric_tags_compact(noit_metric_tag_t *tags, size_t tag_count,
     return tag_count;
   }
   else if(tag_count == 1) {
-    *canonical_size_out = tags[0].total_size;
+    *canonical_size_out = tag_canonical_size(&tags[0]);
     return tag_count;
   }
   /* output should be in lexically-sorted form */
@@ -365,7 +426,7 @@ noit_metric_tags_compact(noit_metric_tag_t *tags, size_t tag_count,
   size_t squash_index_right = 1;
   size_t sum_tags_len = 0;
   while(squash_index_right < tag_count) {
-    sum_tags_len += tags[squash_index_left].total_size;
+    sum_tags_len += tag_canonical_size(&tags[squash_index_left]);
 
     while(noit_metric_tags_compare(&tags[squash_index_left], &tags[squash_index_right]) == 0) {
       squash_index_right++;
@@ -380,7 +441,7 @@ noit_metric_tags_compact(noit_metric_tag_t *tags, size_t tag_count,
     else
       squash_index_right++;
   }
-  *canonical_size_out = sum_tags_len + tags[squash_index_left].total_size + squash_index_left;
+  *canonical_size_out = sum_tags_len + tag_canonical_size(&tags[squash_index_left]) + squash_index_left;
   return squash_index_left + 1;
 }
 
@@ -411,15 +472,27 @@ noit_metric_tags_parse(const char *tagnm, size_t tagnmlen,
 
 ssize_t
 noit_metric_tags_canonical(const noit_metric_tag_t *tags,
-                           size_t tag_count, char *tagnm, size_t tagnmlen) {
+                           size_t tag_count, char *tagnm, size_t tagnmlen,
+                           mtev_boolean already_decoded) {
+  char dbuff[NOIT_TAG_MAX_PAIR_LEN];
   if(!tag_count) return 0;
   size_t rval = 0;
   while(tag_count > 0) {
-    if(tagnmlen < tags[0].total_size) return -1;
-    memcpy(tagnm, tags[0].tag, tags[0].total_size);
-    tagnm += tags[0].total_size;
-    tagnmlen -= tags[0].total_size;
-    rval += tags[0].total_size;
+    int dlen;
+    if(already_decoded) {
+      dlen = noit_metric_tagset_encode_tag(dbuff, sizeof(dbuff), tags->tag, tags->total_size);
+      if(dlen < 0) return -1;
+    } else {
+      dlen = noit_metric_tagset_decode_tag(dbuff, sizeof(dbuff), tags->tag, tags->total_size);
+      if(dlen < 0) return -1;
+      dlen = noit_metric_tagset_encode_tag(dbuff, sizeof(dbuff), dbuff, dlen);
+      if(dlen < 0) return -1;
+    }
+    if(tagnmlen < dlen) return -1;
+    memcpy(tagnm, dbuff, dlen);
+    tagnm += dlen;
+    tagnmlen -= dlen;
+    rval += dlen;
     tags++;
     tag_count--;
     if(tag_count > 0) {
@@ -441,7 +514,7 @@ noit_metric_tagset_from_tags(noit_metric_tagset_t *lookup,
    * anyway... helps our display logic. */
   char *canonical = malloc(canonical_size + 1);
   if(!canonical) return NULL;
-  if(noit_metric_tags_canonical(tags, tag_count, canonical, canonical_size) != canonical_size) {
+  if(noit_metric_tags_canonical(tags, tag_count, canonical, canonical_size, mtev_false) != canonical_size) {
     free((void *) canonical);
     return NULL;
   }

--- a/src/noit_message_decoder.c
+++ b/src/noit_message_decoder.c
@@ -410,10 +410,10 @@ noit_metric_tags_parse_one(const char *tagnm, size_t tagnmlen,
 static int
 tag_canonical_size(noit_metric_tag_t *tag) {
   int len;
-  char dbuff[NOIT_TAG_MAX_PAIR_LEN], ebuff[NOIT_TAG_MAX_PAIR_LEN];
+  char dbuff[NOIT_TAG_MAX_PAIR_LEN];
   len = noit_metric_tagset_decode_tag(dbuff, sizeof(dbuff), tag->tag, tag->total_size);
   if(len < 0) return 0;
-  len = noit_metric_tagset_encode_tag(ebuff, sizeof(ebuff), dbuff, len);
+  len = noit_metric_tagset_encode_tag(dbuff, sizeof(dbuff), dbuff, len);
   if(len < 0) return 0;
   return len;
 }

--- a/src/noit_message_decoder.h
+++ b/src/noit_message_decoder.h
@@ -40,7 +40,7 @@
 API_EXPORT(int)
   noit_message_decoder_parse_line(noit_metric_message_t *message, int has_noit);
 
-API_EXPORT(void)
+API_EXPORT(int)
   noit_metric_process_tags(noit_metric_message_t *metric);
 
 API_EXPORT(int)

--- a/src/noit_metric.c
+++ b/src/noit_metric.c
@@ -33,13 +33,17 @@
  */
 
 #include "noit_metric.h"
+#include "noit_metric_private.h"
 
 #include <mtev_b64.h>
 #include <mtev_json_object.h>
 #include <mtev_str.h>
+#include <mtev_log.h>
 #include <circllhist.h>
 
 #include <stdio.h>
+
+#define MAX_TAGS 256
 
 mtev_boolean
 noit_metric_as_double(metric_t *metric, double *out) {
@@ -217,17 +221,28 @@ noit_metric_to_json(noit_metric_message_t *metric, char **json, size_t *len, mte
 
 /*
  * map for ascii tags
- 
-  perl -e '$valid = qr/[A-Za-z0-9\._-]/;
+  perl -e '$valid = qr/[+A-Za-z0-9!@#\$%^&"'\/\?\._-]/;
   foreach $i (0..7) {
   foreach $j (0..31) { printf "%d,", chr($i*32+$j) =~ $valid; }
   print "\n";
   }'
 */
-static uint8_t vtagmap[256] = {
+static uint8_t vtagmap_key[256] = {
   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,0,
-  0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,1,
+  0,1,1,1,1,1,1,1,0,0,0,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,1,
+  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,1,1,
+  0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+};
+
+/* Same as above, but allow for ':' and '=' */
+static uint8_t vtagmap_value[256] = {
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+  0,1,1,1,1,1,1,1,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,1,0,1,
+  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,1,1,
   0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,
   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -257,9 +272,15 @@ static uint8_t base64_vtagmap[256] = {
 
 
 static inline mtev_boolean
-noit_metric_tagset_is_taggable_char(char c) {
+noit_metric_tagset_is_taggable_key_char(char c) {
   uint8_t cu = c;
-  return vtagmap[cu] == 1;
+  return vtagmap_key[cu] == 1;
+}
+
+static inline mtev_boolean
+noit_metric_tagset_is_taggable_value_char(char c) {
+  uint8_t cu = c;
+  return vtagmap_value[cu] == 1;
 }
 
 mtev_boolean
@@ -269,7 +290,7 @@ noit_metric_tagset_is_taggable_b64_char(char c) {
 }
 
 mtev_boolean
-noit_metric_tagset_is_taggable_key(const char *key, size_t len)
+noit_metric_tagset_is_taggable_part(const char *key, size_t len, mtev_boolean (*tf)(char))
 {
   /* there are 2 tag formats supported, plain old tags that obey the vtagmap
      charset, and base64 encoded tags that obey the:
@@ -281,7 +302,7 @@ noit_metric_tagset_is_taggable_key(const char *key, size_t len)
     if (memcmp(key, "b\"", 2) == 0) {
       /* and end with " */
       if (key[len - 1] == '"') {
-        size_t sum_good = 0;
+        size_t sum_good = 3;
         for (size_t i = 2; i < len - 1; i++) {
           sum_good += (size_t)noit_metric_tagset_is_taggable_b64_char(key[i]);
         }
@@ -292,17 +313,78 @@ noit_metric_tagset_is_taggable_key(const char *key, size_t len)
   }
   size_t sum_good = 0;
   for (size_t i = 0; i < len; i++) {
-    sum_good += (size_t)noit_metric_tagset_is_taggable_char(key[i]);
+    sum_good += (size_t)tf(key[i]);
   }
   return len == sum_good;
 }
 
 mtev_boolean
-noit_metric_tagset_is_taggable_value(const char *val, size_t len)
+noit_metric_tagset_is_taggable_key(const char *val, size_t len)
 {
-  return noit_metric_tagset_is_taggable_key(val, len);
+  return noit_metric_tagset_is_taggable_part(val, len, noit_metric_tagset_is_taggable_key_char);
 }
 
+mtev_boolean
+noit_metric_tagset_is_taggable_value(const char *val, size_t len)
+{
+  return noit_metric_tagset_is_taggable_part(val, len, noit_metric_tagset_is_taggable_value_char);
+}
+
+size_t
+noit_metric_tagset_encode_tag(char *encoded_tag, size_t max_len, const char *decoded_tag, size_t decoded_len)
+{
+  char scratch[NOIT_TAG_MAX_PAIR_LEN];
+  if(max_len > sizeof(scratch)) return -1;
+  int i = 0, sepcnt = 0;
+  for(i=0; i<decoded_len; i++)
+    if(decoded_tag[i] == 0x1f) {
+      sepcnt = i;
+      break;
+    }
+  if(sepcnt == 0) return -1;
+  int first_part_needs_b64 = 0;
+  for(i=0;i<sepcnt;i++)
+    first_part_needs_b64 += !noit_metric_tagset_is_taggable_key_char(decoded_tag[i]);
+  int first_part_len = sepcnt;
+  if(first_part_needs_b64) first_part_len = mtev_b64_encode_len(first_part_len) + 3;
+ 
+  int second_part_needs_b64 = 0; 
+  for(i=sepcnt+1;i<decoded_len;i++)
+	second_part_needs_b64 += !noit_metric_tagset_is_taggable_value_char(decoded_tag[i]);
+  int second_part_len = decoded_len - sepcnt - 1;
+  if(second_part_needs_b64) second_part_len = mtev_b64_encode_len(second_part_len) + 3;
+
+  if(first_part_len + second_part_len + 2 > max_len) return -1;
+  char *cp = scratch;
+  if(first_part_needs_b64) {
+    *cp++ = 'b';
+    *cp++ = '"';
+    int len = mtev_b64_encode((unsigned char *)decoded_tag, sepcnt,
+                              cp, sizeof(scratch) - (cp - scratch));
+    if(len <= 0) return -1;
+    cp += len;
+    *cp++ = '"';
+  } else {
+    memcpy(cp, decoded_tag, sepcnt);
+    cp += sepcnt;
+  }
+  *cp++ = ':';
+  if(second_part_needs_b64) {
+    *cp++ = 'b';
+    *cp++ = '"';
+    int len = mtev_b64_encode((unsigned char *)decoded_tag + sepcnt + 1,
+                              decoded_len - sepcnt - 1, cp, sizeof(scratch) - (cp - scratch));
+    if(len <= 0) return -1;
+    cp += len;
+    *cp++ = '"';
+  } else {
+    memcpy(cp, decoded_tag + sepcnt + 1, decoded_len - sepcnt - 1);
+    cp += decoded_len - sepcnt - 1;
+  }
+  *cp = '\0';
+  memcpy(encoded_tag, scratch, cp - scratch + 1);
+  return cp - scratch;
+}
 size_t
 noit_metric_tagset_decode_tag(char *decoded_tag, size_t max_len, const char *encoded_tag, size_t encoded_size)
 {
@@ -314,10 +396,11 @@ noit_metric_tagset_decode_tag(char *decoded_tag, size_t max_len, const char *enc
   char *decoded = decoded_tag;
   if (memcmp(encoded, "b\"", 2) == 0) {
     encoded += 2;
-    const char *eend = (const char *)memchr(encoded, '"', colon - encoded);
-    if (!eend) return 0;
+    const char *eend = colon - 1;
+    if (*eend != '"') return 0;
     size_t elen = eend - encoded;
     int len = mtev_b64_decode(encoded, elen, (unsigned char *)decoded, max_len);
+    if (len < 0) return 0;
     decoded += len;
     encoded += elen + 1; // skip enclosing quote
   }
@@ -331,10 +414,11 @@ noit_metric_tagset_decode_tag(char *decoded_tag, size_t max_len, const char *enc
   decoded++;
   if (memcmp(encoded, "b\"", 2) == 0) {
     encoded += 2;
-    const char *eend = memchr(encoded, '"', encoded_end - encoded);
-    if (!eend || eend != encoded_end - 1) return 0;
+    const char *eend = encoded_end - 1;
+    if (*eend != '"') return 0;
     size_t elen = eend - encoded;
     int len = mtev_b64_decode(encoded, elen, (unsigned char *)decoded, max_len - (decoded - decoded_tag));
+    if (len < 0) return 0;
     decoded += len;
     encoded += elen + 1; // skip enclosing quote
   }
@@ -344,4 +428,121 @@ noit_metric_tagset_decode_tag(char *decoded_tag, size_t max_len, const char *enc
   }
   *decoded = '\0';
   return decoded - decoded_tag;
+}
+
+/* This is a reimplementation of the stuff in noit_message_decoder b/c allocations are
+ * rampant there and it's basically impossible to change the API.
+ */
+static mtev_boolean
+build_tags(const char *input, size_t len, noit_metric_tag_t *tags, int max_tags, int *ntags) {
+  
+  while(len > 0 && *ntags < max_tags) {
+    const char *next = noit_metric_tags_parse_one(input, len, &tags[*ntags]);
+    if(!next) return mtev_false;
+    
+    len -= (next - input);
+    input = next;
+    (*ntags)++;
+    if(len > 0) {
+      /* there's string left, we require it to be ",<next_tag>". */
+      if(*input != ',' || len == 1) return mtev_false;
+      input++;
+      len--;
+    }
+  }
+  return mtev_true;
+}
+static mtev_boolean
+eat_up_tags(const char *input, size_t *input_len, noit_metric_tag_t *tags, int max_tags,
+            int *ntags, const char *prefix, const char *suffix) {
+  int slen = strlen(suffix);
+  int plen = strlen(prefix);
+  const char *end = input + *input_len;
+  if(*input_len < slen + plen) return mtev_false;
+  if(memcmp(input+*input_len-slen, suffix, slen)) return mtev_false;
+  const char *next_start = memchr(input, prefix[0], *input_len);
+  const char *block_start = NULL;
+  while(next_start) {
+    if(end - next_start > plen+slen &&
+       memcmp(next_start, prefix, plen) == 0) {
+      block_start = next_start;
+    }
+    next_start = memchr(next_start+1, prefix[0], (end - next_start - 1));
+  }
+  if(!block_start) return mtev_false;
+  if(build_tags(block_start + plen, *input_len - (block_start + plen - input) - slen,
+                  tags, max_tags, ntags)) {
+    *input_len = (block_start - input);
+    return mtev_true;
+  }
+  return mtev_false;
+}
+static int
+tags_sort_dedup(noit_metric_tag_t *tags, int n_tags) {
+  int i;
+  qsort((void *) tags, n_tags, sizeof(noit_metric_tag_t), noit_metric_tags_decoded_compare);
+  for(i=0; i<n_tags - 1; i++) {
+    if(noit_metric_tags_decoded_compare(&tags[i], &tags[i+1]) == 0) {
+      memmove(&tags[i], &tags[i+1], sizeof(*tags) * (n_tags-i+1));
+      i--;
+      n_tags--;
+    }
+  }
+  return n_tags;
+}
+static void
+decode_tags(noit_metric_tag_t *tags, int ntags) {
+  for(int i=0; i<ntags; i++) {
+    tags[i].total_size = noit_metric_tagset_decode_tag((char *)tags[i].tag, tags[i].total_size, tags[i].tag, tags[i].total_size);
+  }
+}
+ssize_t
+noit_metric_canonicalize(const char *input, size_t input_len, char *output, size_t output_len,
+                         mtev_boolean null_term) {
+  int i = 0, ntags = 0;
+  noit_metric_tag_t stags[MAX_TAGS], mtags[MAX_TAGS];
+  int n_stags = 0, n_mtags = 0;
+  char buff[MAX_METRIC_TAGGED_NAME];
+  if(output_len < input_len) return -1;
+  if(input != output) memcpy(output, input, input_len);
+
+  if(input_len > MAX_METRIC_TAGGED_NAME) return -1;
+
+  for(i=0; i<input_len; i++) ntags += (input[i] == ',');
+  if(ntags > MAX_TAGS) return -1;
+
+  while(eat_up_tags(output, &input_len, stags, MAX_TAGS, &n_stags, "|ST[", "]") ||
+        eat_up_tags(output, &input_len, mtags, MAX_TAGS, &n_mtags, "|MT{", "}"));
+
+  if(strnstrn("|ST[", 4, output, input_len) || strnstrn("|MT{", 4, output, input_len))
+    return -1;
+
+  decode_tags(stags, n_stags);
+  decode_tags(mtags, n_mtags);
+  n_stags = tags_sort_dedup(stags, n_stags);
+  n_mtags = tags_sort_dedup(mtags, n_mtags);
+  if(output_len > MAX_METRIC_TAGGED_NAME) output_len = MAX_METRIC_TAGGED_NAME;
+
+  /* write to buff then copy to allow for output and input to be the same */
+  char *out = buff;
+  int len;
+  memcpy(out, output, input_len);
+  out += input_len;
+  if(n_stags) {
+    memcpy(out, "|ST[", 4); out += 4;
+    len = noit_metric_tags_canonical(stags, n_stags, out, (output_len - (out-buff)), mtev_true);
+    if(len < 0) return -1;
+    out += len;
+    *out++ = ']';
+  }
+  if(n_mtags) {
+    memcpy(out, "|MT{", 4); out += 4;
+    len = noit_metric_tags_canonical(mtags, n_mtags, out, (output_len - (out-buff)), mtev_true);
+    if(len < 0) return -1;
+    out += len;
+    *out++ = '}';
+  }
+  memcpy(output, buff, (out-buff));
+  if(null_term) output[out-buff] = '\0';
+  return (out - buff);
 }

--- a/src/noit_metric.c
+++ b/src/noit_metric.c
@@ -531,9 +531,8 @@ noit_metric_canonicalize(const char *input, size_t input_len, char *output, size
   int n_stags = 0, n_mtags = 0;
   char buff[MAX_METRIC_TAGGED_NAME];
   if(output_len < input_len) return -1;
-  if(input != output) memcpy(output, input, input_len);
-
   if(input_len > MAX_METRIC_TAGGED_NAME) return -1;
+  if(input != output) memcpy(output, input, input_len);
 
   for(i=0; i<input_len; i++) ntags += (input[i] == ',');
   if(ntags > MAX_TAGS) return -1;

--- a/src/noit_metric.h
+++ b/src/noit_metric.h
@@ -187,6 +187,12 @@ API_EXPORT(mtev_boolean)
   noit_metric_tagset_builder_end(noit_metric_tagset_builder_t *builder, noit_metric_tagset_t *out,
                                  char **canonical);
 
+API_EXPORT(mtev_boolean)
+  noit_metric_name_is_clean(const char *m, size_t len);
+
+API_EXPORT(size_t)
+  noit_metric_clean_name(char *m, size_t len);
+
 API_EXPORT(ssize_t)
   noit_metric_canonicalize(const char *input, size_t input_len, char *output, size_t output_len,
                            mtev_boolean null_term);

--- a/src/noit_metric.h
+++ b/src/noit_metric.h
@@ -37,6 +37,8 @@
 #include <mtev_defines.h>
 #include <mtev_atomic.h>
 
+#define MAX_METRIC_TAGGED_NAME 4096
+
 typedef enum {
   METRIC_ABSENT = 0,
   METRIC_GUESS = '0',
@@ -77,6 +79,7 @@ typedef enum {
 } noit_message_type;
 
 #define NOIT_TAG_MAX_COMPONENT_LEN 127
+#define NOIT_TAG_MAX_PAIR_LEN 256
 
 typedef struct {
   uint16_t total_size;
@@ -94,9 +97,11 @@ typedef struct {
   uuid_t id;
   const char *name;
   int name_len;
+  int name_len_with_tags;
   uint64_t account_id;
   noit_metric_tagset_t stream;
   noit_metric_tagset_t measurement;
+  char *alloc_name;
 } noit_metric_id_t;
 
 typedef struct {
@@ -156,6 +161,9 @@ API_EXPORT(mtev_boolean)
 API_EXPORT(mtev_boolean)
   noit_metric_tagset_is_taggable_value(const char *val, size_t len);
 API_EXPORT(size_t)
+  noit_metric_tagset_encode_tag(char *encoded_tag, size_t max_len, 
+                                const char *decoded_tag, size_t decoded_len);
+API_EXPORT(size_t)
   noit_metric_tagset_decode_tag(char *decoded_tag, size_t max_len, 
                                 const char *encoded_tag, size_t encoded_size);
 API_EXPORT(int)
@@ -178,5 +186,9 @@ API_EXPORT(mtev_boolean)
 API_EXPORT(mtev_boolean)
   noit_metric_tagset_builder_end(noit_metric_tagset_builder_t *builder, noit_metric_tagset_t *out,
                                  char **canonical);
+
+API_EXPORT(ssize_t)
+  noit_metric_canonicalize(const char *input, size_t input_len, char *output, size_t output_len,
+                           mtev_boolean null_term);
 
 #endif

--- a/src/noit_metric_private.h
+++ b/src/noit_metric_private.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018, Circonus, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ * 
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name Circonus, Inc. nor the names of its contributors
+ *       may be used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _NOIT_METRIC_PRIVATE_H
+#define _NOIT_METRIC_PRIVATE_H
+
+#include "noit_metric.h"
+#include <mtev_log.h>
+
+API_EXPORT(const char *)
+  noit_metric_tags_parse_one(const char *tagnm, size_t tagnmlen,
+                             noit_metric_tag_t *output);
+
+API_EXPORT(ssize_t)
+  noit_metric_tags_canonical(const noit_metric_tag_t *tags,
+                             size_t tag_count, char *tagnm, size_t tagnmlen,
+                             mtev_boolean alread_decoded);
+
+static inline int
+noit_metric_tags_compare(const void *v_l, const void *v_r) {
+  const noit_metric_tag_t *l = (noit_metric_tag_t *) v_l;
+  const noit_metric_tag_t *r = (noit_metric_tag_t *) v_r;
+  char lb[NOIT_TAG_MAX_PAIR_LEN], rb[NOIT_TAG_MAX_PAIR_LEN];
+  mtevAssert(l->total_size <= NOIT_TAG_MAX_PAIR_LEN);
+  mtevAssert(r->total_size <= NOIT_TAG_MAX_PAIR_LEN);
+  int llen = noit_metric_tagset_decode_tag(lb, sizeof(lb), l->tag, l->total_size);
+  mtevAssert(llen >= 0);
+  int rlen = noit_metric_tagset_decode_tag(rb, sizeof(rb), r->tag, r->total_size);
+  mtevAssert(rlen >= 0);
+  size_t memcmp_len = llen < rlen ? llen : rlen;
+  int cmp_rslt = memcmp(lb, rb, memcmp_len);
+  if(cmp_rslt != 0) return cmp_rslt;
+  if(llen < rlen) return -1;
+  if(llen > rlen) return 1;
+  return 0;
+}
+
+static inline int
+noit_metric_tags_decoded_compare(const void *v_l, const void *v_r) {
+  const noit_metric_tag_t *l = (noit_metric_tag_t *) v_l;
+  const noit_metric_tag_t *r = (noit_metric_tag_t *) v_r;
+  size_t memcmp_len = l->total_size < r->total_size ? l->total_size : r->total_size;
+  int cmp_rslt = memcmp(l->tag, r->tag, memcmp_len);
+  if(cmp_rslt != 0) return cmp_rslt;
+  if(l->total_size < r->total_size) return -1;
+  if(l->total_size > r->total_size) return 1;
+  return 0;
+}
+
+#endif

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -32,7 +32,7 @@ clean:	clean-keys clean-tests
 
 # This stuff if all cert stuff to make testing the daemons easier
 
-test_tags:
+test_tags:	test_tags.c
 	$(CC) -g -o test_tags -I../src $(CPPFLAGS) $(CFLAGS) -I$(MTEV_INCLUDEDIR) test_tags.c -L../src -lnoit
 
 others:

--- a/test/test_tags.c
+++ b/test/test_tags.c
@@ -1,6 +1,21 @@
+#include <stdio.h>
 #include "noit_metric.h"
 #include "noit_metric_tag_search.h"
+#include "noit_message_decoder.h"
 #include <assert.h>
+#include <sys/time.h>
+
+int ntest = 0;
+int failures = 0;
+#define test_assert(a) do { \
+  ntest++; \
+  if(a) { \
+    printf("ok - %d (%s)\n", ntest, #a); \
+  } else { \
+    printf("not ok - %d (%s)\n", ntest, #a); \
+    failures++; \
+  } \
+} while(0)
 
 void test_tag_decode()
 {
@@ -10,35 +25,35 @@ void test_tag_decode()
   const char *encoded = "b\"Zm9vOmJhcltzdHVmZl0=\":value";
   int rval  = noit_metric_tagset_decode_tag(decoded, sizeof(decoded),
 					    encoded, strlen(encoded));
-  assert(rval > 0);
+  test_assert(rval > 0);
 
   int eq = strncmp("foo:bar[stuff]\037value", decoded, rval);
-  assert(eq == 0);
+  test_assert(eq == 0);
 
   encoded = "b\"Zm9vOmJhcltzdHVmZl0=\":b\"Zm9vOmJhcltzdHVmZl0=\"";
   rval = noit_metric_tagset_decode_tag(decoded, sizeof(decoded),
 				       encoded, strlen(encoded));
-  assert(rval > 0);
+  test_assert(rval > 0);
 
   eq = strncmp("foo:bar[stuff]\037foo:bar[stuff]", decoded, rval);
-  assert(eq == 0);
+  test_assert(eq == 0);
 
   encoded = "category:b\"Zm9vOmJhcltzdHVmZl0=\"";
   rval = noit_metric_tagset_decode_tag(decoded, sizeof(decoded),
 				       encoded, strlen(encoded));
-  assert(rval > 0);
+  test_assert(rval > 0);
 
   eq = strncmp("category\037foo:bar[stuff]", decoded, rval);
-  assert(eq == 0);
+  test_assert(eq == 0);
 
   /* normal tags should just pass through with copies */
   encoded = "category:value";
   rval = noit_metric_tagset_decode_tag(decoded, sizeof(decoded),
 				       encoded, strlen(encoded));
-  assert(rval > 0);
+  test_assert(rval > 0);
 
   eq = strncmp("category\037value", decoded, rval);
-  assert(eq == 0);
+  test_assert(eq == 0);
 
 }
 
@@ -48,40 +63,40 @@ void test_ast_decode()
 
   /* simple test */
   noit_metric_tag_search_ast_t *ast = noit_metric_tag_search_parse("and(foo:bar)", &erroroffset);
-  assert(ast != NULL);
-  assert(ast->operation == OP_AND_ARGS);
-  assert(ast->contents.args.node[0]->operation == OP_MATCH);
-  assert(strcmp(ast->contents.args.node[0]->contents.spec.cat.str,"foo") == 0);
-  assert(strcmp(ast->contents.args.node[0]->contents.spec.name.str,"bar") == 0);
+  test_assert(ast != NULL);
+  test_assert(ast->operation == OP_AND_ARGS);
+  test_assert(ast->contents.args.node[0]->operation == OP_MATCH);
+  test_assert(strcmp(ast->contents.args.node[0]->contents.spec.cat.str,"foo") == 0);
+  test_assert(strcmp(ast->contents.args.node[0]->contents.spec.name.str,"bar") == 0);
   noit_metric_tag_search_free(ast);
   
   /* base64 fixed category */
   ast = noit_metric_tag_search_parse("and(foo:bar,not(b\"c29tZTpzdHVmZltoZXJlXQ==\":value))", &erroroffset);
-  assert(ast != NULL);
-  assert(ast->operation == OP_AND_ARGS);
-  assert(ast->contents.args.node[0]->operation == OP_MATCH);
-  assert(strcmp(ast->contents.args.node[0]->contents.spec.cat.str,"foo") == 0);
-  assert(strcmp(ast->contents.args.node[0]->contents.spec.name.str,"bar") == 0);
-  assert(ast->contents.args.node[1]->operation == OP_NOT_ARGS);
+  test_assert(ast != NULL);
+  test_assert(ast->operation == OP_AND_ARGS);
+  test_assert(ast->contents.args.node[0]->operation == OP_MATCH);
+  test_assert(strcmp(ast->contents.args.node[0]->contents.spec.cat.str,"foo") == 0);
+  test_assert(strcmp(ast->contents.args.node[0]->contents.spec.name.str,"bar") == 0);
+  test_assert(ast->contents.args.node[1]->operation == OP_NOT_ARGS);
   noit_metric_tag_search_ast_t *not = ast->contents.args.node[1]->contents.args.node[0];
-  assert(not != NULL);
-  assert(strcmp(not->contents.spec.cat.str,"some:stuff[here]") == 0);
-  assert(strcmp(not->contents.spec.name.str,"value") == 0);
+  test_assert(not != NULL);
+  test_assert(strcmp(not->contents.spec.cat.str,"some:stuff[here]") == 0);
+  test_assert(strcmp(not->contents.spec.name.str,"value") == 0);
   noit_metric_tag_search_free(ast);
 
   /* base64 regex parse */
   ast = noit_metric_tag_search_parse("and(foo:bar,not(b/c29tZS4q/:value))", &erroroffset);
-  assert(ast != NULL);
-  assert(ast->operation == OP_AND_ARGS);
-  assert(ast->contents.args.node[0]->operation == OP_MATCH);
-  assert(strcmp(ast->contents.args.node[0]->contents.spec.cat.str,"foo") == 0);
-  assert(strcmp(ast->contents.args.node[0]->contents.spec.name.str,"bar") == 0);
-  assert(ast->contents.args.node[1]->operation == OP_NOT_ARGS);
+  test_assert(ast != NULL);
+  test_assert(ast->operation == OP_AND_ARGS);
+  test_assert(ast->contents.args.node[0]->operation == OP_MATCH);
+  test_assert(strcmp(ast->contents.args.node[0]->contents.spec.cat.str,"foo") == 0);
+  test_assert(strcmp(ast->contents.args.node[0]->contents.spec.name.str,"bar") == 0);
+  test_assert(ast->contents.args.node[1]->operation == OP_NOT_ARGS);
   not = ast->contents.args.node[1]->contents.args.node[0];
-  assert(not != NULL);
-  assert(strcmp(not->contents.spec.cat.str,"some.*") == 0);
-  assert(not->contents.spec.cat.re != NULL);
-  assert(strcmp(not->contents.spec.name.str,"value") == 0);
+  test_assert(not != NULL);
+  test_assert(strcmp(not->contents.spec.cat.str,"some.*") == 0);
+  test_assert(not->contents.spec.cat.re != NULL);
+  test_assert(strcmp(not->contents.spec.name.str,"value") == 0);
   noit_metric_tag_search_free(ast);
   
 }
@@ -101,29 +116,110 @@ void test_tag_match()
   /* simple test */
   noit_metric_tag_search_ast_t *ast = noit_metric_tag_search_parse("and(foo:bar)", &erroroffset);
   mtev_boolean match = noit_metric_tag_search_evaluate_against_tags(ast, &tagset);
-  assert(match == mtev_true);
+  test_assert(match == mtev_true);
   noit_metric_tag_search_free(ast);
 
   ast = noit_metric_tag_search_parse("and(foo:bar,b\"c29tZTpzdHVmZltoZXJlXQ==\":value)", &erroroffset);
   match = noit_metric_tag_search_evaluate_against_tags(ast, &tagset);
-  assert(match == mtev_true);
+  test_assert(match == mtev_true);
   noit_metric_tag_search_free(ast);
 
   ast = noit_metric_tag_search_parse("and(b/c29tZS4q/:value)", &erroroffset);
   match = noit_metric_tag_search_evaluate_against_tags(ast, &tagset);
-  assert(match == mtev_true);
+  test_assert(match == mtev_true);
   noit_metric_tag_search_free(ast);
 
   ast = noit_metric_tag_search_parse("and(quux:value)", &erroroffset);
   match = noit_metric_tag_search_evaluate_against_tags(ast, &tagset);
-  assert(match == mtev_false);
+  test_assert(match == mtev_false);
   noit_metric_tag_search_free(ast);
+}
+
+void metric_parsing(void) {
+  int len;
+  char buff[NOIT_TAG_MAX_PAIR_LEN], dbuff[NOIT_TAG_MAX_PAIR_LEN], ebuff[NOIT_TAG_MAX_PAIR_LEN];
+
+  snprintf(buff, sizeof(buff), "@#lkm45lsnd:kljnmsdkflnsdf:kjnsdkfjnsdf");
+  len = noit_metric_tagset_decode_tag(dbuff, sizeof(dbuff), buff, strlen(buff));
+  test_assert(len > 0);
+  len = noit_metric_tagset_encode_tag(ebuff, sizeof(ebuff), dbuff, len);
+  test_assert(len > 0);
+  test_assert(strcmp(buff, ebuff) == 0);
+
+  snprintf(buff, sizeof(buff), "b\"Zm9v\":http://12.3.3.4:80/this?is=it");
+  len = noit_metric_tagset_decode_tag(dbuff, sizeof(dbuff), buff, strlen(buff));
+  test_assert(len > 0);
+  len = noit_metric_tagset_encode_tag(ebuff, sizeof(ebuff), dbuff, len);
+  test_assert(len > 0);
+  test_assert(strcmp("foo:http://12.3.3.4:80/this?is=it", ebuff) == 0);
+
+  char *hbuff;
+  noit_metric_message_t message;
+  int rval;
+
+  hbuff = "H1\t1525385460.000\tpush`httptrap`c_933_247631::httptrap`43e5c324-44c2-4877-a625-3b4c8230f2eb\tSuperSimpleMetricName|ST[a:b,c:d]\tAAUK/wACDP8AARH/AAEa/wABVP8AAQ==";
+  memset(&message, 0, sizeof(message));
+  message.original_message = hbuff;
+  rval = noit_message_decoder_parse_line(&message, 0);
+  test_assert(message.id.alloc_name == NULL);
+  test_assert(rval == 1);
+  noit_metric_message_clear(&message);
+
+  hbuff = "H1\t1525385460.000\tpush`httptrap`c_933_247631::httptrap`43e5c324-44c2-4877-a625-3b4c8230f2eb\t/transmissions`latency|ST[b\"bjo6Og==\":b\"YT1i\",customer:noone,node:j.mta2vrest.cc.aws-usw2a.prd.acme,cluster:mta2]\tAAUK/wACDP8AARH/AAEa/wABVP8AAQ==";
+  memset(&message, 0, sizeof(message));
+  message.original_message = hbuff;
+  rval = noit_message_decoder_parse_line(&message, 0);
+  test_assert(message.id.alloc_name);
+  test_assert(rval == 1);
+  noit_metric_message_clear(&message);
+
+  /* This one has a stray { in one of the tag keys. */  
+  hbuff = "H1\t1525385460.000\tpush`httptrap`c_933_247631::httptrap`43e5c324-44c2-4877-a625-3b4c8230f2eb\t/transmissions`latency|ST[b\"bjo6Og==\":b\"YT1i\",c{ustomer:noone,node:j.mta2vrest.cc.aws-usw2a.prd.acme,cluster:mta2]\tAAUK/wACDP8AARH/AAEa/wABVP8AAQ==";
+  memset(&message, 0, sizeof(message));
+  message.original_message = hbuff;
+  rval = noit_message_decoder_parse_line(&message, 0);
+  test_assert(message.id.alloc_name == NULL);
+  test_assert(rval < 0);
+  noit_metric_message_clear(&message);
+
+  hbuff = strdup("/transmissions`latency|ST[b\"bjo6Og==\":b\"YT1i\",customer:noone,node:j.mta2vrest.cc.aws-usw2a.prd.acme,cluster:mta2]");
+  len = noit_metric_canonicalize(hbuff, strlen(hbuff), hbuff, strlen(hbuff), mtev_true);
+  test_assert(len > 0);
+  test_assert(!strcmp(hbuff, "/transmissions`latency|ST[cluster:mta2,customer:noone,b\"bjo6Og==\":a=b,node:j.mta2vrest.cc.aws-usw2a.prd.acme]"));
+  free(hbuff);
+
+  hbuff = strdup("woop|ST[a:b,c:d]|MT{foo:bar}|ST[c:d,e:f,a:b]");
+  len = noit_metric_canonicalize(hbuff, strlen(hbuff), hbuff, strlen(hbuff), mtev_true);
+  test_assert(len > 0);
+  test_assert(!strcmp(hbuff, "woop|ST[a:b,c:d,e:f]|MT{foo:bar}"));
+  free(hbuff);
 
 }
 
+void loop(char *str) {
+  int len;
+  const int nloop = 1000000;
+  struct timeval start, end;
+  char *hbuff = strdup(str);
+  int hlen = strlen(hbuff);
+  char obuff[MAX_METRIC_TAGGED_NAME];
+  gettimeofday(&start, NULL);
+  for(int i=0; i<nloop; i++) {
+    len = noit_metric_canonicalize(hbuff, hlen, obuff, sizeof(obuff), mtev_true);
+    assert(len > 0);
+  }
+  gettimeofday(&end, NULL);
+  double elapsed = sub_timeval_d(end, start);
+  free(hbuff);
+  printf("canonicalize('%s') -> %f ns/op\n", str, (elapsed * 1000000000.0) / (double)nloop);
+}
 int main(int argc, const char **argv)
 {
   test_tag_decode();
   test_ast_decode();
-  return 0;
+  metric_parsing();
+  loop("woop|ST[a:b,c:d]|MT{foo:bar}|ST[c:d,e:f,a:b]");
+  loop("testing_this|ST[cluster:mta2,customer:noone,b\"bjo6Og==\":a=b,node:j.mta2vrest.prd.acme]");
+  loop("testing_this_long_untagged_metric");
+  return !(failures == 0);
 }


### PR DESCRIPTION
 * Expand tag characters to a large alowable set
 * Define form as name|ST[..]|MT{...}
 * |ST and |MT are omitted if no such tags are there
 * Base64 tags are decoded before sorting.
 * Tags within groups are unique and sorted.
 * Only tags parts (key or value) are base64 encoded if they cannot be expressed otherwise.
 * Canonicalize on the way into the set metrics path for checks.
 * Canonicalize on the message decoding path (extra alloc if non-canonical)