### PR TITLE
Return "metric_name_with_tags" to lua

### DIFF
--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -101,8 +101,12 @@ static int noit_metric_id_index_func(lua_State *L) {
       return 1;
     case 'n':
       if(!strcmp(k, "name")) {
-        lua_pushlstring(L, metric_id->name, metric_id->name_len);
+        lua_pushlstring(L, metric_id->name, metric_id->name_len_with_tags);
       } else if(!strcmp(k, "name_len")) {
+        lua_pushinteger(L, metric_id->name_len_with_tags);
+      } else if(!strcmp(k, "name_without_tags")) {
+        lua_pushlstring(L, metric_id->name, metric_id->name_len);
+      } else if(!strcmp(k, "name_len_without_tags")) {
         lua_pushinteger(L, metric_id->name_len);
       } else {
         break;


### PR DESCRIPTION
This restores the behavior of returning the full metric name, instead
of truncating stram tag. In this way we keep the policy that a metric
is uniquely identified by UUID+name.