### PR TITLE
Support deleteing checks on clusters.

### DIFF
--- a/src/modules/ping_icmp.c
+++ b/src/modules/ping_icmp.c
@@ -451,13 +451,13 @@ static int ping_icmp_real_send(eventer_t e, int mask,
   k.addr_of_check = payload->addr_of_check;
   mtev_uuid_copy(k.checkid, payload->checkid);
 
-  if(pcl->check->target_ip[0] == '\0') goto cleanup;
-
   if(!mtev_hash_retrieve(data->in_flight, (const char *)&k, sizeof(k),
                          &vcheck)) {
     mtevLT(nldeb, now, "ping check no longer active, bailing\n");
     goto cleanup;
   }
+
+  if(pcl->check->target_ip[0] == '\0') goto cleanup;
 
   mtevLT(nldeb, now, "ping_icmp_real_send(%s)\n", pcl->check->target_ip);
   mtev_gettimeofday(&whence, NULL); /* now isn't accurate enough */

--- a/src/noit.conf.in
+++ b/src/noit.conf.in
@@ -227,4 +227,10 @@
       <rule type="deny">66.225.209.0/24</rule>
     </acl>
   </acls>
+  <clusters my_id="f7cea020-f19d-11dd-85a6-cb6d3a2207dc">
+    <cluster name="noit" port="43191" period="1000" timeout="5000" maturity="10000" key="shame_on_me" seq="1">
+      <node id="183bf75c-507a-48db-8fb4-5fdcf77e1089" cn="test-noit2" address="127.0.0.1" port="43192"/>
+      <node id="f7cea020-f19d-11dd-85a6-cb6d3a2207dc" cn="test-noit" address="127.0.0.1" port="43191"/>
+    </cluster>
+  </clusters>
 </noit>

--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -82,6 +82,8 @@
 #define NP_RESOLVE               0x00000020
 /* Name service resolution has been compelted for the check */
 #define NP_RESOLVED              0x00000040
+/* The check has been deleted, but is kept as a tombstone */
+#define NP_DELETED               0x00000080
 /* This check should have 'S' lines suppressed from logging */
 #define NP_SUPPRESS_STATUS       0x00001000
 /* This check should have 'M' lines suppressed from logging */
@@ -155,6 +157,7 @@ API_EXPORT(void) noit_check_end(noit_check_t *);
 #define NOIT_CHECK_CONFIGURED(a) (((a)->flags & NP_UNCONFIG) == 0)
 #define NOIT_CHECK_RUNNING(a) ((a)->flags & NP_RUNNING)
 #define NOIT_CHECK_KILLED(a) ((a)->flags & NP_KILLED)
+#define NOIT_CHECK_DELETED(a) ((a)->flags & NP_DELETED)
 #define NOIT_CHECK_SHOULD_RESOLVE(a) ((a)->flags & NP_RESOLVE)
 /* It is resolved if it is resolved or never needed to be resolved */
 #define NOIT_CHECK_RESOLVED(a) (((a)->flags & NP_RESOLVED) || (((a)->flags & NP_RESOLVE) == 0))

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -864,8 +864,9 @@ rest_delete_check(mtev_http_rest_closure_t *restc,
     if(!noit_poller_deschedule(check->checkid, mtev_true))
       just_mark = mtev_true;
   if(just_mark) {
+    int64_t newseq = noit_conf_check_bump_seq(node);
     xmlSetProp(node, (xmlChar *)"deleted", (xmlChar *)"deleted");
-    noit_conf_check_bump_seq(node);
+    if(check) check->config_seq = newseq;
     CONF_DIRTY(mtev_conf_section_from_xmlnodeptr(node));
   } else {
     CONF_REMOVE(mtev_conf_section_from_xmlnodeptr(node));

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -866,7 +866,10 @@ rest_delete_check(mtev_http_rest_closure_t *restc,
   if(just_mark) {
     int64_t newseq = noit_conf_check_bump_seq(node);
     xmlSetProp(node, (xmlChar *)"deleted", (xmlChar *)"deleted");
-    if(check) check->config_seq = newseq;
+    if(check) {
+      check->config_seq = newseq;
+      noit_cluster_mark_check_changed(check, NULL);
+    }
     CONF_DIRTY(mtev_conf_section_from_xmlnodeptr(node));
   } else {
     CONF_REMOVE(mtev_conf_section_from_xmlnodeptr(node));

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -225,19 +225,22 @@ noit_check_state_as_json(noit_check_t *check, int full) {
   uint64_t ms = 0;
   struct json_object *doc;
   uuid_unparse_lower(check->checkid, id_str);
+  snprintf(seq_str, sizeof(seq_str), "%lld", (long long)check->config_seq);
 
   doc = json_object_new_object();
   json_object_object_add(doc, "id", json_object_new_string(id_str));
+  json_object_object_add(doc, "seq", json_object_new_string(seq_str));
+  json_object_object_add(doc, "flags", json_object_new_int(check->flags));
+  if(NOIT_CHECK_DELETED(check)) return doc;
+
   json_object_object_add(doc, "name", json_object_new_string(check->name));
   json_object_object_add(doc, "module", json_object_new_string(check->module));
   json_object_object_add(doc, "target", json_object_new_string(check->target));
   json_object_object_add(doc, "target_ip", json_object_new_string(check->target_ip));
   json_object_object_add(doc, "filterset", json_object_new_string(check->filterset));
-  snprintf(seq_str, sizeof(seq_str), "%lld", (long long)check->config_seq);
-  json_object_object_add(doc, "seq", json_object_new_string(seq_str));
   json_object_object_add(doc, "period", json_object_new_int(check->period));
   json_object_object_add(doc, "timeout", json_object_new_int(check->timeout));
-  json_object_object_add(doc, "flags", json_object_new_int(check->flags));
+  json_object_object_add(doc, "active_on_cluster_node", json_object_new_boolean(noit_should_run_check(check, NULL)));
 
   c = noit_check_get_stats_current(check);
   t = noit_check_stats_whence(c, NULL);

--- a/src/noit_check_tools.c
+++ b/src/noit_check_tools.c
@@ -187,8 +187,9 @@ noit_check_schedule_next(noit_module_t *self,
   rcl->dispatch = dispatch;
   newe = eventer_alloc_timer(noit_check_recur_handler, rcl, &tgt);
 
-  /* knuth's golden ratio approach */
-  if(!self->thread_unsafe) {
+  if(self->thread_unsafe) {
+    eventer_set_owner(newe, eventer_choose_owner(0));
+  } else {
     eventer_set_owner(newe, CHOOSE_EVENTER_THREAD_FOR_CHECK(check));
   }
   check->fire_event = newe;

--- a/src/noit_clustering.h
+++ b/src/noit_clustering.h
@@ -54,4 +54,7 @@ void
   noit_cluster_xml_filter_changes(uuid_t peerid, const char *cn,
                                   int64_t prev_end, int64_t limit, xmlNodePtr parent);
 
+mtev_boolean
+  noit_cluster_checkid_replication_pending(uuid_t);
+
 #endif

--- a/src/noit_conf_checks.c
+++ b/src/noit_conf_checks.c
@@ -680,6 +680,7 @@ noit_console_config_nocheck(mtev_console_closure_t ncct,
     goto bad;
   }
   cnt = xmlXPathNodeSetGetLength(pobj->nodesetval);
+  mtev_boolean removed = mtev_false;
   for(i=0; i<cnt; i++) {
     xmlNodePtr node;
     char *uuid_conf;
@@ -701,6 +702,7 @@ noit_console_config_nocheck(mtev_console_closure_t ncct,
         if(noit_poller_deschedule(checkid, mtev_true)) {
           CONF_REMOVE(mtev_conf_section_from_xmlnodeptr(node));
           xmlUnlinkNode(node);
+          removed = mtev_true;
         }
         else {
           xmlSetProp(node, (xmlChar *)"deleted", (xmlChar *)"deleted");
@@ -712,7 +714,7 @@ noit_console_config_nocheck(mtev_console_closure_t ncct,
     }
     xmlFree(uuid_conf);
   }
-  if(argc > 1) {
+  if(!removed) {
     noit_poller_process_checks(xpath);
     noit_poller_reload(xpath);
   }

--- a/src/noit_conf_checks.c
+++ b/src/noit_conf_checks.c
@@ -108,12 +108,12 @@ void noit_console_conf_checks_init() {
   register_console_config_check_commands();
 }
 
-void
+int64_t
 noit_conf_check_bump_seq(xmlNodePtr node) {
-  int64_t seq;
+  int64_t seq = 0;
   xmlChar *seq_str;
   seq_str = xmlGetProp(node, (xmlChar *)"seq");
-  if(!seq_str) return;
+  if(!seq_str) return seq;
   seq = strtoll((const char *)seq_str, NULL, 10);
   if(seq != 0) {
     char new_seq_str[64];
@@ -124,6 +124,7 @@ noit_conf_check_bump_seq(xmlNodePtr node) {
     xmlSetProp(node, (xmlChar *)"seq", (xmlChar *)new_seq_str);
   }
   xmlFree(seq_str);
+  return seq;
 }
 static int
 noit_console_mkcheck_xpath(char *xpath, int len,

--- a/src/noit_conf_checks.h
+++ b/src/noit_conf_checks.h
@@ -50,7 +50,7 @@ API_EXPORT(void)
 API_EXPORT(void)
   noit_conf_checks_init_globals(void);
 
-API_EXPORT(void)
+API_EXPORT(int64_t)
   noit_conf_check_bump_seq(xmlNodePtr node);
 
 #endif

--- a/src/noit_conf_checks.h
+++ b/src/noit_conf_checks.h
@@ -50,4 +50,7 @@ API_EXPORT(void)
 API_EXPORT(void)
   noit_conf_checks_init_globals(void);
 
+API_EXPORT(void)
+  noit_conf_check_bump_seq(xmlNodePtr node);
+
 #endif

--- a/test/t/cluster/120_cluster_noit.tjs
+++ b/test/t/cluster/120_cluster_noit.tjs
@@ -1,0 +1,265 @@
+name = "clustered noit"
+plan = 39
+
+'use strict';
+var tools = require('./testconfig'),
+    nc = require('../../src/js/noit/index'),
+    fs = require('fs'),
+    async = require('async');
+
+var global_seq = 12928734;
+
+var expected_comms = 
+  { '0x50555420': { name: 'mtev_wire_rest_api', version: '1.0' },
+    '0x47455420': { name: 'mtev_wire_rest_api', version: '1.0' },
+    '0x48454144': { name: 'mtev_wire_rest_api', version: '1.0' },
+    '0xda7afeed': { name: 'log_transit', version: '1.0' },
+    '0x44454c45': { name: 'mtev_wire_rest_api', version: '1.0' },
+    '0x7e66feed': { name: 'log_transit', version: '1.0' },
+    '0x52455645': { name: 'reverse_socket_accept' },
+    '0x504f5354': { name: 'mtev_wire_rest_api', version: '1.0' },
+    '0xfa57feed': { name: 'livestream_transit', version: '1.0' },
+    '0x43415041': { name: 'capabilities_transit', version: '1.0' },
+    '0x4d455247': { name: 'mtev_wire_rest_api', version: '1.0' } };
+
+var noit, conn;
+
+function check_caps(conn, test, noit, callback) {
+  var reqtime = Date.now();
+  conn.request({ path: '/capa.json' }, function(code,data) {
+    var caps = {}, restime = Date.now();
+    try { caps = JSON.parse(data); } catch(e) {}
+
+    test.like(caps.current_time, /^\d+$/, 'current_time is a number');
+    var reqdur = restime - reqtime;
+    var remote_time = parseInt(caps.current_time) + reqdur/2.0;
+    var time_error = Math.abs(remote_time - restime);
+    test.ok(time_error < reqdur, 'time skew check')
+
+    for (var p in caps.services) {
+      if(caps.services[p].control_dispatch == 'control_dispatch') {
+        var comms = caps.services[p].commands;
+        test.is_deeply(comms, expected_comms, "capabilities");
+        return callback();
+      }
+    }
+    callback();
+  });
+}
+
+function check_show(conn, uuid, cb) {
+  conn.request({path: '/checks/show/' + uuid + '.json'}, cb);
+}
+
+function check_delete(conn, uuid, cb) {
+  conn.request({method: 'DELETE', path: '/checks/delete/' + uuid}, cb);
+}
+
+function put_check(conn, uuid, name, cb) {
+  var seq = 0;
+  var module = 'selfcheck';
+  if(cb == null) {
+    cb = name;
+    name = "selfcheck";
+  }
+  if(name != "selfcheck") {
+    module = "ping_icmp";
+    seq = global_seq++;
+  }
+  conn.request({path: '/checks/set/' + uuid, method: 'PUT' },
+    '<?xml version="1.0" encoding="utf8"?>' +
+    '<check>' +
+    '<attributes>' +
+    '  <target>127.0.0.1</target>' +
+    '  <period>1000</period>' +
+    '  <timeout>500</timeout>' +
+    '  <name>' + name + '</name>' +
+    '  <filterset>allowall</filterset>' +
+    '  <module>' + module + '</module>' +
+    '  <seq>' + seq + '</seq>' +
+    '</attributes>' +
+    '<config/>' +
+    '</check>',
+    cb);
+}
+
+function put_cluster(conn, nodes, idx, cb) {
+  var payload = '<?xml version="1.0" encoding="utf8"?>' +
+    '<cluster name="noit" port="' + nodes[idx].port + '" period="200" timeout="1000" maturity="2000" key="shame_on_me" seq="1">';
+  for(var i=0; i<nodes.length; i++) {
+    payload = payload + '<node id="' + nodes[i].id +'" cn="noit-test" address="127.0.0.1" port="' + nodes[i].port + '"/>';
+  }
+  payload = payload + ' </cluster>';
+  conn.request({path: '/cluster', method: 'POST' }, payload, cb);
+}
+
+function spinup_selfcheck(conn, test, noit, uuid) {
+ return [
+      function(callback) {
+        check_show(conn, uuid, function(code, data) {
+          test.is(code, 404, 'show check absent');
+          callback();
+        })
+      },
+      function(callback) {
+        put_check(conn, uuid, function(code, data) {
+          test.is(code, 200, 'put check');
+          callback();
+        })
+      },
+      function(done) { noit.wait_for_log(/`selfcheck <-/, 20000, function() {done();}) },
+      function(callback) {
+        check_show(conn, uuid, function(code, data) {
+          test.is(code, 200, 'show check absent');
+          try {
+            var json = JSON.parse(data);
+            test.is(json.status.good, true, 'show check run');
+          }
+          catch(e) { test.fail('show check run'); }
+          callback();
+        })
+      }
+  ];
+}
+
+function check_check(test, conn, uuid, expect_code, key, value, callback) {
+  if(callback == null) {
+    callback = value;
+    value = null;
+  }
+  if(callback == null) {
+    callback = key;
+    key = null;
+  }
+  check_show(conn, uuid, function(code, json) {
+    var data = {}
+    test.is(code, expect_code, 'check check: ('+expect_code+')');
+    if(key) {
+      try { data = JSON.parse(json); } catch(e) {}
+      if(typeof(key) === 'function') {
+        key(test, data);
+      } else {
+        if(!Array.isArray(key)) key = [key];
+        var obj = data;
+        for(var i=0; i<key.length; i++) if(obj != null) obj = obj[key[i]];
+        test.is(obj, value, 'check check: ' + key + '=' + value);
+      }
+    }
+    callback();
+  })
+}
+
+test = function() {
+  var test = this;
+  noit1 = new tools.noit(test, "120a", { 'logs_debug': { '': 'false' } });
+  noit2 = new tools.noit(test, "120b", { 'logs_debug': { '': 'false' } });
+  selfcheck1 = '5a74f6f2-3125-44de-84e7-6ea7275e5fee';
+  selfcheck2 = 'ab419eda-6f51-466f-b086-63ae940c8147';
+  check = '39568546-da44-465e-abd8-a348a27b2fd5';
+  conn1 = noit1.get_connection();
+  conn2 = noit2.get_connection();
+  var running = 0;
+  var complete = function() {
+    if(running < 2) return;
+    async.series([
+      function(callback) { check_caps(conn1, test, noit1, callback); },
+      function(callback) {
+        var fns = spinup_selfcheck(conn1, test, noit1, selfcheck1);
+        fns.push(function() { callback(); });
+        async.series(fns);
+      },
+      function(callback) {
+        var fns = spinup_selfcheck(conn2, test, noit2, selfcheck2);
+        fns.push(function() { callback(); });
+        async.series(fns);
+      },
+      function(callback) {
+        put_cluster(conn1, [ { id: selfcheck1, port: noit1.get_api_port() },
+                             { id: selfcheck2, port: noit2.get_api_port() } ], 0,
+                    function(code, data) {
+                      test.is(code, 204, "configure cluster");
+                      callback();
+                    });
+      },
+      function(callback) {
+        put_cluster(conn2, [ { id: selfcheck1, port: noit1.get_api_port() },
+                             { id: selfcheck2, port: noit2.get_api_port() } ], 1,
+                    function(code, data) {
+                      test.is(code, 204, "configure cluster");
+                      callback();
+                    });
+      },
+      function(callback) {
+        check_check(test, conn1, check, 404, callback);
+      },
+      function(callback) {
+        check_check(test, conn2, check, 404, callback);
+      },
+      function(callback) { put_check(conn1, check, 'plague',
+        function(code, data) {
+          test.is(code, 200, 'put plague check');
+          callback();
+        });
+      },
+      function(done) { noit2.wait_for_log(/plague/, 20000, function() {done();}) },
+      function(callback) {
+        check_check(test, conn1, check, 200, "active_on_cluster_node", true, callback);
+      },
+      function(callback) {
+        check_check(test, conn2, check, 200, "active_on_cluster_node", false, callback);
+      },
+      function(callback) { noit1.pause(); callback(); },
+      function(callback) { setTimeout(function() { callback(); }, 2000); },
+      function(callback) {
+        check_check(test, conn2, check, 200, "active_on_cluster_node", true, callback);
+      },
+      function(callback) { noit1.continue(); callback(); },
+      function(callback) { setTimeout(function() { callback(); }, 1000); },
+      function(callback) {
+        check_check(test, conn1, check, 200, "active_on_cluster_node", true, callback);
+      },
+      function(callback) {
+        check_check(test, conn2, check, 200, "active_on_cluster_node", false, callback);
+      },
+      function(callback) {
+        check_delete(conn2, check, function(code, data) {
+          test.is(code, 200, 'deleted from node 2');
+          callback();
+        });
+      },
+      function(callback) {
+        check_check(test, conn2, check, 200, function(t,o) {
+          t.ok(o.flags & 0x80, "check deleted");
+        }, callback);
+      },
+      function(callback) { setTimeout(function() { callback(); }, 500); },
+      function(callback) {
+        check_check(test, conn1, check, 200, function(t,o) {
+          t.ok(o.flags & 0x80, "check deleted");
+        }, callback);
+      },
+      function(callback) { setTimeout(function() { callback(); }, 1500); },
+      function(callback) {
+        check_check(test, conn1, check, 404, callback);
+      },
+      function(callback) {
+        check_check(test, conn2, check, 404, callback);
+      },
+      function(callback) { noit1.stop(); callback(); },
+      function(callback) { noit2.stop(); callback(); },
+    ]);
+  };
+
+  noit1.start(function(pid, port) {
+    test.is(port, noit1.get_api_port(), 'API port matches');
+    running++;
+    complete();
+  });
+
+  noit2.start(function(pid, port) {
+    test.is(port, noit2.get_api_port(), 'API port matches');
+    running++;
+    complete();
+  });
+
+}


### PR DESCRIPTION
Deleting checks on clusters requires delete replication and seq manipulation.
The seq must be increased and the check considered a tombstone until it has
been replicated everywhere and then it can be formally deleted. If this isn't
done, then old nodes can come back online and reinstantiate the check.