### PR TITLE
When a delete config comes through, don't reschedule polling for the …

### DIFF
--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -708,7 +708,7 @@ noit_poller_process_check_conf(mtev_conf_section_t section) {
     mtevL(noit_error, "Check config seq backwards, ignored\n");
     if(found) noit_check_log_delete((noit_check_t *)vcheck);
   }
-  else {
+  else if (!deleted) {
     noit_poller_schedule(target, module, name, filterset, options,
                          moptions_used ? moptions : NULL,
                          period, timeout, oncheck[0] ? oncheck : NULL,


### PR DESCRIPTION
…check, just leave it descheduled.. the recycle sweep will come through and delete it later