### PR TITLE
unlock mutex before update_peer to prevent deadlock

### DIFF
--- a/src/noit_clustering.c
+++ b/src/noit_clustering.c
@@ -681,9 +681,11 @@ attach_to_cluster(mtev_cluster_t *nc) {
   }
   mtev_cluster_node_t *nodeset[MAX_CLUSTER_NODES];
   n = mtev_cluster_get_nodes(my_cluster, nodeset, MAX_CLUSTER_NODES, mtev_false);
+  pthread_mutex_unlock(&noit_peer_lock);
   for(i=0; i<n; i++) {
     update_peer(nodeset[i]);
   }
+  pthread_mutex_lock(&noit_peer_lock);
   clear_old_peers();
   pthread_mutex_unlock(&noit_peer_lock);
   eventer_jobq_set_min_max(repl_jobq, 0, i);


### PR DESCRIPTION
```(gdb) bt
#0  0x00007f327a8c451d in __lll_lock_wait () from /lib64/libpthread.so.0
#1  0x00007f327a8bfe1b in _L_lock_812 () from /lib64/libpthread.so.0
#2  0x00007f327a8bfce8 in pthread_mutex_lock () from /lib64/libpthread.so.0
#3  0x000000000058c774 in noit_cluster_mark_filter_changed (name=0x6020000addf0 "allowall",
    vpeer=0x60f00000c610) at noit_clustering.c:220
#4  0x00000000005ae439 in noit_filtersets_build_cluster_changelog (vpeer=0x60f00000c610) at noit_filters.c:804
#5  0x000000000059229e in noit_peer_rebuild_changelog (peer=0x60f00000c610) at noit_clustering.c:190
#6  0x00000000005913cc in update_peer (node=0x614000020860) at noit_clustering.c:644
#7  0x0000000000590366 in attach_to_cluster (nc=0x6110000dc920) at noit_clustering.c:685
#8  0x000000000058ff05 in cluster_topo_cb (closure=0x0, node_changes=2 '\002', updated_node=0x614000020860,
    cluster=0x6110000dc920, old_boot_time=...) at noit_clustering.c:724
#9  0x00007f32791e56af in mtev_cluster_handle_node_update_hook_invoke (
    node_change=node_change@entry=2 '\002', updated_node=updated_node@entry=0x614000020860,
    cluster=cluster@entry=0x6110000dc920, old_boot_time=...) at mtev_cluster.c:142
#10 0x00007f32791e58e0 in mtev_cluster_on_node_changed (cluster=0x6110000dc920, sender=0x614000020860,
    new_boot_time=<optimized out>, seq=<optimized out>, node_change=<optimized out>) at mtev_cluster.c:278
#11 0x00007f32791e64de in mtev_cluster_info_process (msg=0x2, len=128, c=0x6110000dc920) at mtev_cluster.c:441
#12 0x00007f3279210148 in mtev_net_heartbeat_handler (e=<optimized out>, mask=<optimized out>,
    closure=0x60c000022300, now=<optimized out>) at mtev_net_heartbeat.c:163
#13 0x00007f32792336b1 in eventer_run_callback (n=0x7ffe37c667d0, c=<optimized out>, m=1, e=0x6080013c13a0)
    at ../src/eventer/eventer_impl_private.h:202
#14 eventer_epoll_impl_trigger (e=0x6080013c13a0, mask=1) at eventer/eventer_epoll_impl.c:367
#15 0x00007f327923414f in eventer_epoll_impl_loop (id=<optimized out>) at eventer/eventer_epoll_impl.c:519
#16 0x00007f327922e20f in thrloopwrap (vid=0x0) at eventer/eventer_impl.c:624
#17 0x0000000000536aa8 in child_main () at noitd.c:303
#18 0x00007f32791e2231 in mtev_main (appname=<optimized out>, config_filename=<optimized out>,
    debug=<optimized out>, foreground=<optimized out>, lock=<optimized out>, _glider=<optimized out>,
    drop_to_user=0x0, drop_to_group=0x0, passed_child_main=0x535900 <child_main>) at mtev_main.c:506
#19 0x00000000005358f8 in main (argc=4, argv=0x7ffe37c68528) at noitd.c:325```

Frame 7 locks the mutex, frame 3 locks it again.