### PR TITLE
Auto hist

### DIFF
--- a/src/modules-lua/noit/module/resmon.lua
+++ b/src/modules-lua/noit/module/resmon.lua
@@ -153,6 +153,8 @@ function set_check_metric(check, name, type, value)
         check.metric_double(name, value)
     elseif type == 's' then
         check.metric_string(name, value)
+    elseif type == 'h' then
+        check.metric_histogram(name, value)
     else
         check.metric(name, value)
     end

--- a/src/modules/histogram.c
+++ b/src/modules/histogram.c
@@ -630,7 +630,7 @@ histogram_stats_populate_json_impl(void *closure, struct mtev_json_object *doc, 
       MJ_KV(v, "_value", MJ_NULL());
     }
   }
-
+  return MTEV_HOOK_CONTINUE;
 }
 static int
 histogram_init(mtev_dso_generic_t *self) {

--- a/src/modules/histogram.c
+++ b/src/modules/histogram.c
@@ -386,7 +386,7 @@ histogram_metric(void *closure, noit_check_t *check, metric_t *m) {
         break;
     }
   }
-  return MTEV_HOOK_CONTINUE;
+  return MTEV_HOOK_DONE;
 }
 static mtev_hook_return_t
 histogram_hook_impl(void *closure, noit_check_t *check, stats_t *stats,
@@ -403,7 +403,8 @@ histogram_hook_impl(void *closure, noit_check_t *check, stats_t *stats,
     return MTEV_HOOK_CONTINUE;
 
   histogram_metric(closure, check, m);
-  return MTEV_HOOK_CONTINUE;
+  mtevL(mtev_error, "HERE with '%s'\n", m->metric_name);
+  return MTEV_HOOK_DONE;
 }
 
 static void
@@ -461,7 +462,7 @@ histogram_hook_special_impl(void *closure, noit_check_t *check, stats_t *stats,
     return MTEV_HOOK_CONTINUE;
 
   histogram_metric_hformat(closure, check, stats, metric_name, type, v);
-  return MTEV_HOOK_CONTINUE;
+  return MTEV_HOOK_DONE;
 }
 
 static void

--- a/src/modules/histogram.c
+++ b/src/modules/histogram.c
@@ -427,6 +427,10 @@ histogram_metric_hformat(void *closure,
                          &vht)) {
     ht = calloc(1, sizeof(*ht));
     vht = ht;
+    ht->cadence = check->period/1000;
+    if(ht->cadence < 1) ht->cadence = 1;
+    if(ht->cadence > 60) ht->cadence = 60;
+    ht->secs = calloc(ht->cadence, sizeof(*ht->secs));
     mtev_hash_store(metrics, strdup(metric_name), strlen(metric_name),
                     vht);
   }

--- a/src/modules/lua_check.c
+++ b/src/modules/lua_check.c
@@ -500,6 +500,32 @@ noit_lua_set_metric_f(lua_State *L, mtev_boolean allow_whence,
 }
 
 static int
+noit_lua_set_metric_histogram(lua_State *L) {
+  noit_check_t *check;
+  const char *metric_name;
+  struct timeval whence = { 0UL, 0UL };
+
+  double __n = 0.0;
+  int32_t __i = 0;
+  uint32_t __I = 0;
+  int64_t __l = 0;
+  uint64_t __L = 0;
+
+  if(lua_gettop(L) < 2 || lua_gettop(L) > 4) luaL_error(L, "need 2-4 arguments: <metric_name> <value> [whence_s] [whence_us]");
+  check = lua_touserdata(L, lua_upvalueindex(1));
+  if(!lua_isstring(L, 1)) luaL_error(L, "argument #1 must be a string");
+  metric_name = lua_tostring(L, 1);
+
+  if(lua_isnil(L, 2)) {
+    lua_pushboolean(L, 1);
+    return 1;
+  }
+  noit_stats_set_metric_histogram(check, metric_name, METRIC_GUESS, (void *)lua_tostring(L,2));
+  lua_pushboolean(L, 1);
+  return 1;
+}
+
+static int
 noit_lua_set_histo_metric(lua_State *L) {
   noit_check_t *check;
   const char *metric_name;
@@ -708,6 +734,10 @@ noit_check_index_func(lua_State *L) {
       else IF_METRIC_BLOCK("metric_int64", METRIC_INT64)
       else IF_METRIC_BLOCK("metric_uint64", METRIC_UINT64)
       else IF_METRIC_BLOCK("metric_double", METRIC_DOUBLE)
+      else if(!strcmp(k, "metric_histogram")) {
+        lua_pushlightuserdata(L, check);
+        lua_pushcclosure(L, noit_lua_set_metric_histogram, 1);
+      }
       else if(!strcmp(k, "metric_json")) {
         lua_pushlightuserdata(L, check);
         lua_pushcclosure(L, noit_lua_set_metric_json, 1);

--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -140,6 +140,12 @@ MTEV_HOOK_IMPL(noit_check_stats_populate_json,
   (void *closure, struct mtev_json_object *doc, noit_check_t *check, stats_t *s, const char *name),
   (closure, doc, check, s, name));
 
+MTEV_HOOK_IMPL(noit_check_stats_populate_xml,
+  (xmlNodePtr doc, noit_check_t *check, stats_t *s, const char *name),
+  void *, closure,
+  (void *closure, xmlNodePtr doc, noit_check_t *check, stats_t *s, const char *name),
+  (closure, doc, check, s, name));
+
 MTEV_HOOK_IMPL(noit_stats_log_immediate_metric_timed,
   (noit_check_t *check, const char *metric_name, metric_type_t type, const void *value, const struct timeval *whence),
   void *, closure,

--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -489,4 +489,9 @@ MTEV_HOOK_PROTO(noit_check_stats_populate_json,
                 void *, closure,
                 (void *closure, struct mtev_json_object *doc, noit_check_t *check, stats_t *s, const char *name));
 
+MTEV_HOOK_PROTO(noit_stats_log_immediate_metric_timed,
+                (noit_check_t *check, const char *metric_name, metric_type_t type, const void *value, const struct timeval *whence),
+                void *, closure,
+                (void *closure, noit_check_t *check, const char *metric_name, metric_type_t type, const void *value, const struct timeval *whence));
+
 #endif

--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -489,6 +489,11 @@ MTEV_HOOK_PROTO(noit_check_stats_populate_json,
                 void *, closure,
                 (void *closure, struct mtev_json_object *doc, noit_check_t *check, stats_t *s, const char *name));
 
+MTEV_HOOK_PROTO(noit_check_stats_populate_xml,
+                (xmlNodePtr doc, noit_check_t *check, stats_t *s, const char *name),
+                void *, closure,
+                (void *closure, xmlNodePtr doc, noit_check_t *check, stats_t *s, const char *name));
+
 MTEV_HOOK_PROTO(noit_stats_log_immediate_metric_timed,
                 (noit_check_t *check, const char *metric_name, metric_type_t type, const void *value, const struct timeval *whence),
                 void *, closure,

--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -312,6 +312,11 @@ API_EXPORT(void)
                                const char *);
 
 API_EXPORT(void)
+  noit_stats_set_metric_histogram(noit_check_t *check,
+                                  const char *name, metric_type_t t,
+                                  void *value);
+
+API_EXPORT(void)
   noit_stats_log_immediate_metric(noit_check_t *check,
                                   const char *name, metric_type_t type,
                                   const void *value);
@@ -473,5 +478,15 @@ MTEV_HOOK_PROTO(check_deleted,
                 (noit_check_t *check),
                 void *, closure,
                 (void *closure, noit_check_t *check));
+
+MTEV_HOOK_PROTO(check_stats_set_metric_histogram,
+                (noit_check_t *check, metric_t *m),
+                void *, closure,
+                (void *closure, noit_check_t *check, metric_t *m));
+
+MTEV_HOOK_PROTO(noit_check_stats_populate_json,
+                (struct mtev_json_object *doc, noit_check_t *check, stats_t *s, const char *name),
+                void *, closure,
+                (void *closure, struct mtev_json_object *doc, noit_check_t *check, stats_t *s, const char *name));
 
 #endif

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -186,7 +186,7 @@ noit_check_state_as_xml(noit_check_t *check, int full) {
 }
 
 static struct json_object *
-stats_to_json(stats_t *c, mtev_hash_table *supp) {
+stats_to_json(noit_check_t *check, stats_t *c, const char *name, mtev_hash_table *supp) {
   struct json_object *doc;
   doc = json_object_new_object();
   mtev_hash_table *metrics;
@@ -194,6 +194,8 @@ stats_to_json(stats_t *c, mtev_hash_table *supp) {
   const char *k;
   int klen;
   void *data;
+
+  noit_check_stats_populate_json_hook_invoke(doc, check, c, name);
 
   metrics = noit_check_stats_metrics(c);
   while(mtev_hash_next(metrics, &iter, &k, &klen, &data)) {
@@ -317,7 +319,7 @@ noit_check_state_as_json(noit_check_t *check, int full) {
   
       t = noit_check_stats_whence(c, NULL);
       if(t->tv_sec) {
-        json_object_object_add(metrics, "current", stats_to_json(c, supp));
+        json_object_object_add(metrics, "current", stats_to_json(check, c, "current", supp));
         snprintf(timestr, sizeof(timestr), "%llu%03d",
                  (unsigned long long int)t->tv_sec, (int)(t->tv_usec / 1000));
         json_object_object_add(metrics, "current_timestamp", json_object_new_string(timestr));
@@ -326,7 +328,7 @@ noit_check_state_as_json(noit_check_t *check, int full) {
       c = noit_check_get_stats_inprogress(check);
       t = noit_check_stats_whence(c, NULL);
       if(t->tv_sec) {
-        json_object_object_add(metrics, "inprogress", stats_to_json(c, supp));
+        json_object_object_add(metrics, "inprogress", stats_to_json(check, c, "inprogress", supp));
         snprintf(timestr, sizeof(timestr), "%llu%03d",
                  (unsigned long long int)t->tv_sec, (int)(t->tv_usec / 1000));
         json_object_object_add(metrics, "inprogress_timestamp", json_object_new_string(timestr));
@@ -335,7 +337,7 @@ noit_check_state_as_json(noit_check_t *check, int full) {
       c = noit_check_get_stats_previous(check);
       t = noit_check_stats_whence(c, NULL);
       if(t->tv_sec) {
-        json_object_object_add(metrics, "previous", stats_to_json(c, supp));
+        json_object_object_add(metrics, "previous", stats_to_json(check, c, "previous", supp));
         snprintf(timestr, sizeof(timestr), "%llu%03d",
                  (unsigned long long int)t->tv_sec, (int)(t->tv_usec / 1000));
         json_object_object_add(metrics, "previous_timestamp", json_object_new_string(timestr));

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -167,16 +167,19 @@ noit_check_state_as_xml(noit_check_t *check, int full) {
       }
       xmlAddChild(state, (metrics = xmlNewNode(NULL, (xmlChar *)"metrics")));
   
+      noit_check_stats_populate_xml_hook_invoke(metrics, check, noit_check_get_stats_inprogress(check), "inprogress");
       add_metrics_to_node(noit_check_get_stats_inprogress(check), metrics, "inprogress", 0, supp);
       whence = noit_check_stats_whence(c, NULL);
       if(whence->tv_sec) {
         xmlAddChild(state, (metrics = xmlNewNode(NULL, (xmlChar *)"metrics")));
+        noit_check_stats_populate_xml_hook_invoke(metrics, check, c, "current");
         add_metrics_to_node(c, metrics, "current", 1, supp);
       }
       previous = noit_check_get_stats_previous(check);
       whence = noit_check_stats_whence(previous, NULL);
       if(whence->tv_sec) {
         xmlAddChild(state, (metrics = xmlNewNode(NULL, (xmlChar *)"metrics")));
+        noit_check_stats_populate_xml_hook_invoke(metrics, check, previous, "previous");
         add_metrics_to_node(previous, metrics, "previous", 1, supp);
       }
       if(supp) mtev_hash_destroy(supp, NULL, NULL);

--- a/test/busted/checks_data/httptrap/httptrap_spec.lua
+++ b/test/busted/checks_data/httptrap/httptrap_spec.lua
@@ -3,7 +3,7 @@ describe("noit", function()
   setup(function()
     Reconnoiter.clean_workspace()
     noit = Reconnoiter.TestNoit:new("trap", {
-      modules = { httptrap = { image = "httptrap" } }
+      modules = { httptrap = { image = "httptrap", config = { asynch_metrics = "true" } } }
     })
   end)
   teardown(function() if noit ~= nil then noit:stop() end end)
@@ -43,13 +43,13 @@ describe("noit", function()
   expected_stats["array`2"] = { _type = "s", _value = "string" }
   expected_stats["array`3"] = { _type = "s", _value = "100" }
   expected_stats["array`4"] = { _type = "n", _value = "1.844674407371e+19" }
-  expected_stats["explicit_histogram"] = { _type = "n", _value = "1.500000000000e+00" }
-  expected_stats["implicit_histogram"] = { _type = "h", _value = {
+  expected_stats["explicit_histogram"] = { _type = "h", _value = {
       'H[+10e-001]=1',
       'H[+20e-001]=1',
       'H[+30e-001]=1',
       'H[+40e-001]=120'
   } }
+  expected_stats["implicit_histogram"] = expected_stats["explicit_histogram"]
   expected_stats["lvl1`lvl2`boolean"] = { _type = "i", _value = "1" }
 
   it("should start", function()
@@ -105,7 +105,7 @@ describe("noit", function()
             end
           end
         end
-        if metrics.implicit_histogram ~= nil then break end
+        if metrics.implicit_histogram ~= nil and metrics.explicit_histogram ~= nil then break end
       end
       assert.is.same(expected_stats, metrics)
     end)

--- a/test/busted/checks_data/httptrap/httptrap_spec.lua
+++ b/test/busted/checks_data/httptrap/httptrap_spec.lua
@@ -1,0 +1,113 @@
+describe("noit", function()
+  local noit, api
+  setup(function()
+    Reconnoiter.clean_workspace()
+    noit = Reconnoiter.TestNoit:new("trap", {
+      modules = { httptrap = { image = "httptrap" } }
+    })
+  end)
+  teardown(function() if noit ~= nil then noit:stop() end end)
+
+  local uuid = mtev.uuid()
+  local check_xml =
+[=[<?xml version="1.0" encoding="utf8"?>
+<check>
+  <attributes>
+    <target>127.0.0.1</target>
+    <period>1000</period>
+    <timeout>500</timeout>
+    <name>httptrap</name>
+    <filterset>allowall</filterset>
+    <module>httptrap</module>
+  </attributes>
+  <config xmlns:histogram="noit://module/histogram">
+    <secret>foofoo</secret>
+    <histogram:value name="explicit_histogram">add</histogram:value>
+  </config>
+</check>]=]
+
+  local payload = [=[{
+    "array": [ 1, 1.2, "string", { "_type": "s", "_value": "100" },
+               { "_type": "L", "_value": 18446744073709551614 } ],
+    "lvl1": {
+      "lvl2": {
+        "boolean": true
+      }
+    },
+    "explicit_histogram": { "_type": "n", "_value": [ 1,2,3,"H[4]=120" ] },
+    "implicit_histogram": { "_type": "h", "_value": [ "H[4]=120", 3, 2, 1 ] }
+  }]=]
+  local expected_stats = {}
+  expected_stats["array`0"] = { _type = "L", _value = "1" }
+  expected_stats["array`1"] = { _type = "n", _value = "1.200000000000e+00" }
+  expected_stats["array`2"] = { _type = "s", _value = "string" }
+  expected_stats["array`3"] = { _type = "s", _value = "100" }
+  expected_stats["array`4"] = { _type = "n", _value = "1.844674407371e+19" }
+  expected_stats["explicit_histogram"] = { _type = "n", _value = "1.500000000000e+00" }
+  expected_stats["implicit_histogram"] = { _type = "h", _value = {
+      'H[+10e-001]=1',
+      'H[+20e-001]=1',
+      'H[+30e-001]=1',
+      'H[+40e-001]=120'
+  } }
+  expected_stats["lvl1`lvl2`boolean"] = { _type = "i", _value = "1" }
+
+  it("should start", function()
+    assert.is_true(noit:start():is_booted())
+    api = noit:API()
+  end)
+
+  describe("httptrap", function()
+    local key = noit:watchfor(mtev.pcre('H1\t'), true)
+    it("put", function()
+      local code, doc = api:raw("PUT", "/checks/set/" .. uuid, check_xml)
+      assert.is.equal(200, code)
+    end)
+    it("rejects payload", function()
+      local code, doc = api:json("POST", "/module/httptrap/" .. uuid .. "/nopenope", payload)
+      assert.is.not_equal(200, code)
+    end)
+    it("accepts payload", function()
+      local code, doc, raw = api:json("POST", "/module/httptrap/" .. uuid .. "/foofoo", payload)
+      assert.is.equal(200, code)
+    end)
+    it("has matching H1 records", function()
+      local record = {}
+      local rparts = {}
+      local keys = {}
+      -- split by \t, make sure we have the parts, and track #4 as the metric name
+      for i=1,2 do
+        record[i] = noit:waitfor(key, 2)
+        assert.is_not_nil(record[i])
+        rparts[i] = record[i]:split('\t')
+        assert.is_not_nil(rparts[i][4])
+        assert.is_not_nil(rparts[i][5])
+        keys[rparts[i][4]] = true
+      end
+      assert.is.same({ explicit_histogram = true, implicit_histogram = true }, keys)
+      -- the histograms should be the same.
+      assert.is.equal(rparts[1][5], rparts[2][5])
+    end)
+    it("is reporting", function()
+      local metrics = {}
+      -- we need to line this up to fire right after an aligned 1s boundary b/c
+      -- the histogram stats will roll 
+      for i=1,10 do
+        local code, doc, raw = api:json("POST", "/module/httptrap/" .. uuid .. "/foofoo", payload)
+        assert.is.equal(200, code)
+        mtev.sleep(1.1)
+        local code, doc = api:json("GET", "/checks/show/" .. uuid .. ".json")
+        assert.is.equal(200, code)
+        for i, key in ipairs({ 'previous', 'current', 'inprogress' }) do
+          if doc.metrics[key] ~= nil then
+            for k,v in pairs(doc.metrics[key]) do
+              metrics[k] = v
+            end
+          end
+        end
+        if metrics.implicit_histogram ~= nil then break end
+      end
+      assert.is.same(expected_stats, metrics)
+    end)
+  end)
+end)

--- a/test/busted/lua-support/reconnoiter.lua
+++ b/test/busted/lua-support/reconnoiter.lua
@@ -272,13 +272,14 @@ function TestConfig:make_logs_config(fd, opts)
   "  <feeds>\n" ..
   "    <config><extended_id>on</extended_id></config>\n" ..
   "    <outlet name=\"feed\"/>\n" ..
+  "    <log name=\"config\"/>\n" ..
+  "    <also>\n" ..
+  "    <outlet name=\"error\"/>\n" ..
   "    <log name=\"bundle\"/>\n" ..
-  "    <log name=\"check\">\n" ..
-  "      <outlet name=\"error\"/>\n" ..
-  "    </log>\n" ..
+  "    <log name=\"check\"/>\n" ..
   "    <log name=\"status\"/>\n" ..
   "    <log name=\"metrics\"/>\n" ..
-  "    <log name=\"config\"/>\n" ..
+  "    </also>\n" ..
   "  </feeds>\n" ..
   "</logs>\n")
 end


### PR DESCRIPTION
support _type: 'h' as a histogram type that bypassed complex a priori configuration requirements.

A priori configuration requirements still work.

The httptrap submission and lua extensions are tested.  The resmon-style pull stuff is not tested.