### PR TITLE
Support NOIT_MODULES environment variable.

### DIFF
--- a/src/noit_module.c
+++ b/src/noit_module.c
@@ -281,7 +281,7 @@ void noit_module_init() {
     if(module_match) {
       int ovector[30];
       if(pcre_exec(module_match, NULL, module_name, strlen(module_name), 0, 0, ovector, 30) < 0) {
-        mtevL(mtev_notice, "skipping check module '%s' due to NOIT_MODULES.\n", module_name);
+        mtevL(mtev_notice, "skipping noit module '%s' due to NOIT_MODULES env var.\n", module_name);
         continue;
       }
     }


### PR DESCRIPTION
This variable contains a PCRE (default `.`) that will be
applied to each noit check module.  Module (names) that do
not match this regular expression will be skipped.

For example `NOIT_MODULES="^(selfcheck|prometheus)"` will only
load modules starting with `selfcheck` or `prometheus`.