### PR TITLE
Fix escape function to work with spaces

### DIFF
--- a/src/modules-lua/noit/AWSClient.lua
+++ b/src/modules-lua/noit/AWSClient.lua
@@ -131,10 +131,9 @@ function orderedPairs(t)
 end
 
 function escape(s)
-  s = string.gsub(s, "([%%,:/&=+%c])", function (c)
+  s = string.gsub(s, "([%%,:/&=+%c%s])", function (c)
     return string.format("%%%02X", string.byte(c))
   end)
-  s = string.gsub(s, " ", "%20")
   return s
 end
 


### PR DESCRIPTION
With a space in the metric name (or anything passed to escape) lua
would generate an error: "invalid capture index"

The fix is to just pull the %s into the first gsub and then remove
the second that looks for just spaces since they will ne taken care
of