### PR TITLE
Fix sloppy polls_by_name maintenance.

### DIFF
--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -218,7 +218,7 @@ API_EXPORT(int)
   noit_check_activate(noit_check_t *check);
 
 API_EXPORT(int)
-  noit_poller_deschedule(uuid_t in, mtev_boolean log);
+  noit_poller_deschedule(uuid_t in, mtev_boolean log, mtev_boolean readding);
 
 API_EXPORT(noit_check_t *)
   noit_poller_lookup(uuid_t in);

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -899,7 +899,7 @@ rest_delete_check(mtev_http_rest_closure_t *restc,
   /* delete this here */
   mtev_boolean just_mark = mtev_false;
   if(check)
-    if(!noit_poller_deschedule(check->checkid, mtev_true))
+    if(!noit_poller_deschedule(check->checkid, mtev_true, mtev_false))
       just_mark = mtev_true;
   if(just_mark) {
     int64_t newseq = noit_conf_check_bump_seq(node);

--- a/src/noit_conf_checks.c
+++ b/src/noit_conf_checks.c
@@ -699,7 +699,7 @@ noit_console_config_nocheck(mtev_console_closure_t ncct,
         CONF_DIRTY(mtev_conf_section_from_xmlnodeptr(node));
       } else {
         nc_printf(ncct, "descheduling %s\n", uuid_conf);
-        if(noit_poller_deschedule(checkid, mtev_true)) {
+        if(noit_poller_deschedule(checkid, mtev_true, mtev_false)) {
           CONF_REMOVE(mtev_conf_section_from_xmlnodeptr(node));
           xmlUnlinkNode(node);
           removed = mtev_true;

--- a/test/busted/run-tests.sh
+++ b/test/busted/run-tests.sh
@@ -3,6 +3,15 @@
 PATH=$PATH:/opt/circonus/bin:/opt/pgsql9214/bin
 export PATH
 
+if [ -f /opt/llvm-5.0.0/bin/llvm-symbolizer ]
+then
+  export ASAN_SYMBOLIZER_PATH=/opt/llvm-5.0.0/bin/llvm-symbolizer
+else
+  export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
+fi
+export ASAN_OPTIONS=detect_leaks=0,alloc_dealloc_mismatch=1
+
+
 DIR=`dirname $0`
 LD_LIBRARY_PATH=$DIR/../../src
 export LD_LIBRARY_PATH

--- a/test/busted/simple/delete/delete_spec.lua
+++ b/test/busted/simple/delete/delete_spec.lua
@@ -6,9 +6,11 @@ describe("noit", function()
   end)
   teardown(function() if noit ~= nil then noit:stop() end end)
 
-  local uuid = mtev.uuid()
+  local check_cnt = 50
+  local uuid = {}
+  for i = 1,check_cnt do uuid[i] = mtev.uuid() end
   local gseq = 0
-  local check_xml = function()
+  local check_xml = function(i)
     gseq = gseq + 2
     local id = "foo_" .. gseq
     return
@@ -19,7 +21,7 @@ describe("noit", function()
     <target>]=] .. id .. [=[</target>
     <period>1000</period>
     <timeout>500</timeout>
-    <name>thisisauniquename_]=] .. id .. [=[</name>
+    <name>thisisauniquename_]=] .. tostring(i) .. [=[</name>
     <filterset>allowall</filterset>
     <module>http</module>
   </attributes>
@@ -35,42 +37,37 @@ describe("noit", function()
 
   describe("check", function()
     it("is not present", function()
-      local code = api:json("GET", "/checks/show/" .. uuid .. ".json")
-      assert.is.equal(404, code)
+      for i = 1,check_cnt do
+        local code = api:json("GET", "/checks/show/" .. uuid[i] .. ".json")
+        assert.is.equal(404, code)
+      end
     end)
     it("adds", function()
-      local code, doc = api:raw("PUT", "/checks/set/" .. uuid, check_xml())
-      assert.is.equal(200, code)
+      for i = 1,check_cnt do
+        local code, doc = api:raw("PUT", "/checks/set/" .. uuid[i], check_xml(i))
+        assert.is.equal(200, code)
+      end
     end)
     it("is present", function()
-      local code, doc = api:json("GET", "/checks/show/" .. uuid .. ".json")
-      assert.is.equal(200, code)
-    end)
-  end)
-
-  describe("check", function()
-    it("deletes", function()
-      local code, doc = api:raw("DELETE", "/checks/delete/" .. uuid)
-      assert.is.equal(200, code)
-    end)
-    it("is not present", function()
-      local code, doc, data = api:json("GET", "/checks/show/" .. uuid .. ".json")
-      assert.is_true(code == 404 or bit.band(doc.flags, tonumber("80", 16)) ~= 0)
+      for i = 1,check_cnt do
+        local code, doc = api:json("GET", "/checks/show/" .. uuid[i] .. ".json")
+        assert.is.equal(200, code)
+      end
     end)
   end)
 
   describe("check", function()
     it("tortures w/o delete", function()
       for i=1,100,1 do
-        local code, doc, data = api:raw("PUT", "/checks/set/" .. uuid, check_xml())
+        local code, doc, data = api:raw("PUT", "/checks/set/" .. uuid[8], check_xml(8))
         assert.is.equal(200, code)
       end
     end)
     it("tortures w delete", function()
       for i=1,100,1 do
-        local code, doc = api:raw("PUT", "/checks/set/" .. uuid, check_xml())
+        local code, doc = api:raw("PUT", "/checks/set/" .. uuid[8], check_xml(8))
         assert.is.equal(200, code)
-        code, doc = api:raw("DELETE", "/checks/delete/" .. uuid)
+        code, doc = api:raw("DELETE", "/checks/delete/" .. uuid[8])
         assert.is.equal(200, code)
       end
     end)


### PR DESCRIPTION
 * target_ip was modified while node was in list.
 * target was modified while node was in list.
 * removals were skipped for sequenced checks
   (which should be done if the check will be readded)