### PR TITLE
If tag cat:val is too long truncate uniquely.

### DIFF
--- a/src/modules/graphite.c
+++ b/src/modules/graphite.c
@@ -596,7 +596,11 @@ static int noit_graphite_initiate_check(noit_module_t *self,
                           (const char **)&config_val)) {
       port = atoi(config_val);
     }
-    ccl->port = port;
+
+    /* Skip setting the port for the tls variant, it works differently */
+    if(strcmp(check->module, "graphite_tls")) {
+      ccl->port = port;
+    }
 
     if(mtev_hash_retr_str(check->config, "rows_per_cycle",
                           strlen("rows_per_cycle"),

--- a/src/noit.conf.in
+++ b/src/noit.conf.in
@@ -85,7 +85,8 @@
     <module image="dns" name="dns"/>
     <module image="httptrap" name="httptrap"/>
     <module image="prometheus" name="prometheus"/>
-    <module image="graphite" name="graphite"/>
+    <module image="graphite" name="graphite_tls"/>
+    <module image="graphite" name="graphite_plain"/>
     <module image="statsd" name="statsd"/>
     <module image="collectd" name="collectd"/>
     <module image="ganglia" name="ganglia"/>
@@ -162,10 +163,9 @@
       <ip_acl:global/>
     </config>
     <check uuid="f7cea020-f19d-11dd-85a6-cb6d3a2207dc" module="selfcheck" target="127.0.0.1" period="5000" timeout="4000"/>
-    <check uuid="4dd07e4a-1fe8-42cf-97c4-62e31fab8141" module="graphite" target="none" period="60000" timeout="55000">
+    <check uuid="4dd07e4a-1fe8-42cf-97c4-62e31fab8141" module="graphite_tls" target="none" period="60000" timeout="55000">
       <config>
         <secret>dddd</secret>
-        <listen_port>0</listen_port>
       </config>
     </check>
     <check uuid="d71484e7-73d3-4dad-a5f7-88879ef43225" module="httptrap" target="127.0.0.1" period="60000" timeout="4000">

--- a/src/noit_message_decoder.c
+++ b/src/noit_message_decoder.c
@@ -400,6 +400,7 @@ noit_metric_tags_parse_one(const char *tagnm, size_t tagnmlen,
                            noit_metric_tag_t *output, mtev_boolean *toolong) {
   size_t colon_pos = 0;
   size_t cur_size = 0;
+  *toolong = mtev_false;
   while(cur_size < tagnmlen) {
     char test_char = tagnm[cur_size];
     if(test_char == ':' && !colon_pos) {

--- a/src/noit_metric.c
+++ b/src/noit_metric.c
@@ -703,7 +703,6 @@ noit_metric_canonicalize(const char *input, size_t input_len, char *output, size
   int n_stags = 0, n_mtags = 0;
   char buff[MAX_METRIC_TAGGED_NAME];
   if(output_len < input_len) return -1;
-  if(input_len > MAX_METRIC_TAGGED_NAME) return -2;
   if(input != output) memcpy(output, input, input_len);
 
   for(i=0; i<input_len; i++) ntags += (input[i] == ',');
@@ -719,7 +718,6 @@ noit_metric_canonicalize(const char *input, size_t input_len, char *output, size
   decode_tags(mtags, n_mtags);
   n_stags = tags_sort_dedup(stags, n_stags);
   n_mtags = tags_sort_dedup(mtags, n_mtags);
-  if(output_len > MAX_METRIC_TAGGED_NAME) output_len = MAX_METRIC_TAGGED_NAME;
 
   /* write to buff then copy to allow for output and input to be the same */
   char *out = buff;
@@ -747,5 +745,6 @@ noit_metric_canonicalize(const char *input, size_t input_len, char *output, size
   }
   memcpy(output, buff, (out-buff));
   if(null_term) output[out-buff] = '\0';
+  if((out-buff) > MAX_METRIC_TAGGED_NAME) return -8;
   return (out - buff);
 }

--- a/src/noit_metric.h
+++ b/src/noit_metric.h
@@ -80,6 +80,8 @@ typedef enum {
 } noit_message_type;
 
 #define NOIT_TAG_MAX_PAIR_LEN 256
+/* category_size is uint8_t (255), but includes the : */
+#define NOIT_TAG_MAX_CAT_LEN  254
 
 typedef struct {
   uint16_t total_size;

--- a/src/noit_metric_private.h
+++ b/src/noit_metric_private.h
@@ -36,7 +36,7 @@
 
 API_EXPORT(const char *)
   noit_metric_tags_parse_one(const char *tagnm, size_t tagnmlen,
-                             noit_metric_tag_t *output);
+                             noit_metric_tag_t *output, mtev_boolean *toolong);
 
 static inline int
 noit_metric_tags_compare(const void *v_l, const void *v_r) {

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -36,7 +36,7 @@ check:	all
 # This stuff if all cert stuff to make testing the daemons easier
 
 test_tags:	test_tags.c
-	$(CC) -g -o test_tags -I../src $(CPPFLAGS) $(CFLAGS) -I$(MTEV_INCLUDEDIR) test_tags.c -L../src -lnoit
+	$(CC) -g -o test_tags -I../src $(CPPFLAGS) $(CFLAGS) -I$(MTEV_INCLUDEDIR) test_tags.c -L../src -lnoit $(LDFLAGS) -lmtev
 
 others:
 	$(MAKE) -C ../src tests

--- a/test/busted/libnoit/tags_spec.lua
+++ b/test/busted/libnoit/tags_spec.lua
@@ -1,7 +1,7 @@
 local system = run_command_synchronously_return_output
 describe("tags", function()
   it("should run test_tags", function()
-    local rv, out, err = system({ argv = { "../test_tags" } })
+    local rv, out, err = system({ env = { "LD_PRELOAD=../../src/libnoit.so" }, argv = { "../test_tags" } })
     if rv ~= 0 then
       print(out) print(err)
     end


### PR DESCRIPTION
This determines if the cat:val is too long and
uses a hueristic to size them appropriately and
replace with the largest possible prefix and a
suffix of _tldr_<sha1_hex> of the original cat
or val.