### PR TITLE
mkversion.sh should detect detached HEAD state

### DIFF
--- a/buildtools/mkversion.sh
+++ b/buildtools/mkversion.sh
@@ -6,7 +6,10 @@ if [ $? -eq 0 ]; then
   HASH=`git show --format=%H | head -1`
   TSTAMP=`git show --format=%at | head -1`
   echo "    * version -> $HASH"
-  SYM=`git name-rev $HASH | awk '{print $2;}' | sed -e 's/\^.*//'`
+  SYM=`git symbolic-ref -q HEAD | awk -F'/' '{ print $NF }'`
+  if [ -z "$SYM" ]; then
+    SYM="detached"
+  fi
   if [ -z "`echo $SYM | grep '^tags/'`" ]; then
     SYM="branches/$SYM"
   fi


### PR DESCRIPTION
The value returned by `git name-rev` when in detached-HEAD is
unpredictable and of low value, since it will pick the nearest symbolic
name in lexicographic order, which really does nothing for
communicating "what branch we're on".

Instead, use `git symbolic-ref` to resolve HEAD, and if it's empty,
we must be detached and should just say so.

This solution also works around the lack of a `--short` option to
symbolic-ref in older git versions, so we will still get "master"
instead of "refs/heads/master", for example.