### PR TITLE
Log to */noit log_streams per default

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -127,11 +127,12 @@ LUALIBS=@LUALIBS@
 LIBNOIT_OBJS=noit_check_log_helpers.lo noit_fb.lo bundle.pb-c.lo \
 	noit_check_tools_shared.lo stratcon_ingest.lo noit_metric_rollup.lo \
 	noit_metric_director.lo noit_message_decoder.hlo noit_metric.hlo \
-	noit_metric_tag_search.lo
+	noit_metric_tag_search.lo  noit_mtev_bridge.lo
 
-B2SM_OBJS=noit_b2sm.o noit_check_log_helpers.o bundle.pb-c.o noit_message_decoder.o noit_metric.o
+B2SM_OBJS=noit_b2sm.o noit_mtev_bridge.o noit_check_log_helpers.o bundle.pb-c.o noit_message_decoder.o \
+	noit_metric.o
 
-NOIT_OBJS=noitd.o noit_mtev_bridge.o \
+NOIT_OBJS=noitd.o \
 	noit_check_resolver.o noit_check_log.o \
 	noit_check.o noit_check_tools.o \
 	noit_module.o noit_conf_checks.o noit_clustering.o \
@@ -139,7 +140,7 @@ NOIT_OBJS=noitd.o noit_mtev_bridge.o \
 	noit_check_rest.o noit_filters_rest.o noit_websocket_handler.o \
 	$(LIBNOIT_OBJS:%.lo=%.o)
 
-STRATCON_OBJS=stratcond.o noit_mtev_bridge.o \
+STRATCON_OBJS=stratcond.o \
 	stratcon_realtime_http.o \
 	stratcon_jlog_streamer.o stratcon_datastore.o \
 	stratcon_iep.o \

--- a/src/noit_mtev_bridge.c
+++ b/src/noit_mtev_bridge.c
@@ -31,11 +31,21 @@
 #include <eventer/eventer.h>
 #include <mtev_log.h>
 #include <mtev_console.h>
+#include <noit_mtev_bridge.h>
+
+mtev_log_stream_t noit_error_impl = NULL;
+mtev_log_stream_t noit_notice_impl = NULL;
+mtev_log_stream_t noit_debug_impl = NULL;
 
 static int noit_console_handler(eventer_t e, int mask, void *closure,
                                 struct timeval *now) {
   return mtev_console_handler(e,mask,closure,now);
 }
+
 void noit_mtev_bridge_init() {
+  noit_error_impl = mtev_log_stream_find("error/noit");
+  noit_notice_impl = mtev_log_stream_find("notice/noit");
+  noit_debug_impl = mtev_log_stream_find("debug/noit");
+
   eventer_name_callback("noit_console", noit_console_handler);
 }

--- a/src/noit_mtev_bridge.h
+++ b/src/noit_mtev_bridge.h
@@ -33,9 +33,13 @@
 
 #include <mtev_log.h>
 
-#define noit_debug mtev_debug
-#define noit_error mtev_error
-#define noit_notice mtev_notice
+extern mtev_log_stream_t noit_error_impl;
+extern mtev_log_stream_t noit_notice_impl;
+extern mtev_log_stream_t noit_debug_impl;
+
+#define noit_error ( (noit_error_impl) ? (noit_error_impl) : (mtev_error) )
+#define noit_notice ( (noit_notice_impl) ? (noit_notice_impl) : (mtev_notice) )
+#define noit_debug ( (noit_debug_impl) ? (noit_debug_impl) : (mtev_debug) )
 #define noit_stderr mtev_stderr
 
 API_EXPORT(void)


### PR DESCRIPTION
My debug logs are full of:
```
[2018-11-02 13:39:37.376822] [debug] [t@6853/e:default/7,noit_check.c:2547] q._caql`c_2438_215752::caql <- [OK]
[2018-11-02 13:39:37.376845] [debug] [t@6853/e:default/7,noit_check.c:2552] q._caql`c_2438_215752::caql -> [available:good]
[2018-11-02 13:39:37.392899] [debug] [t@6851/e:default/5,noit_check.c:2547] q._caql`c_2_198461::caql <- [OK]
[2018-11-02 13:39:37.392921] [debug] [t@6851/e:default/5,noit_check.c:2552] q._caql`c_2_198461::caql -> [available:good]
```

This change should give me a way to avoid those.