### PR TITLE
metric_director extensions for lua tag-search

### DIFF
--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -297,7 +297,7 @@ noit_lua_tagset_copy_free(lua_State *L) {
 static int
 noit_lua_tagset_copy_setup(lua_State *L, noit_metric_tagset_t *src_set) {
   noit_metric_tagset_t *dst_set = calloc(1, sizeof(*src_set));
-  memcpy(dst_set, src_set, sizeof(dst_set));
+  memcpy(dst_set, src_set, sizeof(*dst_set));
   noit_metric_tag_t *dst_tags = calloc(src_set->tag_count, sizeof(noit_metric_tag_t));
   memcpy(dst_tags, src_set->tags, src_set->tag_count*sizeof(noit_metric_tag_t));
   dst_set->tags = dst_tags;

--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -71,6 +71,22 @@ lua_noit_checks_unsubscribe(lua_State *L) {
   return lua_noit_checks_adjustsubscribe(L, -1);
 }
 
+mtev_hook_return_t
+hook_metric_subscribe_all(void *closure, noit_metric_message_t *m, int *w, int wlen) {
+  int *lane = (int*) closure;
+  assert(*lane < wlen);
+  w[*lane] = 1;
+  return MTEV_HOOK_CONTINUE;
+}
+
+static int
+lua_noit_metric_subscribe_all(lua_State *L) {
+  int *lane = malloc(sizeof(int));
+  *lane = noit_metric_director_my_lane();
+  metric_director_want_hook_register("metrics_select", hook_metric_subscribe_all, lane);
+  return 0;
+}
+
 static int
 noit_lua_tagset_copy_setup(lua_State *, noit_metric_tagset_t *);
 
@@ -406,6 +422,7 @@ static const luaL_Reg libnoit_binding[] = {
   { "metric_director_next", lua_noit_metric_next },
   { "metric_director_get_messages_received", lua_noit_metric_messages_received },
   { "metric_director_get_messages_distributed", lua_noit_metric_messages_distributed},
+  { "metric_director_subscribe_all", lua_noit_metric_subscribe_all},
   { "tag_parse", lua_noit_tag_parse},
   { "tag_tostring", lua_noit_tag_tostring},
   { "tag_search_parse", lua_noit_tag_search_parse},

--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -167,6 +167,13 @@ static int noit_metric_id_index_func(lua_State *L) {
 
   k = lua_tostring(L, 2);
   switch (*k) {
+    case 'a':
+      if(!strcmp(k, "account_id")){
+        lua_pushinteger(L, metric_id->account_id);
+      } else {
+        break;
+      }
+      return 1;
     case 'i':
       if(!strcmp(k, "id")) {
         char uuid_str[UUID_PRINTABLE_STRING_LENGTH];

--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -105,7 +105,6 @@ static int
 lua_noit_metric_subscribe_all(lua_State *L) {
   int *lane = malloc(sizeof(int));
   *lane = noit_metric_director_my_lane();
-  // Q: Can we register the same hook multiple times (with different closure data)?
   metric_director_want_hook_register("metrics_select", hook_metric_subscribe_all, lane);
   return 0;
 }
@@ -532,13 +531,9 @@ lua_noit_tag_search_eval_message(lua_State *L) {
 
 void
 noit_lua_libnoit_init() {
-  // TODO: Call this once during startup.
-  // I did not find a good place to put this:
-  // - Can't do it from noitd.c: This is a dynamically loaded module.
-  // - Can't do it during module initialization: this is used from the lua_general/lua_web in mtev
-  // - Can't do it during lua state initialization: we have multiple states that get initialized concurrentlya
-  // Also we can't just lock this section with a pthread_mutex: Where should we create the pthread_mutex_t?
-  // Using a spinlock instead, since it does not require initialization
+  // It would be better to call this function once during startup.
+  // However, I did not find a good place to put this, so we are using locks instead,
+  // to ensure this get's called only once.
   ck_spinlock_lock(&noit_lua_libnoit_init_lock);
   if (account_set == NULL) {
     mtev_hash_table *tmp = calloc(1, sizeof(*account_set));

--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -492,6 +492,24 @@ lua_noit_tag_search_eval_string(lua_State *L) {
   return 1;
 }
 
+// Eval tag search query against a metric_message_t
+// param: ast (userdata)
+// param: message (userdata)
+// returns: match (boolean)
+static int
+lua_noit_tag_search_eval_message(lua_State *L) {
+  noit_metric_tag_search_ast_t **ast_ud = (noit_metric_tag_search_ast_t **)
+    luaL_checkudata(L, 1, "noit_metric_tag_search_ast_t");
+  noit_metric_message_t **msg_ud = (noit_metric_message_t **)
+    luaL_checkudata(L, 2, "metric_message_t");
+  noit_metric_message_t *msg = *msg_ud;
+  // evaluate ast against stream tags
+  mtev_boolean ok = noit_metric_tag_search_evaluate_against_tags(*ast_ud, &(msg->id.stream));
+  lua_pushboolean(L, ok);
+  return 1;
+}
+
+
 void
 noit_lua_libnoit_init() {
   // TODO: Call this once during startup.
@@ -527,6 +545,7 @@ static const luaL_Reg libnoit_binding[] = {
   { "tag_search_parse", lua_noit_tag_search_parse},
   { "tag_search_eval", lua_noit_tag_search_eval},
   { "tag_search_eval_string", lua_noit_tag_search_eval_string},
+  { "tag_search_eval_message", lua_noit_tag_search_eval_message},
   { NULL, NULL }
 };
 

--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -71,6 +71,9 @@ lua_noit_checks_unsubscribe(lua_State *L) {
   return lua_noit_checks_adjustsubscribe(L, -1);
 }
 
+static int
+noit_lua_tagset_copy_setup(lua_State *, noit_metric_tagset_t *);
+
 static int noit_metric_id_index_func(lua_State *L) {
   int n;
   const char *k;
@@ -112,6 +115,16 @@ static int noit_metric_id_index_func(lua_State *L) {
         lua_pushinteger(L, metric_id->name_len);
       } else {
         break;
+      }
+      return 1;
+    case 'm':
+      if(!strcmp(k, "mtags")) {
+        noit_lua_tagset_copy_setup(L, &(metric_id->measurement));
+      }
+      return 1;
+    case 's':
+      if(!strcmp(k, "stags")) {
+        noit_lua_tagset_copy_setup(L, &(metric_id->stream));
       }
       return 1;
     default:

--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -312,6 +312,22 @@ noit_lua_tagset_copy_setup(lua_State *L, noit_metric_tagset_t *src_set) {
   return 0;
 }
 
+// Convert a tagset to strings
+// param: tag
+// returns: tag1, tag2, ...
+static int
+lua_noit_tag_tostring(lua_State *L) {
+  noit_metric_tagset_t **udata = (noit_metric_tagset_t **)
+    luaL_checkudata(L, 1, "noit_metric_tagset_t");
+  noit_metric_tagset_t *set = *udata;
+  int cnt = set->tag_count;
+  for (int i=0; i<cnt; i++) {
+    noit_metric_tag_t tag = set->tags[i];
+    lua_pushlstring(L, tag.tag, tag.total_size);
+  }
+  return cnt;
+}
+
 // Parse a metric name to a tagset
 // param: name
 // returns: stags, mtags (userdata)
@@ -378,6 +394,7 @@ static const luaL_Reg libnoit_binding[] = {
   { "metric_director_get_messages_received", lua_noit_metric_messages_received },
   { "metric_director_get_messages_distributed", lua_noit_metric_messages_distributed},
   { "tag_parse", lua_noit_tag_parse},
+  { "tag_tostring", lua_noit_tag_tostring},
   { "tag_search_parse", lua_noit_tag_search_parse},
   { "tag_search_eval", lua_noit_tag_search_eval},
   { "tag_search_eval_string", lua_noit_tag_search_eval_string},

--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -268,6 +268,7 @@ noit_lua_tag_search_ast_setup(lua_State *L, noit_metric_tag_search_ast_t *ast) {
   return 0;
 }
 
+// Parse tag search query string into a tag-search ast
 // param: query
 // retuns: ast
 static int
@@ -311,7 +312,7 @@ noit_lua_tagset_copy_setup(lua_State *L, noit_metric_tagset_t *src_set) {
   return 0;
 }
 
-// TODO: GC
+// Parse a metric name to a tagset
 // param: name
 // returns: stags, mtags (userdata)
 static int
@@ -330,6 +331,7 @@ lua_noit_tag_parse(lua_State *L) {
   return 2;
 }
 
+// Eval tag search query against tagset
 // param: ast (userdata)
 // param: tagset (userdata)
 // returns: matches (boolean)
@@ -344,6 +346,7 @@ lua_noit_tag_search_eval(lua_State *L) {
   return 1;
 }
 
+// Eval tag search query against string
 // param: ast (userdata)
 // param: name (string)
 // returns: matches (boolean)
@@ -374,8 +377,8 @@ static const luaL_Reg libnoit_binding[] = {
   { "metric_director_next", lua_noit_metric_next },
   { "metric_director_get_messages_received", lua_noit_metric_messages_received },
   { "metric_director_get_messages_distributed", lua_noit_metric_messages_distributed},
-  { "tag_search_parse", lua_noit_tag_search_parse},
   { "tag_parse", lua_noit_tag_parse},
+  { "tag_search_parse", lua_noit_tag_search_parse},
   { "tag_search_eval", lua_noit_tag_search_eval},
   { "tag_search_eval_string", lua_noit_tag_search_eval_string},
   { NULL, NULL }

--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -178,11 +178,13 @@ static int noit_metric_id_index_func(lua_State *L) {
       return 1;
     case 'm':
       if(!strcmp(k, "mtags")) {
+        // We don't own the tagset. Pass a copy to the lua state.
         noit_lua_tagset_copy_setup(L, &(metric_id->measurement));
       }
       return 1;
     case 's':
       if(!strcmp(k, "stags")) {
+        // We don't own the tagset. Pass a copy to the lua state.
         noit_lua_tagset_copy_setup(L, &(metric_id->stream));
       }
       return 1;

--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -291,21 +291,24 @@ noit_lua_tagset_copy_free(lua_State *L) {
   noit_metric_tagset_t *set = *udata;
   free(set->tags);
   free(set);
+  return 0;
 }
 
 static int
 noit_lua_tagset_copy_setup(lua_State *L, noit_metric_tagset_t *src_set) {
-  noit_metric_tagset_t *set = calloc(1, sizeof(*src_set));
-  *set = *src_set;
-  noit_metric_tag_t *tags = calloc(src_set->tag_count, sizeof(noit_metric_tag_t));
-  memcpy(set->tags, src_set->tags, src_set->tag_count*sizeof(noit_metric_tag_t));
-  noit_metric_tagset_t **udata = (noit_metric_tagset_t **) lua_newuserdata(L, sizeof(set));
-  *udata = set;
+  noit_metric_tagset_t *dst_set = calloc(1, sizeof(*src_set));
+  memcpy(dst_set, src_set, sizeof(dst_set));
+  noit_metric_tag_t *dst_tags = calloc(src_set->tag_count, sizeof(noit_metric_tag_t));
+  memcpy(dst_tags, src_set->tags, src_set->tag_count*sizeof(noit_metric_tag_t));
+  dst_set->tags = dst_tags;
+  noit_metric_tagset_t **udata = (noit_metric_tagset_t **) lua_newuserdata(L, sizeof(dst_set));
+  *udata = dst_set;
   if(luaL_newmetatable(L, "noit_metric_tagset_t") == 1){
     lua_pushcclosure(L, noit_lua_tagset_copy_free, 0);
     lua_setfield(L, -2, "__gc");
   }
   lua_setmetatable(L, -2);
+  return 0;
 }
 
 // TODO: GC

--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -412,7 +412,7 @@ noit_lua_tagset_copy_setup(lua_State *L, noit_lua_tagset_t *src_set) {
 static int
 lua_noit_tag_tostring(lua_State *L) {
   noit_metric_tagset_t **udata = (noit_metric_tagset_t **)
-    luaL_checkudata(L, 1, "noit_metric_tagset_t");
+    luaL_checkudata(L, 1, "noit_lua_tagset_t");
   noit_metric_tagset_t *set = *udata;
   int cnt = set->tag_count;
   for (int i=0; i<cnt; i++) {
@@ -457,7 +457,7 @@ lua_noit_tag_search_eval(lua_State *L) {
   noit_metric_tag_search_ast_t **ast_ud = (noit_metric_tag_search_ast_t **)
     luaL_checkudata(L, 1, "noit_metric_tag_search_ast_t");
   noit_metric_tagset_t **set_ud = (noit_metric_tagset_t **)
-    luaL_checkudata(L, 2, "noit_metric_tagset_t");
+    luaL_checkudata(L, 2, "noit_lua_tagset_t");
   mtev_boolean ok = noit_metric_tag_search_evaluate_against_tags(*ast_ud, *set_ud);
   lua_pushboolean(L, ok);
   return 1;

--- a/src/modules/noit_lua_noit_binding.c
+++ b/src/modules/noit_lua_noit_binding.c
@@ -149,12 +149,7 @@ nl_hosts_cache_lookup(lua_State *L) {
 }
 
 static const luaL_Reg noit_binding[] = {
-  { "register_dns_ignore_domain", nl_register_dns_ignore_domain },
-  { "valid_ip", nl_valid_ip },
-  { "check", nl_check },
-  { "check_ud", nl_check_ud },
-  { "hosts_cache_lookup", nl_hosts_cache_lookup },
-  { "filtersets_cull", lua_general_filtersets_cull },
+  // libnoit bindings
   { "metric_director_subscribe_checks", lua_noit_checks_subscribe },
   { "metric_director_unsubscribe_checks", lua_noit_checks_unsubscribe },
   { "metric_director_subscribe", lua_noit_metric_subscribe },
@@ -162,6 +157,13 @@ static const luaL_Reg noit_binding[] = {
   { "metric_director_next", lua_noit_metric_next },
   { "metric_director_get_messages_received", lua_noit_metric_messages_received },
   { "metric_director_get_messages_distributed", lua_noit_metric_messages_distributed},
+  // noit binding additions
+  { "register_dns_ignore_domain", nl_register_dns_ignore_domain },
+  { "valid_ip", nl_valid_ip },
+  { "check", nl_check },
+  { "check_ud", nl_check_ud },
+  { "hosts_cache_lookup", nl_hosts_cache_lookup },
+  { "filtersets_cull", lua_general_filtersets_cull },
   { "checks_do", lua_noit_check_do },
   { NULL, NULL }
 };

--- a/src/modules/noit_lua_noit_binding.c
+++ b/src/modules/noit_lua_noit_binding.c
@@ -164,6 +164,7 @@ static const luaL_Reg noit_binding[] = {
   { "tag_search_parse", lua_noit_tag_search_parse},
   { "tag_search_eval", lua_noit_tag_search_eval},
   { "tag_search_eval_string", lua_noit_tag_search_eval_string},
+  { "tag_search_eval_message", lua_noit_tag_search_eval_message},
   // noit binding additions
   { "register_dns_ignore_domain", nl_register_dns_ignore_domain },
   { "valid_ip", nl_valid_ip },

--- a/src/modules/noit_lua_noit_binding.c
+++ b/src/modules/noit_lua_noit_binding.c
@@ -157,6 +157,7 @@ static const luaL_Reg noit_binding[] = {
   { "metric_director_next", lua_noit_metric_next },
   { "metric_director_get_messages_received", lua_noit_metric_messages_received },
   { "metric_director_get_messages_distributed", lua_noit_metric_messages_distributed},
+  { "metric_director_subscribe_all", lua_noit_metric_subscribe_all},
   { "tag_parse", lua_noit_tag_parse},
   { "tag_tostring", lua_noit_tag_tostring},
   { "tag_search_parse", lua_noit_tag_search_parse},

--- a/src/modules/noit_lua_noit_binding.c
+++ b/src/modules/noit_lua_noit_binding.c
@@ -158,6 +158,7 @@ static const luaL_Reg noit_binding[] = {
   { "metric_director_get_messages_received", lua_noit_metric_messages_received },
   { "metric_director_get_messages_distributed", lua_noit_metric_messages_distributed},
   { "metric_director_subscribe_all", lua_noit_metric_subscribe_all},
+  { "metric_director_subscribe_account", lua_noit_metric_subscribe_account},
   { "tag_parse", lua_noit_tag_parse},
   { "tag_tostring", lua_noit_tag_tostring},
   { "tag_search_parse", lua_noit_tag_search_parse},

--- a/src/modules/noit_lua_noit_binding.c
+++ b/src/modules/noit_lua_noit_binding.c
@@ -157,6 +157,11 @@ static const luaL_Reg noit_binding[] = {
   { "metric_director_next", lua_noit_metric_next },
   { "metric_director_get_messages_received", lua_noit_metric_messages_received },
   { "metric_director_get_messages_distributed", lua_noit_metric_messages_distributed},
+  { "tag_parse", lua_noit_tag_parse},
+  { "tag_tostring", lua_noit_tag_tostring},
+  { "tag_search_parse", lua_noit_tag_search_parse},
+  { "tag_search_eval", lua_noit_tag_search_eval},
+  { "tag_search_eval_string", lua_noit_tag_search_eval_string},
   // noit binding additions
   { "register_dns_ignore_domain", nl_register_dns_ignore_domain },
   { "valid_ip", nl_valid_ip },
@@ -173,4 +178,3 @@ LUALIB_API int luaopen_noit_binding(lua_State *L)
   luaL_openlib(L, "noit_binding", noit_binding, 0);
   return 1;
 }
-


### PR DESCRIPTION
caql-broker tag-search PR: https://github.com/circonus/caql-broker/pull/81

Tests are in the caql-broker repository, since there is no test "harness" for lua in here. (TODO: Move tests here)

