### PR TITLE
fix: normalize max text metric value size

### DIFF
--- a/src/modules/httptrap.c
+++ b/src/modules/httptrap.c
@@ -857,7 +857,7 @@ rest_httptrap_handler(mtev_http_rest_closure_t *restc,
       /*Extract metrics*/
       while(mtev_hash_next(metrics, &iter, &k, &klen, &data))
       {
-        char buff[DEFAULT_TEXT_METRIC_SIZE_LIMIT], type_str[2];
+        char buff[NOIT_DEFAULT_TEXT_METRIC_SIZE_LIMIT], type_str[2];
         metric_t *tmp=(metric_t *)data;
         char *metric_name=tmp->metric_name;
         metric_type_t metric_type=tmp->metric_type;

--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -70,7 +70,6 @@
 #include "noit_check_resolver.h"
 #include "modules/histogram.h"
 
-#define DEFAULT_TEXT_METRIC_SIZE_LIMIT  4096
 static int check_recycle_period = 60000;
 static mtev_boolean perpetual_metrics = mtev_false;
 
@@ -294,7 +293,7 @@ struct vp_w_free {
 };
 
 static mtev_boolean system_needs_causality = mtev_false;
-static int32_t text_size_limit = DEFAULT_TEXT_METRIC_SIZE_LIMIT;
+static int32_t text_size_limit = NOIT_DEFAULT_TEXT_METRIC_SIZE_LIMIT;
 static int reg_module_id = 0;
 static char *reg_module_names[MAX_MODULE_REGISTRATIONS] = { NULL };
 static int reg_module_used = -1;
@@ -1002,7 +1001,7 @@ noit_poller_init() {
   eventer_add_in_s_us(check_recycle_bin_processor, NULL, check_recycle_period/1000, 1000*(check_recycle_period%1000));
   mtev_conf_get_int32(MTEV_CONF_ROOT, "noit/@text_size_limit", &text_size_limit);
   if (text_size_limit <= 0) {
-    text_size_limit = DEFAULT_TEXT_METRIC_SIZE_LIMIT;
+    text_size_limit = NOIT_DEFAULT_TEXT_METRIC_SIZE_LIMIT;
   }
   noit_check_dns_ignore_list_init();
   noit_poller_reload(NULL);

--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -108,6 +108,8 @@
 #define NP_BAD 'B'                 /* stats_t.state */
 #define NP_GOOD 'G'                /* stats_t.state */
 
+#define NOIT_DEFAULT_TEXT_METRIC_SIZE_LIMIT  4096
+
 typedef struct stats_t stats_t;
 
 typedef struct dep_list {


### PR DESCRIPTION
Normalize on single define `NOIT_DEFAULT_TEXT_METRIC_SIZE_LIMIT` in:

`noit_check.c`
`noit_check.h`
`modules/httptrap.c`