### PR TITLE
Bigger, better batches.

### DIFF
--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -416,6 +416,10 @@ API_EXPORT(void) noit_check_extended_id_split(const char *in, int len,
                                               char *name, int name_len,
                                               char *uuid, int uuid_len);
 
+API_EXPORT(mtev_boolean)
+  noit_check_build_tag_extended_name(char *tgt, size_t tgtlen, const char *name,
+                                     const noit_check_t *check);
+
 API_EXPORT(char *)
   noit_console_check_opts(mtev_console_closure_t ncct,
                           mtev_console_state_stack_t *stack,

--- a/src/noit_check_log.c
+++ b/src/noit_check_log.c
@@ -528,6 +528,8 @@ _noit_check_log_bundle_metric(mtev_log_stream_t ls, Metric *metric, metric_t *m)
   metric->metrictype = (int)m->metric_type;
 
   metric->name = m->metric_name;
+  metric->whence_ms = m->whence.tv_sec * 1000ULL + m->whence.tv_usec / 1000;
+  if(metric->whence_ms) metric->has_whence_ms = mtev_true;
   if(m->metric_value.vp != NULL) {
     switch (m->metric_type) {
       case METRIC_INT32:
@@ -629,7 +631,7 @@ do_batch:
         rv_err = -1;
       } else {
         int rv;
-        mtevL(mtev_debug, "BF compression: %f%%\n", 100 * ((double)fb_size - (double)outsize)/(double)fb_size);
+        mtevL(mtev_debug, "BF compression batchsize %d: %f%%\n", current_in_batch, 100 * ((double)fb_size - (double)outsize)/(double)fb_size);
         rv = mtev_log(ls, whence, __FILE__, __LINE__,
                       "BF\t%d\t%.*s\n", (int)fb_size,
                       (unsigned int)outsize, outbuf);

--- a/src/noit_fb.c
+++ b/src/noit_fb.c
@@ -33,6 +33,7 @@
  */
 
 #include "noit_fb.h"
+#include <mtev_log.h>
 
 static void
 flatbuffer_encode_metric(flatcc_builder_t *B, metric_t *m, const uint16_t generation)
@@ -42,6 +43,10 @@ flatbuffer_encode_metric(flatcc_builder_t *B, metric_t *m, const uint16_t genera
 
   ns(MetricValue_name_create_str(B, m->metric_name));
   ns(MetricValue_generation_add(B, generation));
+  if(m->whence.tv_sec || m->whence.tv_usec) {
+    uint64_t whence_ms = m->whence.tv_sec * 1000ULL + m->whence.tv_usec / 1000;
+    ns(MetricValue_timestamp_add(B, whence_ms));
+  }
 
 #define ENCODE_TYPE(FBNAME, FBTYPE, MFIELD)                             \
   if (m->metric_value.MFIELD != NULL) {                                 \

--- a/src/noit_metric.h
+++ b/src/noit_metric.h
@@ -69,6 +69,7 @@ typedef struct {
   } metric_value;
   mtev_boolean logged;
   unsigned long accumulator; /* used to track divisor of averages */
+  struct timeval whence; /* if non-zero, specifies a time */
 } metric_t;
 
 typedef enum {

--- a/src/proto/bundle.proto
+++ b/src/proto/bundle.proto
@@ -46,6 +46,7 @@ message Metric
   optional int32 valueI32 = 6;
   optional uint32 valueUI32 = 7;
   optional string valueStr = 8;
+  optional uint64 whence_ms = 9;
 }
 
 message Status


### PR DESCRIPTION
 * Enhance the metric_t to have an optional struct timeval.  If it is
   set to something other than {0,0}, then it should override the
   encapsulating "thing."
 * Extend protobuf definition to have a timestamp in the metric.
 * Alter logging and reading to support reading/populating the
   per-sample timestamp data.
 * Fix some bugs in the httptrap batching.
 * Port the batching from httptrap into the prometheus module.