### PR TITLE
CIRC-3670: Add Object to allowed JMX types

### DIFF
--- a/src/java/src/com/omniti/jezebel/check/jmx.java
+++ b/src/java/src/com/omniti/jezebel/check/jmx.java
@@ -173,6 +173,7 @@ public class jmx implements JezebelCheck {
                                 ||  type.equals("java.lang.Double")
                                 ||  type.equals("java.lang.Character")
                                 ||  type.equals("java.lang.Boolean")
+                                ||  type.equals("java.lang.Object")
                                 ||  type.equals("java.lang.Void")
                                 ||  type.startsWith("javax.management.openmbean")
                             )


### PR DESCRIPTION
- Adds java.lang.Object to the list of MBeanAttributeInfo.getType() values allowed for MBean attributes for which this check will attempt to create metrics.
- The functionality of the getMetric method still ensures that the attribute value is an instance of a valid type for a metric to be created.