### PR TITLE
Support multiple tagset evaluation for search.

### DIFF
--- a/src/Makefile.dep
+++ b/src/Makefile.dep
@@ -8,13 +8,15 @@ noit_check.o noit_check.lo: noit_check.c  \
   noit_config.h \
   noit_mtev_bridge.h noit_dtrace_probes.h noit_check.h \
   noit_metric.h noit_module.h \
-  noit_check_tools.h noit_clustering.h noit_check.h \
-  noit_check_tools_shared.h noit_check_resolver.h modules/histogram.h
+  noit_check_tools.h  \
+  noit_clustering.h noit_check.h noit_check_tools_shared.h \
+  noit_check_resolver.h modules/histogram.h
 
 noit_check_log.o noit_check_log.lo: noit_check_log.c  \
   noit_dtrace_probes.h \
   noit_fb.h  noit_metric.h \
-  flatbuffers/metric_batch_builder.h flatbuffers/metric_batch_reader.h \
+  flatbuffers/metric_batch_builder.h \
+  flatbuffers/metric_batch_reader.h \
   flatbuffers/flatbuffers_common_reader.h \
   flatbuffers/metric_common_reader.h \
   flatbuffers/flatbuffers_common_builder.h \
@@ -22,7 +24,7 @@ noit_check_log.o noit_check_log.lo: noit_check_log.c  \
   flatbuffers/metric_list_builder.h flatbuffers/metric_list_reader.h \
   flatbuffers/metric_reader.h flatbuffers/metric_builder.h \
   noit_mtev_bridge.h  \
-  noit_check.h  \
+  noit_check.h \
   noit_filters.h bundle.pb-c.h \
   noit_check_log_helpers.h
 
@@ -32,7 +34,8 @@ noit_check_log_helpers.o noit_check_log_helpers.lo: noit_check_log_helpers.c \
   noit_check_log_helpers.h flatbuffers/metric_reader.h \
   flatbuffers/flatbuffers_common_reader.h \
   flatbuffers/metric_common_reader.h flatbuffers/metric_batch_reader.h \
-  noit_message_decoder.h
+  flatbuffers/metric_batch_verifier.h \
+  flatbuffers/metric_common_verifier.h noit_message_decoder.h
 
 noit_check_resolver.o noit_check_resolver.lo: noit_check_resolver.c noit_config.h \
   noit_mtev_bridge.h \
@@ -50,14 +53,16 @@ noit_check_tools.o noit_check_tools.lo: noit_check_tools.c \
   noit_mtev_bridge.h noit_dtrace_probes.h noit_check_tools.h \
   noit_module.h \
   noit_check.h \
-  noit_metric.h noit_clustering.h noit_check.h \
+  noit_metric.h noit_clustering.h \
+  noit_check.h  \
   noit_check_tools_shared.h
 
 noit_check_tools_shared.o noit_check_tools_shared.lo: noit_check_tools_shared.c \
   noit_check_tools.h \
   noit_module.h \
   noit_check.h \
-  noit_metric.h noit_clustering.h noit_check.h \
+  noit_metric.h noit_clustering.h \
+  noit_check.h  \
   noit_check_tools_shared.h
 
 noit_clustering.o noit_clustering.lo: noit_clustering.c  \
@@ -67,19 +72,33 @@ noit_clustering.o noit_clustering.lo: noit_clustering.c  \
 noit_conf_checks.o noit_conf_checks.lo: noit_conf_checks.c \
   noit_filters.h noit_check.h  \
   noit_metric.h noit_conf_checks.h \
-  noit_check_tools.h noit_module.h  \
+  noit_check_tools.h  \
+  noit_module.h  \
   noit_clustering.h noit_check.h \
   noit_check_tools_shared.h
 
+noitd.o noitd.lo: noitd.c noit_config.h noit_version.h \
+  noit_clustering.h noit_check.h \
+  noit_metric.h \
+  noit_mtev_bridge.h \
+  noit_jlog_listener.h noit_check_rest.h noit_check.h noit_check_tools.h \
+  noit_module.h  \
+  noit_clustering.h \
+  noit_check_tools_shared.h  \
+  noit_livestream_listener.h noit_websocket_handler.h noit_conf_checks.h \
+  noit_filters.h noit_metric_director.h noit_message_decoder.h \
+  noit_metric.h noit_check_log_helpers.h man/noitd.usage.h
+
 noit_fb.o noit_fb.lo: noit_fb.c noit_fb.h  \
   noit_metric.h \
-  flatbuffers/metric_batch_builder.h flatbuffers/metric_batch_reader.h \
+  flatbuffers/metric_batch_builder.h \
+  flatbuffers/metric_batch_reader.h \
   flatbuffers/flatbuffers_common_reader.h \
   flatbuffers/metric_common_reader.h \
   flatbuffers/flatbuffers_common_builder.h \
   flatbuffers/metric_common_builder.h flatbuffers/metric_common_builder.h \
   flatbuffers/metric_list_builder.h flatbuffers/metric_list_reader.h \
-  flatbuffers/metric_reader.h flatbuffers/metric_builder.h
+  flatbuffers/metric_reader.h flatbuffers/metric_builder.h \
 
 noit_filters.o noit_filters.lo: noit_filters.c  \
   noit_mtev_bridge.h \
@@ -141,23 +160,22 @@ noit_websocket_handler.o noit_websocket_handler.lo: noit_websocket_handler.c \
   noit_metric.h noit_check_log_helpers.h noit_message_decoder.h \
   noit_mtev_bridge.h noit_websocket_handler.h \
 
-noitd.o noitd.lo: noitd.c noit_config.h noit_version.h \
-  noit_clustering.h noit_check.h \
-  noit_metric.h \
-  noit_mtev_bridge.h \
-  noit_jlog_listener.h noit_check_rest.h noit_check.h noit_check_tools.h \
-  noit_module.h  \
-  noit_clustering.h \
-  noit_check_tools_shared.h  \
-  noit_livestream_listener.h noit_websocket_handler.h noit_conf_checks.h \
-  noit_filters.h noit_metric_director.h noit_message_decoder.h \
-  noit_metric.h noit_check_log_helpers.h man/noitd.usage.h
-
 stratcon_datastore.o stratcon_datastore.lo: stratcon_datastore.c \
   noit_mtev_bridge.h stratcon_datastore.h stratcon_realtime_http.h \
   stratcon_ingest.h stratcon_iep.h stratcon_jlog_streamer.h \
   noit_check.h \
   noit_metric.h
+
+stratcond.o stratcond.lo: stratcond.c  \
+  noit_version.h \
+  noit_mtev_bridge.h \
+  noit_config.h noit_module.h  \
+  noit_check.h \
+  noit_metric.h noit_check_tools.h \
+  noit_clustering.h noit_check.h  \
+  noit_check_tools_shared.h stratcon_jlog_streamer.h \
+  stratcon_datastore.h stratcon_realtime_http.h stratcon_iep.h \
+  man/stratcond.usage.h
 
 stratcon_iep.o stratcon_iep.lo: stratcon_iep.c  \
   noit_mtev_bridge.h noit_jlog_listener.h stratcon_jlog_streamer.h \
@@ -184,14 +202,3 @@ stratcon_realtime_http.o stratcon_realtime_http.lo: stratcon_realtime_http.c \
   noit_check_log_helpers.h noit_livestream_listener.h \
   stratcon_realtime_http.h stratcon_jlog_streamer.h \
   stratcon_datastore.h
-
-stratcond.o stratcond.lo: stratcond.c  \
-  noit_version.h \
-  noit_mtev_bridge.h \
-  noit_config.h noit_module.h  \
-  noit_check.h \
-  noit_metric.h noit_check_tools.h \
-  noit_clustering.h noit_check.h  \
-  noit_check_tools_shared.h stratcon_jlog_streamer.h \
-  stratcon_datastore.h stratcon_realtime_http.h stratcon_iep.h \
-  man/stratcond.usage.h

--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -506,24 +506,8 @@ lua_noit_tag_search_eval_message(lua_State *L) {
   noit_metric_message_t **msg_ud = (noit_metric_message_t **)
     luaL_checkudata(L, 2, "metric_message_t");
   noit_metric_message_t *msg = *msg_ud;
-  // evaluate ast against stream tags
-  noit_metric_tagset_t tagset = msg->id.stream;
-  // Add in extra tags: __uuid, __name
-  if ( tagset.tag_count > MAX_TAGS - 2 ) { return 0; }
-  noit_metric_tag_t tags[MAX_TAGS];
-  memcpy(&tags, tagset.tags, tagset.tag_count * sizeof(noit_metric_tag_t));
-  tagset.tags = tags;
-  char name_str[NOIT_TAG_MAX_PAIR_LEN + 1];
-  char uuid_str[13 + UUID_STR_LEN + 1];
-  snprintf(name_str, sizeof(name_str), "__name:%.*s", msg->id.name_len, msg->id.name);
-  strcpy(uuid_str, "__check_uuid:");
-  mtev_uuid_unparse_lower(msg->id.id, uuid_str + 13);
-  noit_metric_tag_t name_tag = { .tag = name_str, .total_size = strlen(name_str), .category_size = 7 };
-  noit_metric_tag_t uuid_tag = { .tag = uuid_str, .total_size = strlen(uuid_str), .category_size = 13 };
-  tags[tagset.tag_count] = name_tag;
-  tags[tagset.tag_count + 1] = uuid_tag;
-  tagset.tag_count += 2;
-  mtev_boolean ok = noit_metric_tag_search_evaluate_against_tags(*ast_ud, &tagset);
+
+  mtev_boolean ok = noit_metric_tag_search_evaluate_against_metric_id(*ast_ud, &msg->id);
   lua_pushboolean(L, ok);
   return 1;
 }

--- a/src/noit_metric.c
+++ b/src/noit_metric.c
@@ -46,6 +46,12 @@
 
 #include <stdio.h>
 
+MTEV_HOOK_IMPL(noit_metric_tagset_fixup,
+               (noit_metric_tagset_class_t cls, noit_metric_tagset_t *tagset),
+               void *, closure,
+               (void *closure, noit_metric_tagset_class_t cls, noit_metric_tagset_t *tagset),
+               (closure,cls,tagset))
+
 mtev_boolean
 noit_metric_as_double(metric_t *metric, double *out) {
   if(metric == NULL || metric->metric_value.vp == NULL) return mtev_false;

--- a/src/noit_metric.h
+++ b/src/noit_metric.h
@@ -35,10 +35,17 @@
 #define _NOIT_METRIC_H
 
 #include <mtev_defines.h>
+#include <mtev_hooks.h>
 #include <mtev_uuid.h>
 
 #define MAX_METRIC_TAGGED_NAME 4096
 #define MAX_TAGS 256
+
+typedef enum {
+  NOIT_METRIC_TAGSET_CHECK = 1,
+  NOIT_METRIC_TAGSET_STREAM = 2,
+  NOIT_METRIC_TAGSET_MEASUREMENT = 3,
+} noit_metric_tagset_class_t;
 
 typedef enum {
   METRIC_ABSENT = 0,
@@ -103,6 +110,7 @@ typedef struct {
   int name_len;
   int name_len_with_tags;
   uint64_t account_id;
+  noit_metric_tagset_t check;
   noit_metric_tagset_t stream;
   noit_metric_tagset_t measurement;
   char *alloc_name;
@@ -210,5 +218,10 @@ API_EXPORT(ssize_t)
   noit_metric_parse_tags(const char *input, size_t input_len,
                          noit_metric_tagset_t *stset, noit_metric_tagset_t *mtset);
 
+
+MTEV_HOOK_PROTO(noit_metric_tagset_fixup,
+                (noit_metric_tagset_class_t, noit_metric_tagset_t *),
+                void *, closure,
+                (void *closure, noit_metric_tagset_class_t cls, noit_metric_tagset_t *tagset))
 
 #endif

--- a/src/noit_metric_tag_search.h
+++ b/src/noit_metric_tag_search.h
@@ -107,6 +107,14 @@ API_EXPORT(mtev_boolean)
   noit_metric_tag_search_evaluate_against_tags(noit_metric_tag_search_ast_t *search,
                                                noit_metric_tagset_t *tags);
 
+API_EXPORT(mtev_boolean)
+  noit_metric_tag_search_evaluate_against_tags_multi(noit_metric_tag_search_ast_t *search,
+                                                     noit_metric_tagset_t **tags, int ntagsets);
+
+API_EXPORT(mtev_boolean)
+  noit_metric_tag_search_evaluate_against_metric_id(noit_metric_tag_search_ast_t *search,
+                                                    noit_metric_id_t *id);
+
 API_EXPORT(char *)
   noit_metric_tag_search_unparse(noit_metric_tag_search_ast_t *);
 


### PR DESCRIPTION
 * add a hook `noit_metric_tagset_fixup`
 * add `noit_metric_tag_search_evaluate_against_metric_id`
 * add `noit_metric_tag_search_evaluate_against_tags_multi`

The `noit_metric_tag_search_evaluate_against_metric_id` function is
preferred as it does all the hard work of introducing the __name and
__check_uuid tags into the stream and check tagsets, respectively.
It also calls the hooks so that third-parties can manipulate the
three tagsets: `check`, `stream`, and `measurement`.