### PR TITLE
CIRC-3566 Ping_icmp module test check fixes

### DIFF
--- a/src/modules/check_test.c
+++ b/src/modules/check_test.c
@@ -40,11 +40,14 @@
 #include "noit_check.h"
 #include "noit_check_rest.h"
 
+#include "check_test.h"
 #include "check_test.xmlh"
 
 static void check_test_schedule_sweeper();
 static mtev_log_stream_t nlerr = NULL;
 static mtev_log_stream_t nldeb = NULL;
+static mtev_hash_table test_checks;
+static pthread_mutex_t test_checks_lock = PTHREAD_MUTEX_INITIALIZER;
 
 struct check_test_closure {
   noit_check_t *check;
@@ -176,6 +179,8 @@ noit_fire_check(xmlNodePtr attr, xmlNodePtr config, const char **error) {
   c->flags |= NP_DISABLED; /* this is hack to know we haven't run it yet */
   if(NOIT_CHECK_SHOULD_RESOLVE(c))
     noit_check_resolve(c);
+  mtev_hash_replace(&test_checks, (char *)c->checkid, UUID_SIZE, c, NULL,
+                    (NoitHashFreeFunc)noit_poller_free_check);
 
  error:
   if(conf_hash) {
@@ -246,7 +251,8 @@ rest_test_check_result(struct check_test_closure *cl) {
     }
   }
 
-  noit_poller_free_check(cl->check);
+  // this should free the check automatically with noit_poller_free_check
+  mtev_hash_delete(&test_checks, (char *)cl->check->checkid, UUID_SIZE, NULL, NULL);
   free(cl);
 }
 
@@ -365,11 +371,23 @@ rest_test_check(mtev_http_rest_closure_t *restc,
 
 static int
 check_test_init(mtev_dso_generic_t *self) {
+  mtev_hash_init(&test_checks);
   mtevAssert(mtev_http_rest_register(
-    "POST", "/checks/", "^test(\\.xml|\\.json)?$",
-    rest_test_check
-  ) == 0);
+                 "POST", "/checks/", "^test(\\.xml|\\.json)?$",
+                 rest_test_check) == 0);
   return 0;
+}
+
+noit_check_t *
+noit_testcheck_lookup_dyn(uuid_t in) {
+  void *vcheck;
+  pthread_mutex_lock(&test_checks_lock);
+  if(mtev_hash_retrieve(&test_checks, (char *)in, UUID_SIZE, &vcheck)) {
+    pthread_mutex_unlock(&test_checks_lock);
+    return (noit_check_t *)vcheck;
+  }
+  pthread_mutex_unlock(&test_checks_lock);
+  return NULL;
 }
 
 mtev_dso_generic_t check_test = {
@@ -384,4 +402,3 @@ mtev_dso_generic_t check_test = {
   check_test_config,
   check_test_init
 };
-

--- a/src/modules/check_test.c
+++ b/src/modules/check_test.c
@@ -374,7 +374,7 @@ check_test_init(mtev_dso_generic_t *self) {
   mtevAssert(mtev_http_rest_register(
     "POST", "/checks/", "^test(\\.xml|\\.json)?$",
     rest_test_check
-  )== 0);
+  ) == 0);
   return 0;
 }
 

--- a/src/modules/check_test.c
+++ b/src/modules/check_test.c
@@ -372,8 +372,9 @@ static int
 check_test_init(mtev_dso_generic_t *self) {
   mtev_hash_init_locks(&test_checks, 32, MTEV_HASH_LOCK_MODE_MUTEX);
   mtevAssert(mtev_http_rest_register(
-                 "POST", "/checks/", "^test(\\.xml|\\.json)?$",
-                 rest_test_check) == 0);
+    "POST", "/checks/", "^test(\\.xml|\\.json)?$",
+    rest_test_check
+  )== 0);
   return 0;
 }
 

--- a/src/modules/check_test.h
+++ b/src/modules/check_test.h
@@ -1,5 +1,32 @@
-/* Copyright 2019, Circonus Inc.
- * All Rights Reserved.
+/*
+ * Copyright (c) 2019, Circonus, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name Circonus, Inc. nor the names
+ *       of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written
+ *       permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef CHECK_TEST_H

--- a/src/modules/check_test.h
+++ b/src/modules/check_test.h
@@ -42,13 +42,7 @@ MTEV_RUNTIME_RESOLVE(noit_testcheck_lookup,
                      (uuid_t in),
                      (in))
 
-#define NOIT_TESTCHECK_LOOKUP(noit_check_ptr,uuid) do { \
-  if(noit_testcheck_lookup_available()) { \
-    noit_check_ptr = noit_testcheck_lookup(uuid); \
-  } \
-  else { \
-    noit_check_ptr = NULL; \
-  } \
-} while(0)
+#define NOIT_TESTCHECK_LOOKUP(uuid) \
+  (noit_testcheck_lookup_available() ? noit_testcheck_lookup(uuid) : (noit_check_t *)NULL)
 
 #endif

--- a/src/modules/check_test.h
+++ b/src/modules/check_test.h
@@ -1,0 +1,27 @@
+/* Copyright 2019, Circonus Inc.
+ * All Rights Reserved.
+ */
+
+#ifndef CHECK_TEST_H
+#define CHECK_TEST_H
+
+#include <mtev_hooks.h>
+
+MTEV_RUNTIME_AVAIL(noit_testcheck_lookup,
+                   noit_testcheck_lookup_dyn)
+MTEV_RUNTIME_RESOLVE(noit_testcheck_lookup,
+                     noit_testcheck_lookup_dyn,
+                     noit_check_t *,
+                     (uuid_t in),
+                     (in))
+
+#define NOIT_TESTCHECK_LOOKUP(noit_check_ptr,uuid) do { \
+  if(noit_testcheck_lookup_available()) { \
+    noit_check_ptr = noit_testcheck_lookup(uuid); \
+  } \
+  else { \
+    noit_check_ptr = NULL; \
+  } \
+} while(0)
+
+#endif

--- a/src/modules/ping_icmp.c
+++ b/src/modules/ping_icmp.c
@@ -310,7 +310,7 @@ static int ping_icmp_handler(eventer_t e, int mask,
     check = noit_poller_lookup(k.checkid);
     // if we don't get a match, need to also scan test checks if that module is loaded
     if(!check) {
-      NOIT_TESTCHECK_LOOKUP(check, k.checkid);
+      check = NOIT_TESTCHECK_LOOKUP(k.checkid);
     }
     if(!check) {
       mtevLT(nldeb, now,
@@ -352,12 +352,12 @@ static int ping_icmp_handler(eventer_t e, int mask,
     }
     if(payload->check_pack_cnt != data->expected_count) {
       mtevLT(nldeb, now,
-             "ping_icmp response check pack count mismatch for check '%s'\n", uuid_str);
+             "ping_icmp response check packet count mismatch for check '%s'\n", uuid_str);
       continue;
     }
     if(payload->check_pack_no >= data->expected_count) { 
       mtevLT(nldeb, now,
-             "ping_icmp response check pack number mismatch for check '%s'\n", uuid_str);
+             "ping_icmp response check packet number mismatch for check '%s'\n", uuid_str);
       continue;
     }
 


### PR DESCRIPTION
PIng_icmp currently fails to match up ping responses with a test check, so running a test check always fails.  This was due to a tightening up of code done 8 months ago where code was added to make sure that the ping is coming from a valid check being polled (but test checks are not in the polling list because they are temporary).
To fix this we add a new hash and access function in the testcheck module which allows another check module to see if the check is a test check.  This function is dynamically linked and will do nothing if the testcheck module is not loaded.  If ping_icmp cannot find the check by doing noit_poller_lookup(), then it will fallback to looking for a test check (if that module is loaded).