### PR TITLE
Fix how modules are determining complete payloads.

### DIFF
--- a/src/modules/collectd.c
+++ b/src/modules/collectd.c
@@ -2049,8 +2049,7 @@ rest_get_json_upload(mtev_http_rest_closure_t *restc,
       return NULL;
     }
     content_length = mtev_http_request_content_length(req);
-    if((mtev_http_request_payload_chunked(req) && len == 0) ||
-       (rxc->len == content_length)) {
+    if(len == 0 && mtev_http_request_payload_chunked(req)) {
       rxc->complete = 1;
       yajl_complete_parse(rxc->parser);
     }

--- a/src/modules/httptrap.c
+++ b/src/modules/httptrap.c
@@ -761,8 +761,7 @@ rest_get_json_upload(mtev_http_rest_closure_t *restc,
       *complete = 1;
       return NULL;
     }
-    if((mtev_http_request_payload_chunked(req) && len == 0) ||
-       (rxc->len == content_length)) {
+    if(len == 0 && mtev_http_request_payload_complete(req)) {
       rxc->complete = 1;
       _YD("no more data, finishing YAJL parse\n");
       yajl_complete_parse(rxc->parser);

--- a/src/modules/prometheus.c
+++ b/src/modules/prometheus.c
@@ -140,8 +140,7 @@ rest_get_upload(mtev_http_rest_closure_t *restc, int *mask, int *complete)
       return NULL;
     }
     content_length = mtev_http_request_content_length(req);
-    if((mtev_http_request_payload_chunked(req) && len == 0) ||
-       (mtev_dyn_buffer_used(&rxc->data) == content_length)) {
+    if(len == 0 && mtev_http_request_payload_complete(req)) {
       rxc->complete = 1;
     }
   }


### PR DESCRIPTION
It's not how much you've received, it is how much we've read
from the wire.  If we can't decompress something we could get
stuck thinking there should be more data when the http client
has already ready everything.