### PR TITLE
Log check replication errors to the error log

### DIFF
--- a/src/noit_clustering.c
+++ b/src/noit_clustering.c
@@ -431,7 +431,7 @@ fetch_xml_from_noit(CURL *curl, const char *url, struct curl_slist *connect_to) 
       mtevL(clerr, "curl stat error: %s\n", strerror(errno));
     }
   } else {
-     mtevL(cldeb, "curl error: %ld/%ld\n", code, httpcode);
+    mtevL(clerr, "Error fetching %s: %ld/%ld\n", url, code, httpcode);
   }
   close(fd);
   return doc;


### PR DESCRIPTION
Example:
```
[2019-07-19 19:22:58.101762] [error/cluster] Error fetching https://caql-broker-caqlbroker1-mnc4:43191/filters/updates?peer=19a27dc1-6e4f-4b48-a00f-9ba095955d94&prev=0&end=18: 0/403
[2019-07-19 19:22:58.602756] [error/cluster] Error fetching https://caql-broker-caqlbroker1-mnc4:43191/checks/updates?peer=19a27dc1-6e4f-4b48-a00f-9ba095955d94&prev=0&end=8902: 0/403
[2019-07-19 19:22:59.104110] [error/cluster] Error fetching https://caql-broker-caqlbroker1-mnc4:43191/filters/updates?peer=19a27dc1-6e4f-4b48-a00f-9ba095955d94&prev=0&end=18: 0/403
```