### PR TITLE
Redo statsd to use histogram intelligently.

### DIFF
--- a/src/modules/histogram.c
+++ b/src/modules/histogram.c
@@ -368,7 +368,7 @@ extract_Hformat_metric(const char *v, uint64_t *p_cnt, double *p_bucket) {
   return 0;
 }
 static mtev_hook_return_t
-histogram_metric(void *closure, noit_check_t *check, mtev_boolean cumulative, metric_t *m) {
+histogram_metric(void *closure, noit_check_t *check, mtev_boolean cumulative, metric_t *m, uint64_t count) {
   void *vht;
   histotier *ht;
   mtev_hash_table *metrics;
@@ -395,7 +395,7 @@ histogram_metric(void *closure, noit_check_t *check, mtev_boolean cumulative, me
   }
   else ht = vht;
   if(m->metric_value.vp != NULL) {
-#define UPDATE_HISTOTIER(a) update_histotier(ht, cumulative, time(NULL), conf, check, m->metric_name, *m->metric_value.a, 1)
+#define UPDATE_HISTOTIER(a) update_histotier(ht, cumulative, time(NULL), conf, check, m->metric_name, *m->metric_value.a, count)
     switch(m->metric_type) {
       case METRIC_UINT64:
         UPDATE_HISTOTIER(L); break;
@@ -432,7 +432,7 @@ histogram_hook_impl(void *closure, noit_check_t *check, stats_t *stats,
   if(!track || strcmp(track, "add"))
     return MTEV_HOOK_CONTINUE;
 
-  histogram_metric(closure, check, m->metric_type == METRIC_HISTOGRAM_CUMULATIVE, m);
+  histogram_metric(closure, check, m->metric_type == METRIC_HISTOGRAM_CUMULATIVE, m, 1);
   return MTEV_HOOK_DONE;
 }
 

--- a/src/modules/httptrap.c
+++ b/src/modules/httptrap.c
@@ -546,7 +546,8 @@ httptrap_yajl_cb_end_map(void *ctx) {
           }
         } else {
           track_filtered(json, metric_name);
-          noit_stats_set_metric_histogram(json->check, metric_name, hist_type, p->v);
+          noit_stats_set_metric_histogram(json->check, metric_name,
+                                          hist_type == METRIC_HISTOGRAM_CUMULATIVE, METRIC_GUESS, p->v, 1);
         }
       } else {
         if(json->got_timestamp) {

--- a/src/modules/lua_check.c
+++ b/src/modules/lua_check.c
@@ -515,7 +515,7 @@ noit_lua_set_metric_histogram(lua_State *L) {
     lua_pushboolean(L, 1);
     return 1;
   }
-  noit_stats_set_metric_histogram(check, metric_name, METRIC_HISTOGRAM, (void *)lua_tostring(L,2));
+  noit_stats_set_metric_histogram(check, metric_name, mtev_false, METRIC_GUESS, (void *)lua_tostring(L,2), 1);
   lua_pushboolean(L, 1);
   return 1;
 }

--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -315,8 +315,8 @@ API_EXPORT(void)
 
 API_EXPORT(void)
   noit_stats_set_metric_histogram(noit_check_t *check,
-                                  const char *name, metric_type_t t,
-                                  void *value);
+                                  const char *name, mtev_boolean cumulative,
+                                  metric_type_t t, void *value, uint64_t count);
 
 API_EXPORT(void)
   noit_stats_log_immediate_metric(noit_check_t *check,
@@ -503,9 +503,9 @@ MTEV_HOOK_PROTO(check_deleted,
                 (void *closure, noit_check_t *check));
 
 MTEV_HOOK_PROTO(check_stats_set_metric_histogram,
-                (noit_check_t *check, mtev_boolean cumulative, metric_t *m),
+                (noit_check_t *check, mtev_boolean cumulative, metric_t *m, uint64_t count),
                 void *, closure,
-                (void *closure, noit_check_t *check, mtev_boolean cumulative, metric_t *m));
+                (void *closure, noit_check_t *check, mtev_boolean cumulative, metric_t *m, uint64_t count));
 
 MTEV_HOOK_PROTO(noit_check_stats_populate_json,
                 (struct mtev_json_object *doc, noit_check_t *check, stats_t *s, const char *name),

--- a/src/noit_check_tools.c
+++ b/src/noit_check_tools.c
@@ -302,13 +302,12 @@ populate_stats_from_resmon_formatted_json(noit_check_t *check,
             struct json_object *item = json_object_array_get_idx(has_value, i);
             if (item) {
               if(*type_str == 'h' || *type_str == 'H') {
-                metric_type_t hist_type = (*type_str == 'H') ? METRIC_HISTOGRAM_CUMULATIVE : METRIC_HISTOGRAM;
                 const char *value_str = NULL;
                 if(json_object_is_type(item, json_type_string))
                   value_str = json_object_get_string(item);
                 else if(!json_object_is_type(item, json_type_null))
                   value_str = json_object_to_json_string(item);
-                if(value_str) noit_stats_set_metric_histogram(check, prefix, hist_type, (void *)value_str);
+                if(value_str) noit_stats_set_metric_histogram(check, prefix, (*type_str == 'H'), METRIC_GUESS, (void *)value_str, 1);
               }
               else {
                 COERCE_JSON_OBJECT(*type_str, item);
@@ -322,13 +321,12 @@ populate_stats_from_resmon_formatted_json(noit_check_t *check,
         }
         else {
           if(*type_str == 'h' || *type_str == 'H') {
-            metric_type_t hist_type = (*type_str == 'H') ? METRIC_HISTOGRAM_CUMULATIVE : METRIC_HISTOGRAM;
             const char *value_str = NULL;
             if(json_object_is_type(has_value, json_type_string))
               value_str = json_object_get_string(has_value);
             else if(!json_object_is_type(has_value, json_type_null))
               value_str = json_object_to_json_string(has_value);
-            if(value_str) noit_stats_set_metric_histogram(check, prefix, hist_type, (void *)value_str);
+            if(value_str) noit_stats_set_metric_histogram(check, prefix, (*type_str == 'H'), METRIC_GUESS, (void *)value_str, 1);
           }
           else {
             COERCE_JSON_OBJECT(*type_str, has_value);

--- a/src/noit_socket_listener.c
+++ b/src/noit_socket_listener.c
@@ -253,9 +253,9 @@ socket_close:
     num_records = count_records((char *)mtev_dyn_buffer_data(&self->buffer));
     if (num_records > 0) {
       records_this_loop += num_records;
-      char *end_ptr = strrchr((char *)mtev_dyn_buffer_data(&self->buffer), '\n');
-      *end_ptr = '\0';
       size_t total_size = mtev_dyn_buffer_used(&self->buffer);
+      char *end_ptr = memrchr((char *)mtev_dyn_buffer_data(&self->buffer), '\n', total_size);
+      *end_ptr = '\0';
       size_t used_size = end_ptr - (char *)mtev_dyn_buffer_data(&self->buffer);
 
       self->payload_handler(check, (char *)mtev_dyn_buffer_data(&self->buffer), used_size);

--- a/test/busted/lua-support/reconnoiter.lua
+++ b/test/busted/lua-support/reconnoiter.lua
@@ -157,9 +157,6 @@ local all_noit_modules = {
   selfcheck = { image = 'selfcheck' },
   ping_icmp = { image = 'ping_icmp' },
   snmp = { image = 'snmp' },
-  ssh2 = { image = 'ssh2' },
-  mysql = { image = 'mysql' },
-  postgres = { image = 'postgres' },
   test_abort = { image = 'test_abort' },
   varnish = { loader = 'lua', object = 'noit.module.varnish' },
   http = { loader = 'lua', object = 'noit.module.http' },
@@ -376,7 +373,16 @@ function TestConfig:make_modules_config(fd, opts)
     if module.object ~= nil then
       mtev.write(fd, " object=\"" .. module.object .. "\"")
     end
-    mtev.write(fd, " name=\"" .. k .. "\"/>\n")
+    mtev.write(fd, " name=\"" .. k .. "\">\n")
+    if module.config ~= nil then
+      mtev.write(fd, "      <config>\n")
+      for name, value in pairs(module.config) do
+        mtev.write(fd, "        <" .. name .. ">" .. value ..
+                         "</" .. name .. ">\n")
+      end
+      mtev.write(fd, "      </config>\n")
+    end
+    mtev.write(fd, "</module>\n")
   end
   mtev.write(fd, "</modules>\n")
 end


### PR DESCRIPTION
This is a breaking change as metric names will change.  However,
the prior implementation was severely broken and not cluster-capable.
This should use histograms where it makes sense.  For counters,
we count in the zero bucket so that no one attempts to sum them
(they should count them).