### PR TITLE
Fix HTTPTrap Test

### DIFF
--- a/test/busted/checks_data/httptrap/httptrap_spec.lua
+++ b/test/busted/checks_data/httptrap/httptrap_spec.lua
@@ -152,7 +152,7 @@ describe("noit", function()
       local rparts = {}
       local keys = {}
       local rcnt = 0
-      for r=1,5 do
+      for r=1,10 do
         local out = ffi.new("char **[?]", 1)
         local line = noit:waitfor(tkey, 2)
         line = string.gsub(line, "^.+(B[12F]\t)", "%1")


### PR DESCRIPTION
libmtev 1.9.3 has made mtev_stderr messages asynch. This test depends on
these log messages to gauge correctness. We need to increase the number
of times we check to make sure we see everything that's available here.