### PR TITLE
Fix short reads of compressed httptrap submissions.

### DIFF
--- a/src/modules/httptrap.c
+++ b/src/modules/httptrap.c
@@ -748,11 +748,8 @@ rest_get_json_upload(mtev_http_rest_closure_t *restc,
   }
   while(!rxc->complete) {
     int len;
-    len = mtev_http_session_req_consume(
-            restc->http_ctx, buffer,
-            mtev_http_request_payload_chunked(req) ? sizeof(buffer) : MIN(content_length - rxc->len, sizeof(buffer)),
-            sizeof(buffer),
-            mask);
+    len = mtev_http_session_req_consume(restc->http_ctx, buffer,
+                                        sizeof(buffer), sizeof(buffer), mask);
     if(len > 0) {
       yajl_status status;
       _YD("inbound payload chunk (%d bytes) continuing YAJL parse\n", len);


### PR DESCRIPTION
Reading only up to the content length makes no sense as the
content-length is the compressed version and the read length
is the decompressed version.  We should just read as much as
we can always.

Fixes CIRC-4425