### PR TITLE
Support legacy statsd concepts.

### DIFF
--- a/docs/config/modules/statsd.xml
+++ b/docs/config/modules/statsd.xml
@@ -98,6 +98,37 @@
     </variablelist>
   </section>
   <section>
+    <title>Check Configuration</title>
+    <variablelist>
+      <varlistentry>
+        <term>legacy</term>
+        <listitem>
+          <variablelist>
+            <varlistentry>
+              <term>required</term>
+              <listitem>
+                <para>optional</para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>default</term>
+              <listitem>
+                <para>false</para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>allowed</term>
+              <listitem>
+                <para>^(true|false)$</para>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+          <para>If true, no tags are added and counters are tracked as numeric measurements instead of histograms.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </section>
+  <section>
     <title>Examples</title>
     <example>
       <title>A sample statsd configuration.</title>

--- a/src/modules/statsd.xml
+++ b/src/modules/statsd.xml
@@ -16,6 +16,12 @@
                required="optional"
                allowed="^[0-9a-fA-F]{4}(?:[0-9a-fA-F]{4}-){4}[0-9a-fA-F]{12}$">A specific check to which all statsd data will be delegated.</parameter>
   </moduleconfig>
+  <checkconfig>
+    <parameter name="legacy"
+               required="optional"
+               default="false"
+               allowed="^(true|false)$">If true, no tags are added and counters are tracked as numeric measurements instead of histograms.</parameter>
+  </checkconfig>
   <examples>
     <example>
       <title>A sample statsd configuration.</title>


### PR DESCRIPTION
legacy=true in the check config will avoid appending statsd type tags
and use regular numeric stats for |c count metrics instead of
histograms.  This concession does not have an elegant clustering story.
Timing metrics are still treated as histograms as the alternative is an
assualt on dignity.