### PR TITLE
Fix tag search evaluation with empty tag values.

### DIFF
--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -311,7 +311,7 @@ noit_metric_tag_match_evaluate_against_tags_multi(struct noit_metric_tag_match_t
   for(int s=0; s<set_cnt; s++) {
     noit_metric_tagset_t *set = sets[s];
     for(int i=0; i<set->tag_count; i++) {
-      if(set->tags[i].total_size > set->tags[i].category_size &&
+      if(set->tags[i].total_size >= set->tags[i].category_size &&
          noit_match_str(set->tags[i].tag, set->tags[i].category_size - 1, &match->cat) &&
          noit_match_str(set->tags[i].tag + set->tags[i].category_size,
                         set->tags[i].total_size - set->tags[i].category_size, &match->name)) {

--- a/test/test_tags.c
+++ b/test/test_tags.c
@@ -92,15 +92,21 @@ const struct {
   struct {
     const char *query;
     mtev_boolean match;
-  } queries[8];
+  } queries[12];
 } testmatches[] = {
   {
-    "foo:bar,b\"c29tZTpzdHVmZltoZXJlXQ==\":value",
+    "foo:bar,b\"c29tZTpzdHVmZltoZXJlXQ==\":value,empty:",
     {
       { "and(foo:bar)", mtev_true },
       { "and(foo:bar,b\"c29tZTpzdHVmZltoZXJlXQ==\":value)", mtev_true },
       { "and(b/c29tZS4q/:value)", mtev_true },
       { "and(quux:value)", mtev_false },
+      { "and(empty:/^$/)", mtev_true },
+      { "and(empty:)", mtev_true },
+      { "and(empty)", mtev_true },
+      { "not(empty:/^$/)", mtev_false },
+      { "not(empty:)", mtev_false },
+      { "not(empty)", mtev_false },
       { NULL, 0 }
     }
   },


### PR DESCRIPTION
Now `and(foo)` and `and(foo:)` and `and(foo:/^$/)` all work against
tags that arrive as `foo:`