### PR TITLE
Extend Metric/Filterset Length Buffers

### DIFF
--- a/src/modules/external.c
+++ b/src/modules/external.c
@@ -59,6 +59,8 @@
 #include "mtev_json.h"
 #include "external_proc.h"
 
+#define UOM_SIZE 128
+
 typedef enum {
   EXTERNAL_ERROR_NONE = 0,
   EXTERNAL_ERROR_TIMEOUT = 1,
@@ -253,7 +255,7 @@ static void external_log_results(noit_module_t *self, noit_check_t *check) {
     int metric_count = 0;
     while((rc = pcre_exec(ci->matcher, NULL, output, len, startoffset, 0,
                           ovector, sizeof(ovector)/sizeof(*ovector))) > 0) {
-      char metric[128];
+      char metric[MAX_METRIC_TAGGED_NAME];
       char value[128];
       startoffset = ovector[1];
       mtevL(data->nldeb, "matched at offset %d\n", rc);
@@ -265,14 +267,14 @@ static void external_log_results(noit_module_t *self, noit_check_t *check) {
         if (ci->type == EXTERNAL_NAGIOS_TYPE) {
           /* We only care about metrics after the pipe - get check status from the
            * pre-pipe data, then only match on post-pipe data */
-          char uom[128];
-          char metric_name[256];
+          char uom[UOM_SIZE];
+          char metric_name[MAX_METRIC_TAGGED_NAME];
           if(pcre_copy_named_substring(ci->matcher, output, ovector, rc,
                                        "uom", uom, sizeof(uom)) > 0) {
-            snprintf(metric_name, 255, "%s_%s", metric, uom);
+            snprintf(metric_name, MAX_METRIC_TAGGED_NAME, "%s_%s", metric, uom);
           }
           else {
-            snprintf(metric_name, 255, "%s", metric);
+            snprintf(metric_name, MAX_METRIC_TAGGED_NAME, "%s", metric);
           }
           noit_stats_set_metric(check, metric_name, METRIC_GUESS, value);
           metric_count++;

--- a/src/modules/histogram.c
+++ b/src/modules/histogram.c
@@ -509,7 +509,7 @@ histogram_sweep_calculations(struct histogram_config *conf, noit_check_t *check)
   out_q = alloca(sizeof(double) * conf->n_quantiles);
 
   while(mtev_hash_next(metrics, &iter, &metric_name, &klen, &data)) {
-    char mname[1024];
+    char mname[MAX_METRIC_TAGGED_NAME];
     histotier *ht = data;
     if(ht->last_aggr == NULL) continue;
     if(conf->mean) {

--- a/src/modules/mysql.c
+++ b/src/modules/mysql.c
@@ -108,7 +108,7 @@ static void mysql_ingest_stats(mysql_check_info_t *ci) {
         int64_t lv, *plv;
         double dv, *pdv;
         char *sv;
-        char mname[128];
+        char mname[MAX_METRIC_TAGGED_NAME];
   
         snprintf(mname, sizeof(mname), "%s`%s", row[0], cdesc[j].name);
         coltype = cdesc[j].type;

--- a/src/modules/postgres.c
+++ b/src/modules/postgres.c
@@ -119,7 +119,7 @@ static void postgres_ingest_stats(postgres_check_info_t *ci) {
         int64_t lv, *plv;
         double dv, *pdv;
         char *sv;
-        char mname[128];
+        char mname[MAX_METRIC_TAGGED_NAME];
   
         snprintf(mname, sizeof(mname), "%s`%s",
                  PQgetvalue(ci->result, i, 0), PQfname(ci->result, j));

--- a/src/modules/prometheus.c
+++ b/src/modules/prometheus.c
@@ -220,10 +220,10 @@ cross_module_reverse_allowed(noit_check_t *check, const char *secret) {
 static char *
 metric_name_from_labels(Prometheus__Label **labels, size_t label_count)
 {
-  char final_name[4096] = {0};
+  char final_name[MAX_METRIC_TAGGED_NAME] = {0};
   char *name = final_name;
-  char buffer[4096] = {0};
-  char encode_buffer[512] = {0};
+  char buffer[MAX_METRIC_TAGGED_NAME] = {0};
+  char encode_buffer[MAX_METRIC_TAGGED_NAME] = {0};
   char *b = buffer;
   size_t tag_count = 0;
   for (size_t i = 0; i < label_count; i++) {

--- a/src/modules/snmp.c
+++ b/src/modules/snmp.c
@@ -742,7 +742,7 @@ noit_snmp_trapvars_to_stats(noit_check_t *check, netsnmp_variable_list *var) {
     int i, len;
     uint64_t u64;
     double doubleVal;
-    char metric_name[128], buff[128], *cp;
+    char metric_name[MAX_METRIC_TAGGED_NAME], buff[MAX_METRIC_TAGGED_NAME], *cp;
     if(var->name_length <= reconnoiter_metric_prefix_oid_len) return -1;
     len = var->name[reconnoiter_metric_prefix_oid_len];
     if(var->name_length != (reconnoiter_metric_prefix_oid_len + 1 + len) ||

--- a/src/noit_check_log.c
+++ b/src/noit_check_log.c
@@ -356,7 +356,7 @@ noit_check_log_bundle_metric_serialize(mtev_log_stream_t ls,
   _noit_check_log_bundle_metric(ls, bundle.metrics[0], m);
 
   if(NOIT_CHECK_METRIC_ENABLED()) {
-    char buff[256];
+    char buff[MAX_METRIC_TAGGED_NAME];
     noit_stats_snprint_metric(buff, sizeof(buff), m);
     NOIT_CHECK_METRIC(uuid_str, check->module, check->name, check->target,
                       m->metric_name, m->metric_type, buff);
@@ -743,7 +743,7 @@ noit_check_log_bundle_serialize(mtev_log_stream_t ls, noit_check_t *check, struc
       metric__init(bundle->metrics[b_i]);
       _noit_check_log_bundle_metric(ls, bundle->metrics[b_i], m);
       if(NOIT_CHECK_METRIC_ENABLED()) {
-        char buff[256];
+        char buff[MAX_METRIC_TAGGED_NAME];
         noit_stats_snprint_metric(buff, sizeof(buff), m);
         NOIT_CHECK_METRIC(uuid_str, check->module, check->name, check->target,
                           m->metric_name, m->metric_type, buff);
@@ -859,7 +859,7 @@ noit_check_log_metric(noit_check_t *check, const struct timeval *whence,
     _noit_check_log_metric(bundle_log, check, uuid_str, whence, m);
 #endif
     if(NOIT_CHECK_METRIC_ENABLED()) {
-      char buff[256];
+      char buff[MAX_METRIC_TAGGED_NAME];
       noit_stats_snprint_metric(buff, sizeof(buff), m);
       NOIT_CHECK_METRIC(uuid_str, check->module, check->name, check->target,
                         m->metric_name, m->metric_type, buff);

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -160,7 +160,7 @@ mtev_boolean
 noit_filter_compile_add(mtev_conf_section_t setinfo) {
   mtev_conf_section_t *rules;
   int j, fcnt;
-  char filterset_name[256];
+  char filterset_name[MAX_METRIC_TAGGED_NAME];
   filterset_t *set;
   int64_t seq = 0;
   if(!mtev_conf_get_stringbuf(setinfo, "@name",
@@ -184,7 +184,7 @@ noit_filter_compile_add(mtev_conf_section_t setinfo) {
   mtevL(nf_debug, "Compiling filterset '%s'\n", set->name);
   for(j=fcnt-1; j>=0; j--) {
     filterrule_t *rule;
-    char buffer[256];
+    char buffer[MAX_METRIC_TAGGED_NAME];
     if(!mtev_conf_get_stringbuf(rules[j], "@type", buffer, sizeof(buffer)) ||
        (strcmp(buffer, "accept") && strcmp(buffer, "allow") && strcmp(buffer, "deny") &&
         strncmp(buffer, "skipto:", strlen("skipto:")))) {
@@ -392,11 +392,11 @@ noit_filters_process_repl(xmlDocPtr doc) {
   for(child = xmlFirstElementChild(root); child; child = next) {
     next = xmlNextElementSibling(child);
 
-    char filterset_name[256];
+    char filterset_name[MAX_METRIC_TAGGED_NAME];
     mtevAssert(mtev_conf_get_stringbuf(mtev_conf_section_from_xmlnodeptr(child), "@name",
                                        filterset_name, sizeof(filterset_name)));
     if(noit_filter_compile_add(mtev_conf_section_from_xmlnodeptr(child))) {
-      char xpath[1024];
+      char xpath[MAX_METRIC_TAGGED_NAME];
       snprintf(xpath, sizeof(xpath), "/noit/filtersets//filterset[@name=\"%s\"]",
                filterset_name);
       mtev_conf_section_t oldsection = mtev_conf_get_section(MTEV_CONF_ROOT, xpath);
@@ -648,7 +648,7 @@ noit_console_filter_show(mtev_console_closure_t ncct,
   }
   rules = mtev_conf_get_sections(fsnode, "rule", &rulecnt);
   for(i=0; i<rulecnt; i++) {
-    char val[256];
+    char val[MAX_METRIC_TAGGED_NAME];
     if(!mtev_conf_get_stringbuf(rules[i], "@type", val, sizeof(val)))
       val[0] = '\0';
     nc_printf(ncct, "Rule %d [%s]:\n", i+1, val);


### PR DESCRIPTION
Some of the buffers were way too short to hold certain metric/filterset
names. Extend them to allow the maximum length.