### PR TITLE
Make pool selection heirarchical and unify logic.

### DIFF
--- a/src/modules/ping_icmp.c
+++ b/src/modules/ping_icmp.c
@@ -460,7 +460,7 @@ static int ping_icmp_init(noit_module_t *self) {
   if(data->ipv4_fd >= 0) {
     eventer_t newe;
     newe = eventer_alloc_fd(ping_icmp4_handler, self, data->ipv4_fd, EVENTER_READ);
-    eventer_pool_t *dp = eventer_pool("noit_module_ping_icmp");
+    eventer_pool_t *dp = noit_check_choose_pool_by_module(self->hdr.name);
     if(dp) eventer_set_owner(newe, eventer_choose_owner_pool(dp, mtev_rand()));
     eventer_add(newe);
   }
@@ -483,7 +483,7 @@ static int ping_icmp_init(noit_module_t *self) {
     if(data->ipv6_fd >= 0) {
       eventer_t newe;
       newe = eventer_alloc_fd(ping_icmp6_handler, self, data->ipv6_fd, EVENTER_READ);
-      eventer_pool_t *dp = eventer_pool("noit_module_ping_icmp");
+      eventer_pool_t *dp = noit_check_choose_pool_by_module(self->hdr.name);
       if(dp) eventer_set_owner(newe, eventer_choose_owner_pool(dp, mtev_rand()));
       eventer_add(newe);
     }

--- a/src/modules/prometheus.c
+++ b/src/modules/prometheus.c
@@ -558,7 +558,7 @@ static int noit_prometheus_init(noit_module_t *self) {
 
   noit_module_set_userdata(self, conf);
 
-  eventer_pool_t *dp = eventer_pool("noit_module_prometheus");
+  eventer_pool_t *dp = noit_check_choose_pool_by_module(self->hdr.name);
 
   /* register rest handler */
   mtev_rest_mountpoint_t *rule;

--- a/src/noit_check_tools.c
+++ b/src/noit_check_tools.c
@@ -413,6 +413,17 @@ noit_check_make_attrs(noit_check_t *check, mtev_hash_table *attrs) {
   CA_STORE("module", check->module);
 }
 
+/* eventer pool selection works by exploring the pool name space
+ * looking for the first available pool by name as follows (using
+ * graphite_pickle as an example module):
+ *
+ *    noit_check_ (if check based)
+ *    noit_module_graphite_pickle
+ *    noit_module_graphite
+ *    noit_module
+ *    noit
+ *    -> default (NULL)
+ */
 eventer_pool_t *noit_check_choose_pool_by_module(const char *mod) {
   char poolname[256];
   eventer_pool_t *dedicated_pool = NULL;

--- a/src/noit_check_tools.h
+++ b/src/noit_check_tools.h
@@ -80,6 +80,10 @@ noit_check_uuid_to_integer(uuid_t uuid)
   return x[0] ^ x[1] ^ x[2] ^ x[3];
 }
 
+API_EXPORT(eventer_pool_t *)
+  noit_check_choose_pool_by_module(const char *mod);
+API_EXPORT(eventer_pool_t *)
+  noit_check_choose_pool(noit_check_t *check);
 API_EXPORT(pthread_t)
   noit_check_choose_eventer_thread(noit_check_t *check);
 

--- a/src/noit_socket_listener.c
+++ b/src/noit_socket_listener.c
@@ -389,11 +389,7 @@ listener_listen_handler(eventer_t e, int mask, void *closure, struct timeval *no
     newe = eventer_alloc_fd(listener_handler, inst, fd,
                             EVENTER_READ | EVENTER_EXCEPTION);
 
-    char poolname[128];
-    poolname[0] = '\0';
-    strlcat(poolname, "noit_module_", sizeof(poolname));
-    strlcat(poolname, self->self->hdr.name, sizeof(poolname));
-    eventer_pool_t *dp = eventer_pool(poolname);
+    eventer_pool_t *dp = noit_check_choose_pool(self->check);
     if(dp) eventer_set_owner(newe, eventer_choose_owner_pool(dp, mtev_rand()));
     else eventer_set_owner(newe, eventer_choose_owner(mtev_rand()));
     eventer_add(newe);


### PR DESCRIPTION
We already had check-based thread selection in noit_check_tools.
This expands that to allow for check-based, module-based, and
module-name based logic (all shared).  This updates ping_icmp, graphite,
and prometheus checks to all use this shared logic.

The new logic will back off the names heirachically based on underscore:

  noit_check_<uuid> (if check based)
  noit_module_graphite_pickle
  noit_module_graphite
  noit_module
  noit
  -> default (NULL)