### PR TITLE
CIRC-4816 Expose check-tags to lua

### DIFF
--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -179,7 +179,6 @@ static int noit_metric_id_index_func(lua_State *L) {
       return 1;
     case 'c':
       if(!strcmp(k, "ctags")) {
-        lua_pushvalue(L, 2);
         /* Before passing along the check tags, we need to
            1. Augment the tag-set by the check uuid we get from the message
            2. Invoke the fixup hook, that will add replicated check tags.
@@ -206,6 +205,7 @@ static int noit_metric_id_index_func(lua_State *L) {
         };
 
         /* warp into lua_tagset */
+        lua_pushvalue(L, 2);
         int ref = luaL_ref(L, LUA_REGISTRYINDEX);
         noit_lua_tagset_t check_lua_tagset = { .tagset = check_tagset, .lua_name_ref = ref };
         noit_lua_tagset_copy_setup(L, &check_lua_tagset);

--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -177,6 +177,42 @@ static int noit_metric_id_index_func(lua_State *L) {
         break;
       }
       return 1;
+    case 'c':
+      if(!strcmp(k, "ctags")) {
+        lua_pushvalue(L, 2);
+        /* Before passing along the check tags, we need to
+           1. Augment the tag-set by the check uuid we get from the message
+           2. Invoke the fixup hook, that will add replicated check tags.
+         */
+        if ( metric_id->check.tag_count > MAX_TAGS - 1 ) { return 0; }
+        /* Step 0: Copy everything to the stack, so we can mutate */
+        noit_metric_tag_t check_tags[MAX_TAGS];
+        memcpy(&check_tags, metric_id->check.tags, metric_id->check.tag_count * sizeof(noit_metric_tag_t));
+        noit_metric_tagset_t check_tagset = {0};
+        memcpy(&check_tagset, &metric_id->check, sizeof(noit_metric_tagset_t));
+        check_tagset.tags = check_tags;
+
+        /* Step 1: Add uuid tag */
+        char uuid_str[13 + UUID_STR_LEN + 1];
+        strcpy(uuid_str, "__check_uuid:");
+        mtev_uuid_unparse_lower(metric_id->id, uuid_str + 13);
+        noit_metric_tag_t uuid_tag = { .tag = uuid_str, .total_size = strlen(uuid_str), .category_size = 13 };
+        check_tagset.tags[check_tagset.tag_count] = uuid_tag;
+        check_tagset.tag_count++;
+
+        /* Step 2: Fixup check tags */
+        if(noit_metric_tagset_fixup_hook_invoke(NOIT_METRIC_TAGSET_CHECK, &check_tagset) == MTEV_HOOK_ABORT) {
+          return 0;
+        };
+
+        /* warp into lua_tagset */
+        int ref = luaL_ref(L, LUA_REGISTRYINDEX);
+        noit_lua_tagset_t check_lua_tagset = { .tagset = check_tagset, .lua_name_ref = ref };
+        noit_lua_tagset_copy_setup(L, &check_lua_tagset);
+      } else {
+        break;
+      }
+      return 1;
     case 'i':
       if(!strcmp(k, "id")) {
         char uuid_str[UUID_PRINTABLE_STRING_LENGTH];
@@ -207,6 +243,8 @@ static int noit_metric_id_index_func(lua_State *L) {
         int ref = luaL_ref(L, LUA_REGISTRYINDEX);
         noit_lua_tagset_t set = { .tagset = metric_id->measurement, .lua_name_ref = ref };
         noit_lua_tagset_copy_setup(L, &set);
+      } else {
+        break;
       }
       return 1;
     case 's':
@@ -215,6 +253,8 @@ static int noit_metric_id_index_func(lua_State *L) {
         int ref = luaL_ref(L, LUA_REGISTRYINDEX);
         noit_lua_tagset_t set = { .tagset = metric_id->stream, .lua_name_ref = ref };
         noit_lua_tagset_copy_setup(L, &set);
+      } else {
+        break;
       }
       return 1;
     default:
@@ -416,9 +456,9 @@ noit_lua_tagset_copy_setup(lua_State *L, noit_lua_tagset_t *src_set) {
 // returns: tag1, tag2, ...
 static int
 lua_noit_tag_tostring(lua_State *L) {
-  noit_metric_tagset_t **udata = (noit_metric_tagset_t **)
-    luaL_checkudata(L, 1, "noit_lua_tagset_t");
-  noit_metric_tagset_t *set = *udata;
+  noit_lua_tagset_t **udata = (noit_lua_tagset_t **) luaL_checkudata(L, 1, "noit_lua_tagset_t");
+  noit_lua_tagset_t *lset = *udata;
+  noit_metric_tagset_t *set = &(lset->tagset);
   int cnt = set->tag_count;
   for (int i=0; i<cnt; i++) {
     noit_metric_tag_t tag = set->tags[i];

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -573,8 +573,8 @@ noit_metric_director_dedupe(mtev_boolean d)
 void noit_metric_director_init() {
   mtev_stats_init();
   stats_ns = mtev_stats_ns(mtev_stats_ns(NULL, "noit"), "metric_director");
-  stats_ns_add_tag(stats_ns, "topic", "messages");
-  stats_ns_add_tag(stats_ns, "level", "metric_director");
+  stats_ns_add_tag(stats_ns, "subsystem", "metric_director");
+  stats_ns_add_tag(stats_ns, "units", "messages");
   /* total count of messages read from fq */
   stats_msg_seen = stats_register_fanout(stats_ns, "seen", STATS_TYPE_COUNTER, 16);
   /* count of messages dropped due to drop_before_threshold */


### PR DESCRIPTION
This PR adds a method .ctags to the noit_metric_id lua object, which returns the fixed-up check tags associated to the noit message.

This will be used in CAQL-broker, to forward metric metadata from find() queries.