### PR TITLE
CIRC-4638 - Improved Check LMDB On/Off Flags

### DIFF
--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -1045,6 +1045,11 @@ noit_poller_init() {
       }
       noit_check_lmdb_migrate_xml_checks_to_lmdb();
     }
+    else if (errno != ENOENT) {
+      /* This means the directory was there, but we just couldn't open it - something has gone wrong,
+       * so we should abort */
+      mtevFatal(mtev_error, "noit_check: couldn't open directory for lmdb instance - %s\n", strerror(errno));
+    }
     free(lmdb_path);
   }
 

--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -1051,6 +1051,7 @@ noit_poller_init() {
       }
       else if (errno == ENOENT) {
         mtevL(mtev_error, "noit_check: lmdb_path (%s) specified, but does not exist - using XML backingstore\n", lmdb_path);
+        use_lmdb = mtev_false;
       }
       else {
         /* This means the directory was there, but we just couldn't open it - something has gone wrong,
@@ -1058,6 +1059,9 @@ noit_poller_init() {
         mtevFatal(mtev_error, "noit_check: couldn't open directory for lmdb instance - %s\n", strerror(errno));
       }
       free(lmdb_path);
+    }
+    else {
+      use_lmdb = mtev_false;
     }
   }
 

--- a/test/busted/lua-support/reconnoiter.lua
+++ b/test/busted/lua-support/reconnoiter.lua
@@ -441,7 +441,8 @@ function TestConfig:make_checks_config(fd, opts)
   local use_lmdb = os.getenv('NOIT_LMDB_CHECKS') or "0"
   if use_lmdb == "1" then
     local path = opts.workspace .. "/" .. opts.name .. "_checks.lmdb"
-    mtev.write(fd,"  <checks minimum_period=\"100\" max_initial_stutter=\"10\" filterset=\"default\" use_lmdb=\"true\" convert_xml_to_lmdb=\"true\" lmdb_path=\"" .. path .. "\">\n")
+    mtev.mkdir_for_file(path .. '/dummy', tonumber('777',8))
+    mtev.write(fd,"  <checks minimum_period=\"100\" max_initial_stutter=\"10\" filterset=\"default\" lmdb_path=\"" .. path .. "\">\n")
   else
     mtev.write(fd,"  <checks minimum_period=\"100\" max_initial_stutter=\"10\" filterset=\"default\">\n")
   end


### PR DESCRIPTION
Rather than having three flags for having LMDB be on or off:

1: Use LMDB if the "lmdb_path" flag exists and the directory provided
there exists
2: Automatically convert XML checks to LMDB if LMDB is enable