### PR TITLE
[CIRC-4944] metric_director: Return current count after adjustment

### DIFF
--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -59,12 +59,15 @@ noit_lua_tagset_copy_setup(lua_State *, noit_lua_tagset_t *);
 
 static int
 lua_noit_metric_adjustsubscribe(lua_State *L, short bump) {
+  const char* uuid = luaL_checkstring(L, 1);
+  const char* metric_name = luaL_checkstring(L, 2);
   uuid_t id;
-  if(mtev_uuid_parse(lua_tostring(L,1), id)) {
-    luaL_error(L, "(un)subscribe expects a uuid as the first parameter");
+  if(mtev_uuid_parse(uuid, id)) {
+    return luaL_error(L, "(un)subscribe expects a uuid as the first parameter");
   }
-  noit_adjust_metric_interest(id, lua_tostring(L,2), bump);
-  return 0;
+  caql_cnt_t cnt = noit_adjust_metric_interest(id, metric_name, bump);
+  lua_pushnumber(L, cnt);
+  return 1;
 }
 
 static int
@@ -79,8 +82,9 @@ lua_noit_metric_unsubscribe(lua_State *L) {
 
 static int
 lua_noit_checks_adjustsubscribe(lua_State *L, short bump) {
-  noit_adjust_checks_interest(bump);
-  return 0;
+  caql_cnt_t cnt = noit_adjust_checks_interest(bump);
+  lua_pushnumber(L, cnt);
+  return 1;
 }
 
 static int

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -81,7 +81,6 @@ static int nthreads;
 static volatile void **thread_queues;
 static mtev_hash_table id_level;
 static mtev_hash_table dedupe_hashes;
-typedef unsigned short caql_cnt_t;
 static caql_cnt_t *check_interests;
 static mtev_boolean dedupe = mtev_true;
 static uint32_t director_in_use = 0;
@@ -133,7 +132,7 @@ noit_metric_director_my_lane() {
   return get_my_lane();
 }
 
-void
+caql_cnt_t
 noit_adjust_checks_interest(short cnt) {
   int thread_id, icnt;
 
@@ -144,9 +143,10 @@ noit_adjust_checks_interest(short cnt) {
   if(icnt < 0) icnt = 0;
   mtevAssert(icnt <= 0xffff);
   check_interests[thread_id] = icnt;
+  return icnt;
 }
 
-void
+caql_cnt_t
 noit_adjust_metric_interest(uuid_t id, const char *metric, short cnt) {
   int thread_id, icnt;
   void *vhash, *vinterests;
@@ -190,6 +190,7 @@ noit_adjust_metric_interest(uuid_t id, const char *metric, short cnt) {
   if(icnt < 0) icnt = 0;
   mtevAssert(icnt <= 0xffff);
   interests[thread_id] = icnt;
+  return icnt;
 }
 
 static void

--- a/src/noit_metric_director.h
+++ b/src/noit_metric_director.h
@@ -36,6 +36,8 @@
 #include <mtev_uuid.h>
 #include "noit_message_decoder.h"
 
+typedef unsigned short caql_cnt_t;
+
 /**
  * Funnel metrics to certain threads for processing.
  * 
@@ -58,12 +60,12 @@ void noit_metric_director_dedupe(mtev_boolean dedupe);
 
 /* Tells noit to funnel all observed lines matching this id-metric
  * back to this thread */
-void noit_adjust_metric_interest(uuid_t id, const char *metric, short cnt);
+caql_cnt_t noit_adjust_metric_interest(uuid_t id, const char *metric, short cnt);
 
 /* Tells noit that this thread is interested in recieving "check" information.
  * This includes C records and S records.
  */
-void noit_adjust_checks_interest(short cnt);
+caql_cnt_t noit_adjust_checks_interest(short cnt);
 
 /* This gets the next line you've subscribed to, if avaialable. */
 noit_metric_message_t *noit_metric_director_lane_next();


### PR DESCRIPTION
With this PR, the lua functions:
```
noit.metric_director_subscribe()
noit.metric_director_subscribe_checks()
```
Return the current interest counters, after the adjustment.

This is, so that we don't have to do our own accounting, when using those functions elsewhere.