### PR TITLE
Noit clustering: Fetch clusters and filtersets in batches (of 500)

### DIFF
--- a/src/noit_clustering.c
+++ b/src/noit_clustering.c
@@ -585,12 +585,16 @@ possibly_start_job(noit_peer_t *peer) {
     /* We have work to do */
     repl_job_t *rj = calloc(1, sizeof(*rj));
     mtev_uuid_copy(rj->peerid, peer->id);
-    uint64_t new_checks = peer->checks.available - peer->checks.fetched;
     rj->checks.prev = peer->checks.fetched;
-    rj->checks.end = (new_checks > batch_size) ? rj->checks.prev + batch_size : peer->checks.available;
-    uint64_t new_filters = peer->filters.available - peer->filters.fetched;
+    rj->checks.end = peer->checks.available;
+    if (batch_size > 0 && (rj->checks.end - rj->checks.prev > batch_size)) {
+      rj->checks.end = rj->checks.prev + batch_size;
+    }
     rj->filters.prev = peer->filters.fetched;
-    rj->filters.end = (new_filters > batch_size) ? rj->filters.prev + batch_size : peer->filters.available;
+    rj->filters.end = peer->filters.available;
+    if (batch_size > 0 && (rj->filters.end - rj->filters.prev > batch_size)) {
+      rj->filters.end = rj->filters.prev + batch_size;
+    }
     if(peer->checks.prev_fetched == rj->checks.end && peer->checks.last_batch == 0) {
       rj->checks.prev = rj->checks.end = 0;
     }

--- a/src/noit_clustering.c
+++ b/src/noit_clustering.c
@@ -71,6 +71,7 @@
 static char *cainfo;
 static char *certinfo;
 static char *keyinfo;
+static uint32_t batch_size = 500; /* for fetching clusters and filters */
 
 static void
 noit_cluster_setup_ssl(int port) {
@@ -867,9 +868,10 @@ void noit_mtev_cluster_init() {
   showcmd = mtev_console_state_get_cmd(tl, "show");
   mtevAssert(showcmd && showcmd->dstate);
 
+  mtev_conf_get_uint32(MTEV_CONF_ROOT, "//clusters/cluster[@name=\"noit\"]/@batch_size", &batch_size);
+
   mtev_console_state_add_cmd(showcmd->dstate,
   NCSCMD("noit-cluster", noit_clustering_show, NULL, NULL, NULL));
-
 
   repl_jobq = eventer_jobq_create_ms("noit_cluster", EVENTER_JOBQ_MS_GC);
   mtevAssert(repl_jobq);

--- a/src/noit_clustering.c
+++ b/src/noit_clustering.c
@@ -202,7 +202,7 @@ void
 noit_cluster_mark_check_changed(noit_check_t *check, void *vpeer) {
   if(!strcmp(check->module, "selfcheck")) return;
   if(check->config_seq <= 0) return;
-  // mtevL(cldeb, "marking check %s [%s] %"PRId64" for repl\n", check->name, check->module, check->config_seq);
+  mtevL(cldeb, "marking check %s [%s] %"PRId64" for repl\n", check->name, check->module, check->config_seq);
   pthread_mutex_lock(&noit_peer_lock);
   mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
   checks_produced++;


### PR DESCRIPTION
This avoids timeout events when replicating brokers with a large number (10K+) of active checks.

Manually tested in dev.