### PR TITLE
CIRC-5074 - Use Conf Sync Flag In Cluster Busted Tests

### DIFF
--- a/test/busted/cluster/delete/delete_spec.lua
+++ b/test/busted/cluster/delete/delete_spec.lua
@@ -40,7 +40,7 @@ describe("cluster", function()
       payload = payload .. '<node id="' .. node.id .. '" cn="noit-test" address="127.0.0.1" port="' .. tostring(node.port) .. '"/>'
     end
     payload = payload .. '</cluster>'
-    return api:xml("POST", "/cluster", payload)
+    return api:xmlforcewrite("POST", "/cluster", payload)
   end
   it("node1 should start", function()
     assert.is_true(noit1:start():is_booted())

--- a/test/busted/cluster/histogram/histogram_spec.lua
+++ b/test/busted/cluster/histogram/histogram_spec.lua
@@ -41,7 +41,7 @@ describe("cluster", function()
       payload = payload .. '<node id="' .. node.id .. '" cn="noit-test" address="127.0.0.1" port="' .. tostring(node.port) .. '"/>'
     end
     payload = payload .. '</cluster>'
-    return api:xml("POST", "/cluster", payload)
+    return api:xmlforcewrite("POST", "/cluster", payload)
   end
   it("node1 should start", function()
     assert.is_true(noit1:start():is_booted())

--- a/test/busted/lua-support/reconnoiter.lua
+++ b/test/busted/lua-support/reconnoiter.lua
@@ -35,6 +35,10 @@ function API:new(port, cert)
   }
   obj.api = MBAPI:new("127.0.0.1", obj.port):ssl(obj.sslconfig)
   obj.xmlapi = MBAPI:new("127.0.0.1", obj.port):headers({accept = "text/xml"}):ssl(obj.sslconfig)
+  force_headers = {}
+  force_headers["accept"] = "text/xml"
+  force_headers["x-mtev-conf-sync"] = "1"
+  obj.xmlforceapi = MBAPI:new("127.0.0.1", obj.port):headers(force_headers):ssl(obj.sslconfig)
   obj.curl_count = 0
   setmetatable(obj, API)
   return obj
@@ -85,6 +89,17 @@ end
 function API:json(method, uri, payload, _pp, config)
   self:curl_logger({}, method, uri, payload)
   return self.api:HTTPS(method, uri, payload, _pp, config)
+end
+
+function API:xmlforcewrite(method, uri, payload, _pp, config)
+  if _pp == nil then
+    _pp = function(result)
+      local doc = mtev.parsexml(result)
+      return doc
+    end
+  end
+  self:curl_logger({accept = "text/xml"}, method, uri, payload)
+  return self.xmlforceapi:HTTPS(method, uri, payload, _pp, config)
 end
 
 function API:xml(method, uri, payload, _pp, config)


### PR DESCRIPTION
There's a pending change in libmtev that uses a header to force cluster
puts to write out the configuration file immediately. Add a header to
the tests that use this so that when that change goes live, we'll use
it. It will have no effect until the libmtev change lands.