### PR TITLE
Allow -Werror on GCC 9.

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -70,3 +70,18 @@ m4_if(m4_version_compare(m4_defn([AC_AUTOCONF_VERSION]), [2.64]), -1,
     AS_VAR_POPDEF([CACHEVAR])dnl
   ])
 ])dnl AX_CHECK_COMPILE_FLAGS
+
+AC_DEFUN([AX_GCC_VERSION], [
+  GCC_VERSION=""
+
+  AS_IF([test "x$GCC" = "xyes"],[
+    AC_CACHE_CHECK([gcc version],[ax_cv_gcc_version],[
+      ax_cv_gcc_version="`$CC -dumpversion`"
+      AS_IF([test "x$ax_cv_gcc_version" = "x"],[
+        ax_cv_gcc_version=""
+      ])
+    ])
+    GCC_VERSION=$ax_cv_gcc_version
+  ])
+  AC_SUBST([GCC_VERSION])
+])

--- a/configure.in
+++ b/configure.in
@@ -41,6 +41,10 @@ fi
 AC_PROG_CC
 AX_CHECK_COMPILE_FLAG(-fexceptions, [ CFLAGS="$CFLAGS -fexceptions" ])
 AC_PROG_CXX
+AX_GCC_VERSION
+GCC_VERSION_MAJOR=$(echo $GCC_VERSION | cut -d'.' -f1)
+GCC_VERSION_MINOR=$(echo $GCC_VERSION | cut -d'.' -f2)
+GCC_VERSION_PATCH=$(echo $GCC_VERSION | cut -d'.' -f3)
 AC_C_INLINE
 AC_C_BIGENDIAN
 AC_PROG_CPP
@@ -83,6 +87,9 @@ else
 fi
 C99FLAG="-std=c99"
 CFLAGS="$CFLAGS `mtev-config --cflags`"
+if test "x$GCC_VERSION_MAJOR" != "x" -a "$GCC_VERSION_MAJOR" -ge "8" ; then
+	CFLAGS="$CFLAGS -Wno-stringop-truncation"
+fi
 WRONG_CFLAGS=$(echo $CFLAGS | [gawk '/^-[ID]/' RS=' ' ORS=' '] | tr '\n' ' ')
 CFLAGS=$(echo $CFLAGS | [gawk '!/^-[ID]/' RS=' ' ORS=' '] | tr '\n' ' ')
 CPPFLAGS="$CPPFLAGS $WRONG_CFLAGS `mtev-config --cppflags` -DOC_NEW_STYLE_INCLUDES -DOC_FACTOR_INTO_H_AND_CC"
@@ -569,8 +576,10 @@ if test -n "`$CC -V 2>&1 | grep 'Sun C'`"; then
 	fi
 else
 	CFLAGS="$CFLAGS -Wall"
+	SHCFLAGS="$SHCFLAGS -Wall"
 	if test "$enable_strict" != "no"; then
 		CFLAGS="$CFLAGS -Werror"
+		SHCFLAGS="$SHCFLAGS -Werror"
 	fi
 fi
 

--- a/src/modules/external.c
+++ b/src/modules/external.c
@@ -255,7 +255,7 @@ static void external_log_results(noit_module_t *self, noit_check_t *check) {
     int metric_count = 0;
     while((rc = pcre_exec(ci->matcher, NULL, output, len, startoffset, 0,
                           ovector, sizeof(ovector)/sizeof(*ovector))) > 0) {
-      char metric[MAX_METRIC_TAGGED_NAME];
+      char metric[MAX_METRIC_TAGGED_NAME - UOM_SIZE - 1];
       char value[128];
       startoffset = ovector[1];
       mtevL(data->nldeb, "matched at offset %d\n", rc);

--- a/src/modules/statsd.c
+++ b/src/modules/statsd.c
@@ -126,7 +126,7 @@ statsd_submit(noit_module_t *self, noit_check_t *check,
 static void
 update_check(noit_check_t *check, const char *key, char type,
              double diff, double sample) {
-  char buff[MAX_METRIC_TAGGED_NAME];
+  char buff[MAX_METRIC_TAGGED_NAME + 24];
 
   if (sample == 0.0) return; /* would be a div-by-zero */
   if (check->closure == NULL) return;

--- a/src/noit_clustering.c
+++ b/src/noit_clustering.c
@@ -476,7 +476,7 @@ repl_work(eventer_t e, int mask, void *closure, struct timeval *now) {
       const char *cn = mtev_cluster_node_get_cn(node);
       char port_str[10];
       char host_port[128];
-      char connect_str[128];
+      char connect_str[256];
       char url[1024];
       struct curl_slist *connect_to = NULL;
       switch(mtev_cluster_node_get_addr(node, &addr, &addrlen)) {

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -403,7 +403,7 @@ noit_filters_process_repl(xmlDocPtr doc) {
     mtevAssert(mtev_conf_get_stringbuf(mtev_conf_section_from_xmlnodeptr(child), "@name",
                                        filterset_name, sizeof(filterset_name)));
     if(noit_filter_compile_add(mtev_conf_section_from_xmlnodeptr(child))) {
-      char xpath[MAX_METRIC_TAGGED_NAME];
+      char xpath[MAX_METRIC_TAGGED_NAME+128];
       snprintf(xpath, sizeof(xpath), "/noit/filtersets//filterset[@name=\"%s\"]",
                filterset_name);
       mtev_conf_section_t oldsection = mtev_conf_get_section_write(MTEV_CONF_ROOT, xpath);

--- a/src/stratcon_jlog_streamer.c
+++ b/src/stratcon_jlog_streamer.c
@@ -825,7 +825,7 @@ periodic_noit_metrics(eventer_t e, int mask, void *closure,
   void *vconn;
   int klen, n = 0, i;
   char str[1024];
-  char uuid_str[1024], tmp_uuid_str[UUID_STR_LEN+1];
+  char uuid_str[64], tmp_uuid_str[UUID_STR_LEN+1];
   struct timeval epoch, diff;
   uint64_t uptime = 0;
   char ip_str[128];


### PR DESCRIPTION
* Fix a set of format truncation warnings.
* Suppress stringop-trunctation for flatbuffers.