### PR TITLE
Fix Double Status Set When Showing LMDB Checks

### DIFF
--- a/src/noit_check_lmdb.c
+++ b/src/noit_check_lmdb.c
@@ -361,7 +361,6 @@ int noit_check_lmdb_show_check(mtev_http_rest_closure_t *restc, int npats, char 
     mtev_http_response_ok(ctx, "text/xml");
   }
 
-  mtev_http_response_ok(ctx, "text/xml");
   mtev_http_response_xml(ctx, doc);
   mtev_http_response_end(ctx);
   goto cleanup;


### PR DESCRIPTION
We were accidentlaly calling "response_ok" no matter what - even if we'd
already set it, or were setting something else. Change to remove the
extra call.