### PR TITLE
CIRC-4638 - Test Both XML and LMDB Checks/Filtersets

### DIFF
--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -31,7 +31,14 @@ all:	testcerts testcrl others test_tags
 clean:	clean-keys clean-tests
 
 check:	all
-	(cd busted && ./run-tests.sh)
+	(cd busted && echo "testing xml" && NOIT_LMDB_FILTERSETS=0 NOIT_LMDB_CHECKS=0 ./run-tests.sh && \
+	 echo "testing lmdb" && NOIT_LMDB_FILTERSETS=1 NOIT_LMDB_CHECKS=1 ./run-tests.sh)
+
+check-xml: all
+	(cd busted && NOIT_LMDB_FILTERSETS=0 NOIT_LMDB_CHECKS=0 ./run-tests.sh)
+
+check-lmdb: all
+	(cd busted && NOIT_LMDB_FILTERSETS=1 NOIT_LMDB_CHECKS=1 ./run-tests.sh)
 
 # This stuff if all cert stuff to make testing the daemons easier
 


### PR DESCRIPTION
Changed "make check" to run the test suite with both XML and LMDB
backingstores for checks and filtersets. Added "check-xml" and
"check-lmdb" to run one or the other.