### PR TITLE
CIRC-4638 - Better Error Logging When Conversion Fails

### DIFF
--- a/test/busted/lua-support/reconnoiter.lua
+++ b/test/busted/lua-support/reconnoiter.lua
@@ -487,6 +487,9 @@ function TestConfig:make_filtersets_config(fd, opts)
     end
     mtev.write(fd,"  </filterset>\n")
   end
+  --Broken filterset with no name
+  mtev.write(fd,"  <filterset>\n")
+  mtev.write(fd,"  </filterset>\n")
   mtev.write(fd,"</filtersets>\n")
 end
 


### PR DESCRIPTION
If we fail to convert an XML filterset to LMDB, we should log exactly
what happened and not remove the filter from the XML. That way, we don't
lose the filterset and can debug later.