### PR TITLE
Flag Delete Torture Test Pending

### DIFF
--- a/test/busted/simple/delete/delete_spec.lua
+++ b/test/busted/simple/delete/delete_spec.lua
@@ -65,7 +65,7 @@ describe("noit", function()
         assert.is.equal(200, code)
       end
     end)
-    it("tortures w delete", function()
+    pending("tortures w delete", function()
       for i=1,100,1 do
         local code, doc = api:raw("PUT", "/checks/set/" .. uuid[8], check_xml(8))
         assert.is.equal(200, code)


### PR DESCRIPTION
This test is occasionally failing due to a race; a fix is in the works,
but in the meantime, we should flag the test as pending.