### PR TITLE
CIRC-5150 - Fix Race In Check Recycle Bin

### DIFF
--- a/src/noit_check_lmdb.h
+++ b/src/noit_check_lmdb.h
@@ -44,13 +44,14 @@ typedef enum {
 int noit_check_lmdb_show_checks(mtev_http_rest_closure_t *restc, int npats, char **pats);
 int noit_check_lmdb_show_check(mtev_http_rest_closure_t *restc, int npats, char **pats);
 int noit_check_lmdb_set_check(mtev_http_rest_closure_t *restc, int npats, char **pats);
-int noit_check_lmdb_remove_check_from_db(uuid_t checkid);
+int noit_check_lmdb_remove_check_from_db(uuid_t checkid, mtev_boolean force);
 int noit_check_lmdb_delete_check(mtev_http_rest_closure_t *restc, int npats, char **pats);
 void noit_check_lmdb_poller_process_checks(uuid_t *uuids, int uuid_cnt);
 void noit_check_lmdb_migrate_xml_checks_to_lmdb();
 int noit_check_lmdb_process_repl(xmlDocPtr doc);
 mtev_boolean noit_check_lmdb_already_in_db(uuid_t checkid);
 char *noit_check_lmdb_get_specific_field(uuid_t checkid, noit_lmdb_check_type_e search_type,
-                                         char *search_namespace, char *search_key);
+                                         char *search_namespace, char *search_key,
+                                         mtev_boolean locked);
 
 #endif

--- a/test/busted/lua-support/reconnoiter.lua
+++ b/test/busted/lua-support/reconnoiter.lua
@@ -880,7 +880,7 @@ end
 TestNoit = inheritsFrom(TestProc)
 function TestNoit:new(...) return TestNoit:create():configure(...) end
 function TestNoit:path() return noitd end
-function TestNoit:argv() return { 'noitd', '-D', '-D', '-c', self.conffile } end
+function TestNoit:argv() return { 'noitd', '-D', '-c', self.conffile } end
 function TestNoit:api_port() return self.opts.noit_api_port end
 function TestNoit:setup_config(opts)
   self.conf = TestConfig:new(self.name, opts)
@@ -890,7 +890,7 @@ end
 TestStratcon = inheritsFrom(TestProc)
 function TestStratcon:new(...) return TestStratcon:create():configure(...) end
 function TestStratcon:path() return stratcond end
-function TestStratcon:argv() return { 'stratcond', '-D', '-D', '-c', self.conffile } end
+function TestStratcon:argv() return { 'stratcond', '-D', '-c', self.conffile } end
 function TestStratcon:api_port() return self.opts.stratcon_api_port end
 function TestStratcon:web_port() return self.opts.stratcon_web_port end
 function TestStratcon:stomp_port() return self.opts.stratcon_stomp_port end

--- a/test/busted/lua-support/reconnoiter.lua
+++ b/test/busted/lua-support/reconnoiter.lua
@@ -880,7 +880,7 @@ end
 TestNoit = inheritsFrom(TestProc)
 function TestNoit:new(...) return TestNoit:create():configure(...) end
 function TestNoit:path() return noitd end
-function TestNoit:argv() return { 'noitd', '-D', '-c', self.conffile } end
+function TestNoit:argv() return { 'noitd', '-D', '-D', '-c', self.conffile } end
 function TestNoit:api_port() return self.opts.noit_api_port end
 function TestNoit:setup_config(opts)
   self.conf = TestConfig:new(self.name, opts)
@@ -890,7 +890,7 @@ end
 TestStratcon = inheritsFrom(TestProc)
 function TestStratcon:new(...) return TestStratcon:create():configure(...) end
 function TestStratcon:path() return stratcond end
-function TestStratcon:argv() return { 'stratcond', '-D', '-c', self.conffile } end
+function TestStratcon:argv() return { 'stratcond', '-D', '-D', '-c', self.conffile } end
 function TestStratcon:api_port() return self.opts.stratcon_api_port end
 function TestStratcon:web_port() return self.opts.stratcon_web_port end
 function TestStratcon:stomp_port() return self.opts.stratcon_stomp_port end

--- a/test/busted/simple/delete/delete_spec.lua
+++ b/test/busted/simple/delete/delete_spec.lua
@@ -60,13 +60,13 @@ describe("noit", function()
   local test = (system == nil or system.sysname == "SunOS") and pending or describe
   test("check", function()
     it("tortures w/o delete", function()
-      for i=1,100,1 do
+      for i=1,500,1 do
         local code, doc, data = api:raw("PUT", "/checks/set/" .. uuid[8], check_xml(8))
         assert.is.equal(200, code)
       end
     end)
-    pending("tortures w delete", function()
-      for i=1,100,1 do
+    it("tortures w delete", function()
+      for i=1,500,1 do
         local code, doc = api:raw("PUT", "/checks/set/" .. uuid[8], check_xml(8))
         assert.is.equal(200, code)
         code, doc = api:raw("DELETE", "/checks/delete/" .. uuid[8])


### PR DESCRIPTION
The check recycle bin - where we clean up checks that have already been
deleted, but not removed from the disk - was encountering a race where
we could potentially accidentally delete a check we're attempting to
restore.

When cleaning the recycle bin, check the config to make sure we're still
set for deletion. If we're not - don't delete it.