### PR TITLE
WIP: Metric Director Move Account Subscriptions Logic

### DIFF
--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -576,6 +576,11 @@ noit_lua_libnoit_init() {
   ck_spinlock_unlock(&noit_lua_libnoit_init_lock);
 }
 
+static int
+lua_noit_metric_subscribe_tag_search(lua_State *L) {
+  return 0;
+}
+
 #ifndef NO_LUAOPEN_LIBNOIT
 static const luaL_Reg libnoit_binding[] = {
   { "metric_director_subscribe_checks", lua_noit_checks_subscribe },

--- a/src/modules/noit_lua_noit_binding.c
+++ b/src/modules/noit_lua_noit_binding.c
@@ -165,6 +165,7 @@ static const luaL_Reg noit_binding[] = {
   { "metric_director_next", lua_noit_metric_next },
   { "metric_director_subscribe_all", lua_noit_metric_subscribe_all},
   { "metric_director_subscribe_account", lua_noit_metric_subscribe_account},
+  { "metric_director_subscribe_tag_search", lua_noit_metric_subscribe_tag_search},
   { "metric_director_drop_before", lua_noit_metric_drop_before},
   { "metric_director_drop_backlogged", lua_noit_metric_drop_backlogged},
   { "tag_parse", lua_noit_tag_parse},

--- a/src/noit_metric_director.h
+++ b/src/noit_metric_director.h
@@ -66,6 +66,8 @@ void noit_metric_director_dedupe(mtev_boolean dedupe);
  * back to this thread */
 caql_cnt_t noit_adjust_metric_interest(uuid_t id, const char *metric, short cnt);
 
+caql_cnt_t noit_adjust_account_interest(int account_id, short cnt);
+
 /* Tells noit that this thread is interested in recieving "check" information.
  * This includes C records and S records.
  */


### PR DESCRIPTION
This is some prep work, for improving the tag-search routing logic.

The account subscription logic was mis-placed in the noit_lua_binding_* files.
Moving those to the metric_director makes more sense, and also avoids quirks
with the initialization logic.

However, this project is not complete.

- Caql-broker tests are flapping with this. There seem to be issues with the delivery of the messages. But it's not clear to me what's causing this. The code change should be feature neutral.

- Debugging is complicated by the fact that mtevL() does not work from the hook handler. #BUG
