### PR TITLE
CIRC-5181 - Add DB Type Response Headers

### DIFF
--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -85,6 +85,8 @@ static int32_t global_maximum_period = 300000;
 #define CHECKS_XPATH_PARENT "checks"
 #define CHECKS_XPATH_BASE CHECKS_XPATH_ROOT "/" CHECKS_XPATH_PARENT
 
+#define CHECK_DB_HEADER_STRING "X-Check-DB-Type"
+
 MTEV_HOOK_IMPL(check_config_fixup,
   (noit_check_t *check),
   void *, closure,
@@ -3606,4 +3608,13 @@ char **noit_check_get_namespaces(int *cnt) {
     toRet[i] = strdup(reg_module_names[i]);
   }
   return toRet;
+}
+
+void
+noit_check_set_db_source_header(mtev_http_session_ctx *ctx) {
+  if (!ctx) {
+    return;
+  }
+  mtev_http_response_header_set(ctx, CHECK_DB_HEADER_STRING,
+    (noit_check_get_lmdb_instance()) ? "LMDB" : "XML");
 }

--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -41,6 +41,7 @@
 
 #include <eventer/eventer.h>
 #include <mtev_hash.h>
+#include <mtev_http.h>
 #include <mtev_skiplist.h>
 #include <mtev_hooks.h>
 #include <mtev_conf.h>
@@ -478,6 +479,9 @@ API_EXPORT(int)
 
 API_EXPORT(char **)
   noit_check_get_namespaces(int *cnt);
+
+API_EXPORT(void)
+  noit_check_set_db_source_header(mtev_http_session_ctx *ctx);
 
 MTEV_HOOK_PROTO(check_config_fixup,
                 (noit_check_t *check),

--- a/src/noit_check_lmdb.c
+++ b/src/noit_check_lmdb.c
@@ -261,12 +261,14 @@ int noit_check_lmdb_show_checks(mtev_http_rest_closure_t *restc, int npats, char
   /* Next, iterate the checks and set the data from LMDB */
   noit_poller_do(noit_check_lmdb_scan_lmdb_for_each_check_cb, root);
 
+  noit_check_set_db_source_header(restc->http_ctx);
   mtev_http_response_ok(ctx, "text/xml");
   mtev_http_response_xml(ctx, doc);
   mtev_http_response_end(ctx);
   goto cleanup;
 
  error:
+  noit_check_set_db_source_header(restc->http_ctx);
   mtev_http_response_standard(ctx, error_code, "ERROR", "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;
@@ -355,9 +357,11 @@ int noit_check_lmdb_show_check(mtev_http_rest_closure_t *restc, int npats, char 
     snprintf(url, sizeof(url), "https://%s:%u/checks/show/%s",
              cn, port, uuid_str);
     mtev_http_response_header_set(restc->http_ctx, "Location", url);
+    noit_check_set_db_source_header(restc->http_ctx);
     mtev_http_response_standard(ctx, redirect ? 302 : 200, "NOT IT", "text/xml");
   }
   else {
+    noit_check_set_db_source_header(restc->http_ctx);
     mtev_http_response_ok(ctx, "text/xml");
   }
 
@@ -366,11 +370,13 @@ int noit_check_lmdb_show_check(mtev_http_rest_closure_t *restc, int npats, char 
   goto cleanup;
 
  not_found:
+  noit_check_set_db_source_header(restc->http_ctx);
   mtev_http_response_not_found(ctx, "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;
 
  error:
+  noit_check_set_db_source_header(restc->http_ctx);
   mtev_http_response_standard(ctx, error_code, "ERROR", "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;
@@ -680,6 +686,7 @@ noit_check_lmdb_set_check(mtev_http_rest_closure_t *restc,
   return restc->fastpath(restc, restc->nparams, restc->params);
 
  error:
+  noit_check_set_db_source_header(restc->http_ctx);
   mtev_http_response_standard(ctx, error_code, "ERROR", "text/xml");
   doc = xmlNewDoc((xmlChar *)"1.0");
   root = xmlNewDocNode(doc, NULL, (xmlChar *)"error", NULL);
@@ -964,16 +971,19 @@ noit_check_lmdb_delete_check(mtev_http_rest_closure_t *restc,
     }
   }
 
+  noit_check_set_db_source_header(restc->http_ctx);
   mtev_http_response_ok(ctx, "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;
 
  not_found:
+  noit_check_set_db_source_header(restc->http_ctx);
   mtev_http_response_not_found(ctx, "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;
 
  error:
+  noit_check_set_db_source_header(restc->http_ctx);
   mtev_http_response_standard(ctx, error_code, "ERROR", "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -69,6 +69,8 @@ static noit_lmdb_instance_t *lmdb_instance = NULL;
 static uint64_t cull_idle_threshold_ms = 300000;
 static bool initialized = false;
 
+#define FILTERSET_DB_HEADER_STRING "X-Filterset-DB-Type"
+
 #define FRF(r,a) do { \
   free(r->a##_re); \
   if(r->a) pcre_free(r->a); \
@@ -100,6 +102,14 @@ noit_lmdb_instance_t *noit_filters_get_lmdb_instance() {
 bool
 noit_filter_initialized() {
   return initialized;
+}
+void
+noit_filter_set_db_source_header(mtev_http_session_ctx *ctx) {
+  if (!ctx) {
+    return;
+  }
+  mtev_http_response_header_set(ctx, FILTERSET_DB_HEADER_STRING,
+    (noit_filters_get_lmdb_instance()) ? "LMDB" : "XML");
 }
 void
 noit_filter_update_last_touched(filterset_t *fs) {

--- a/src/noit_filters.h
+++ b/src/noit_filters.h
@@ -36,6 +36,7 @@
 
 #include <mtev_defines.h>
 #include <mtev_hash.h>
+#include <mtev_http.h>
 #include <mtev_console.h>
 #include <mtev_conf.h>
 #include "noit_check.h"
@@ -111,6 +112,9 @@ typedef struct {
 
 API_EXPORT(bool)
   noit_filter_initialized();
+
+API_EXPORT(void)
+   noit_filter_set_db_source_header(mtev_http_session_ctx *ctx);
 
 API_EXPORT(void)
   noit_filter_update_last_touched(filterset_t *fs);

--- a/src/noit_filters_lmdb.c
+++ b/src/noit_filters_lmdb.c
@@ -1276,12 +1276,14 @@ noit_filters_lmdb_rest_show_filters(mtev_http_rest_closure_t *restc,
 
   noit_filter_free_name_list(names, size);
 
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_ok(ctx, "text/xml");
   mtev_http_response_xml(ctx, doc);
   mtev_http_response_end(ctx);
   goto cleanup;
 
  error:
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_standard(ctx, error_code, "ERROR", "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;
@@ -1320,12 +1322,14 @@ noit_filters_lmdb_rest_show_filter(mtev_http_rest_closure_t *restc,
     goto not_found;
   }
 
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_ok(ctx, "text/xml");
   mtev_http_response_xml(ctx, doc);
   mtev_http_response_end(ctx);
   goto cleanup;
 
  not_found:
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_not_found(ctx, "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;
@@ -1362,16 +1366,19 @@ noit_filters_lmdb_rest_delete_filter(mtev_http_rest_closure_t *restc,
     goto error;
   }
 
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_ok(ctx, "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;
 
  error:
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_standard(ctx, 500, mdb_strerror(rc), "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;
 
  not_found:
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_not_found(ctx, "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;
@@ -1528,6 +1535,7 @@ noit_filters_lmdb_rest_set_filter(mtev_http_rest_closure_t *restc,
   return restc->fastpath(restc, restc->nparams, restc->params);
 
  error:
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_standard(ctx, error_code, "ERROR", "text/html");
   doc = xmlNewDoc((xmlChar *)"1.0");
   root = xmlNewDocNode(doc, NULL, (xmlChar *)"error", NULL);

--- a/src/noit_filters_rest.c
+++ b/src/noit_filters_rest.c
@@ -75,12 +75,14 @@ rest_show_filters(mtev_http_rest_closure_t *restc,
   doc = xmlNewDoc((xmlChar *)"1.0");
   root = xmlCopyNode(mtev_conf_section_to_xmlnodeptr(section), 1);
   xmlDocSetRootElement(doc, root);
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_ok(ctx, "text/xml");
   mtev_http_response_xml(ctx, doc);
   mtev_http_response_end(ctx);
   goto cleanup;
 
  not_found:
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_not_found(ctx, "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;
@@ -117,12 +119,14 @@ rest_show_filter(mtev_http_rest_closure_t *restc,
   doc = xmlNewDoc((xmlChar *)"1.0");
   root = xmlCopyNode(mtev_conf_section_to_xmlnodeptr(section), 1);
   xmlDocSetRootElement(doc, root);
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_ok(ctx, "text/xml");
   mtev_http_response_xml(ctx, doc);
   mtev_http_response_end(ctx);
   goto cleanup;
 
  not_found:
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_not_found(ctx, "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;
@@ -187,11 +191,13 @@ rest_delete_filter(mtev_http_rest_closure_t *restc,
   if(mtev_conf_write_file(NULL) != 0)
     mtevL(noit_error, "local config write failed\n");
   mtev_conf_mark_changed();
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_ok(ctx, "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;
 
  not_found:
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_not_found(ctx, "text/html");
   mtev_http_response_end(ctx);
   goto cleanup;
@@ -218,6 +224,7 @@ rest_cull_filter(mtev_http_rest_closure_t *restc,
     }
   }
   snprintf(cnt_str, sizeof(cnt_str), "%d", rv);
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_ok(ctx, "text/html");
   mtev_http_response_header_set(ctx, "X-Filters-Removed", cnt_str);
   mtev_http_response_end(ctx);
@@ -301,6 +308,7 @@ rest_set_filter(mtev_http_rest_closure_t *restc,
   return restc->fastpath(restc, restc->nparams, restc->params);
 
  error:
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_standard(ctx, error_code, "ERROR", "text/html");
   doc = xmlNewDoc((xmlChar *)"1.0");
   root = xmlNewDocNode(doc, NULL, (xmlChar *)"error", NULL);
@@ -332,6 +340,7 @@ rest_show_filter_updates(mtev_http_rest_closure_t *restc,
   const char *peer_str = mtev_http_request_querystring(req, "peer");
   uuid_t peerid;
   if(!peer_str || !restc->remote_cn || mtev_uuid_parse(peer_str, peerid) != 0) {
+    noit_filter_set_db_source_header(restc->http_ctx);
     mtev_http_response_server_error(ctx, "text/xml");
     mtev_http_response_end(ctx);
     return 0;
@@ -346,6 +355,7 @@ rest_show_filter_updates(mtev_http_rest_closure_t *restc,
   else {
     noit_cluster_xml_filter_changes(peerid, restc->remote_cn, prev, end, root);
   }
+  noit_filter_set_db_source_header(restc->http_ctx);
   mtev_http_response_ok(ctx, "text/xml");
   mtev_http_response_xml(ctx, doc);
   mtev_http_response_end(ctx);


### PR DESCRIPTION
When interacting with the check or filterset DB - add a header to each
that will inform the caller the source of the data.