### PR TITLE
 CIRC-4638 - Fix Empty XML LMDB Conversion

### DIFF
--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -3384,7 +3384,7 @@ noit_poller_lmdb_create_check_from_database_locked(MDB_cursor *cursor, uuid_t ch
     int copySize = 0;
     if (data->type == NOIT_LMDB_CHECK_ATTRIBUTE_TYPE) {
 #define COPYSTRING(val) do { \
-  copySize = MIN(mdb_data.mv_size, sizeof(val) - 1); \
+  copySize = (mdb_data.mv_data == NULL) ? 0 : MIN(mdb_data.mv_size, sizeof(val) - 1); \
   memcpy(val, mdb_data.mv_data, copySize); \
   val[copySize] = 0; \
 } while(0);
@@ -3472,9 +3472,16 @@ noit_poller_lmdb_create_check_from_database_locked(MDB_cursor *cursor, uuid_t ch
       }
       if (insertTable) {
         char *key = strdup(data->key);
-        char *value = (char *)malloc(mdb_data.mv_size + 1);
-        memcpy(value, mdb_data.mv_data, mdb_data.mv_size);
-        value[mdb_data.mv_size] = 0;
+        char *value = NULL;
+        if (mdb_data.mv_data == NULL) {
+          value = (char *)malloc(1);
+          value[0] = 0;
+        }
+        else {
+          value = (char *)malloc(mdb_data.mv_size + 1);
+          memcpy(value, mdb_data.mv_data, mdb_data.mv_size);
+          value[mdb_data.mv_size] = 0;
+        }
         mtev_hash_store(insertTable, key, strlen(key), value);
       }
     }

--- a/src/noit_check_lmdb.c
+++ b/src/noit_check_lmdb.c
@@ -50,7 +50,10 @@ static int noit_check_lmdb_add_attribute(xmlNodePtr root, xmlNodePtr attr, noit_
   if ((mdb_data.mv_data == NULL) && (mdb_data.mv_size > 0)) {
     /* If data is null, but we have a size, something is wrong - just skip
      * this key */
-    mtevL(mtev_error, "noit_check_lmdb_add_attribute: got null data for key with a size, skipping\n");
+    char uuid_str[UUID_STR_LEN + 1];
+    mtev_uuid_unparse_lower(key_data->id, uuid_str);
+    mtevL(mtev_error, "noit_check_lmdb_add_attribute: got null data for key with a size - check %s, namespace %s, key %s - skipping\n",
+        uuid_str, (key_data->ns) ? key_data->ns : "<null>", key_data->key);
     return 0;
   }
   if ((mdb_data.mv_data != NULL) && (mdb_data.mv_size > 0)) {
@@ -77,8 +80,10 @@ static int noit_check_lmdb_add_config(xmlNodePtr root, xmlNodePtr config, noit_l
   if ((mdb_data.mv_data == NULL) && (mdb_data.mv_size > 0)) {
     /* If data is null, but we have a size, something is wrong - just skip
      * this key */
-    mtevL(mtev_error, "noit_check_lmdb_add_config: got null data for key with a size, skipping\n");
-    return 0;
+    char uuid_str[UUID_STR_LEN + 1];
+    mtev_uuid_unparse_lower(key_data->id, uuid_str);
+    mtevL(mtev_error, "noit_check_lmdb_add_config: got null data for key with a size - check %s, namespace %s, key %s - skipping\n",
+        uuid_str, (key_data->ns) ? key_data->ns : "<null>", key_data->key);
   }
   if ((mdb_data.mv_data != NULL) && (mdb_data.mv_size > 0)) {
     val = (char *)calloc(1, mdb_data.mv_size + 1);

--- a/src/noit_check_lmdb.c
+++ b/src/noit_check_lmdb.c
@@ -42,15 +42,21 @@ static int noit_check_lmdb_show_check_json(mtev_http_rest_closure_t *restc,
 
 static int noit_check_lmdb_add_attribute(xmlNodePtr root, xmlNodePtr attr, noit_lmdb_check_data_t *key_data, MDB_val mdb_data, bool separate_stanza) {
   mtevAssert(root != NULL);
-  if ((!mdb_data.mv_data) || (mdb_data.mv_size == 0)) {
-    return 0;
-  }
+  char *val = NULL;
   if (!strcmp(key_data->key, "uuid")) {
     /* This should be set separately */
     return 0;
   }
-  char *val = (char *)calloc(1, mdb_data.mv_size + 1);
-  memcpy(val, mdb_data.mv_data, mdb_data.mv_size);
+  if ((mdb_data.mv_data == NULL) && (mdb_data.mv_size > 0)) {
+    /* If data is null, but we have a size, something is wrong - just skip
+     * this key */
+    mtevL(mtev_error, "noit_check_lmdb_add_attribute: got null data for key with a size, skipping\n");
+    return 0;
+  }
+  if ((mdb_data.mv_data != NULL) && (mdb_data.mv_size > 0)) {
+    val = (char *)calloc(1, mdb_data.mv_size + 1);
+    memcpy(val, mdb_data.mv_data, mdb_data.mv_size);
+  }
   if (separate_stanza) {
     mtevAssert(attr != NULL);
     xmlNodePtr child = NULL;
@@ -67,11 +73,17 @@ static int noit_check_lmdb_add_attribute(xmlNodePtr root, xmlNodePtr attr, noit_
 static int noit_check_lmdb_add_config(xmlNodePtr root, xmlNodePtr config, noit_lmdb_check_data_t *key_data, MDB_val mdb_data) {
   mtevAssert(root != NULL);
   mtevAssert(config != NULL);
-  if ((!mdb_data.mv_data) || (mdb_data. mv_size == 0)) {
+  char *val = NULL;
+  if ((mdb_data.mv_data == NULL) && (mdb_data.mv_size > 0)) {
+    /* If data is null, but we have a size, something is wrong - just skip
+     * this key */
+    mtevL(mtev_error, "noit_check_lmdb_add_config: got null data for key with a size, skipping\n");
     return 0;
   }
-  char *val = (char *)calloc(1, mdb_data.mv_size + 1);
-  memcpy(val, mdb_data.mv_data, mdb_data.mv_size);
+  if ((mdb_data.mv_data != NULL) && (mdb_data.mv_size > 0)) {
+    val = (char *)calloc(1, mdb_data.mv_size + 1);
+    memcpy(val, mdb_data.mv_data, mdb_data.mv_size);
+  }
   xmlNodePtr child = NULL;
   if (key_data->ns == NULL) {
     child = xmlNewNode(NULL, (xmlChar *)key_data->key);
@@ -1332,13 +1344,13 @@ noit_check_lmdb_convert_one_xml_check_to_lmdb(mtev_conf_section_t section, char 
   options = mtev_conf_get_hash(section, "config");
 
 #define WRITE_ATTR_TO_LMDB(type, ns, name, value, inherited, allocated) do { \
-  if ((inherited == mtev_false) && (strlen(value))) { \
+  if (inherited == mtev_false) { \
     key = noit_lmdb_make_check_key(checkid, type, ns, name, &key_size); \
     mtevAssert(key); \
     mdb_key.mv_data = key; \
     mdb_key.mv_size = key_size; \
     mdb_data.mv_data = value; \
-    mdb_data.mv_size = strlen(value); \
+    mdb_data.mv_size = ((value != NULL) ? strlen(value) : 0); \
     rc = mdb_cursor_put(cursor, &mdb_key, &mdb_data, 0); \
     if (rc == MDB_MAP_FULL) { \
       mdb_cursor_close(cursor); \

--- a/test/busted/simple/check_config/check_config_spec.lua
+++ b/test/busted/simple/check_config/check_config_spec.lua
@@ -1,0 +1,153 @@
+describe("check config", function()
+  local noit, api
+  setup(function()
+    Reconnoiter.clean_workspace()
+    noit = Reconnoiter.TestNoit:new()
+  end)
+  teardown(function() if noit ~= nil then noit:stop() end end)
+
+  local uuid = mtev.uuid()
+  local check_xml = function(seq)
+    return
+[=[<?xml version="1.0" encoding="utf8"?>
+<check>
+  <attributes>
+    <target>127.0.0.1</target>
+    <seq>]=] .. tostring(seq) .. [=[</seq>
+    <period>5000</period>
+    <timeout>1000</timeout>
+    <name>dummy</name>
+    <filterset>allowall</filterset>
+    <module>selfcheck</module>
+  </attributes>
+  <config>
+    <dummy></dummy>
+    <anotherdummy/>
+    <setdummy>hello</setdummy>
+  </config>
+</check>]=]
+  end
+
+  function validate_check_config(code, doc)
+    assert.is_equal(200, code)
+    assert.is_not_nil(doc)
+    local attr_count = 0
+    local target_count = 0
+    local seq_count = 0
+    local period_count = 0 
+    local timeout_count = 0
+    local name_count = 0
+    local filterset_count = 0
+    local module_count = 0
+    local uuid_count = 0
+    local config_count = 0
+    local dummy_count = 0
+    local anotherdummy_count = 0
+    local setdummy_count = 0
+    for result in doc:xpath('/check/attributes') do
+      attr_count = attr_count + 1
+      -- We should never hit a second loop here
+      assert.is_equal(1, attr_count)
+      local child_iter = result:children()
+      local unknown_nodes = 0
+      local total_nodes = 0
+      for child_node in child_iter do
+        local node_type = child_node:name()
+        local node_value = child_node:contents()
+        if node_type == "target" then
+          assert.is_equal(0, target_count)
+          target_count = target_count + 1
+          assert.is_equal("127.0.0.1", node_value)
+        elseif node_type == "seq" then
+          assert.is_equal(0, seq_count)
+          seq_count = seq_count + 1
+          assert.is_equal("100", node_value)
+        elseif node_type == "period" then
+          assert.is_equal(0, period_count)
+          period_count = period_count + 1
+          assert.is_equal("5000", node_value)
+        elseif node_type == "timeout" then
+          assert.is_equal(0, timeout_count)
+          timeout_count = timeout_count + 1
+          assert.is_equal("1000", node_value)
+        elseif node_type == "name" then
+          assert.is_equal(0, name_count)
+          name_count = name_count + 1
+          assert.is_equal("dummy", node_value)
+        elseif node_type == "filterset" then
+          assert.is_equal(0, filterset_count)
+          filterset_count = filterset_count + 1
+          assert.is_equal("allowall", node_value)
+        elseif node_type == "module" then
+          assert.is_equal(0, module_count)
+          module_count = module_count + 1
+          assert.is_equal("selfcheck", node_value)
+        elseif node_type == "uuid" then
+          assert.is_equal(0, uuid_count)
+          uuid_count = uuid_count + 1
+          assert.is_equal(uuid, node_value)
+        elseif node_type ~= "text" then
+          unknown_nodes = unknown_nodes + 1
+        end
+        if node_type ~= "text" then
+          total_nodes = total_nodes + 1
+        end
+      end
+      assert.is_equal(0, unknown_nodes)
+      assert.is_equal(8, total_nodes)
+    end
+    assert.is_equal(1, attr_count)
+    for result in doc:xpath('/check/config') do
+      config_count = config_count + 1
+      -- We should never hit a second loop here
+      assert.is_equal(1, config_count)
+      local child_iter = result:children()
+      local unknown_nodes = 0
+      local total_nodes = 0
+      for child_node in child_iter do
+        local node_type = child_node:name()
+        local node_value = child_node:contents()
+        if node_type == "dummy" then
+          assert.is_equal(0, dummy_count)
+          dummy_count = dummy_count + 1
+          assert.is_equal("", node_value)
+        elseif node_type == "anotherdummy" then
+          assert.is_equal(0, anotherdummy_count)
+          anotherdummy_count = anotherdummy_count + 1
+          assert.is_equal("", node_value)
+        elseif node_type == "setdummy" then
+          assert.is_equal(0, setdummy_count)
+          setdummy_count = setdummy_count + 1
+          assert.is_equal("hello", node_value)
+        elseif node_type ~= "text" then
+          unknown_nodes = unknown_nodes + 1
+        end 
+        if node_type ~= "text" then
+          total_nodes = total_nodes + 1
+        end
+      end
+      assert.is_equal(0, unknown_nodes)
+      assert.is_equal(3, total_nodes)
+    end
+    assert.is_equal(1, config_count)
+  end
+
+  it("should start", function()
+    assert.is_true(noit:start():is_booted())
+    api = noit:API()
+  end)
+
+  describe("returns correct config", function()
+    local capa, start, elapsed
+    it("is missing", function()
+      local code, obj = api:raw("GET", "/checks/show/" .. uuid)
+      assert.is.equal(404, code)
+    end)
+    it("returns correct config", function()
+      local code, doc, str = api:xml("PUT", "/checks/set/" .. uuid, check_xml(100))
+      validate_check_config(code, doc)
+      code, doc, str = api:xml("GET", "/checks/show/" .. uuid)
+      validate_check_config(code, doc)
+    end)
+  end)
+end)


### PR DESCRIPTION
We were skipping empty XML elements when converting from XML to LMDB.
Make sure we store these as keys will null values in the DB rather than
skipping them. Add tests to confirm that this works.