### PR TITLE
Facilities to register searches to director lanes

### DIFF
--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -65,7 +65,7 @@ lua_noit_metric_adjustsubscribe(lua_State *L, short bump) {
   if(mtev_uuid_parse(uuid, id)) {
     return luaL_error(L, "(un)subscribe expects a uuid as the first parameter");
   }
-  caql_cnt_t cnt = noit_adjust_metric_interest(id, metric_name, bump);
+  caql_cnt_t cnt = noit_metric_director_adjust_metric_interest(id, metric_name, bump);
   lua_pushnumber(L, cnt);
   return 1;
 }
@@ -82,7 +82,7 @@ lua_noit_metric_unsubscribe(lua_State *L) {
 
 static int
 lua_noit_checks_adjustsubscribe(lua_State *L, short bump) {
-  caql_cnt_t cnt = noit_adjust_checks_interest(bump);
+  caql_cnt_t cnt = noit_metric_director_adjust_checks_interest(bump);
   lua_pushnumber(L, cnt);
   return 1;
 }

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -326,6 +326,7 @@ noit_metric_director_adjust_metric_interest_on_thread(int thread_id, uuid_t id, 
     if(!mtev_hash_store(level2, metric_copy, strlen(metric_copy), vinterests)) {
       free(metric_copy);
       free(vinterests);
+      /* we leave newinterests allocated as we'll use it in our update path */
     } else {
       /* we set the interests here... we're good. */
       mtev_memory_end();

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -119,13 +119,14 @@ static stats_handle_t *stats_msg_queued;
 static stats_handle_t *stats_msg_delivered;
 
 static inline interest_cnt_t adjust_interest(interest_cnt_t in, short adj) {
+  int tmp = (int)in;
   /* If it is USHRT_MAX, then it gets stuck that way. */
-  if(in == USHRT_MAX) return USHRT_MAX;
-  in += adj;
+  if(tmp == USHRT_MAX) return USHRT_MAX;
+  tmp += adj;
   /* bounds cap it back to an unsigned short */
-  if(in < 0) return 0;
-  if(in > USHRT_MAX) return USHRT_MAX;
-  return in;
+  if(tmp < 0) return 0;
+  if(tmp > USHRT_MAX) return USHRT_MAX;
+  return (interest_cnt_t)tmp;
 }
 void
 noit_metric_director_message_ref(void *m) {

--- a/src/noit_metric_director.h
+++ b/src/noit_metric_director.h
@@ -35,12 +35,14 @@
 #include <mtev_hooks.h>
 #include <mtev_uuid.h>
 #include <noit_message_decoder.h>
+#include <noit_metric_tag_search.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef unsigned short caql_cnt_t;
+typedef unsigned short interest_cnt_t;
+typedef interest_cnt_t caql_cnt_t; /*legacy*/
 
 /**
  * Funnel metrics to certain threads for processing.
@@ -64,12 +66,20 @@ void noit_metric_director_dedupe(mtev_boolean dedupe);
 
 /* Tells noit to funnel all observed lines matching this id-metric
  * back to this thread */
-caql_cnt_t noit_adjust_metric_interest(uuid_t id, const char *metric, short cnt);
+interest_cnt_t noit_adjust_metric_interest(uuid_t id, const char *metric, short cnt) __attribute__((deprecated));
+interest_cnt_t noit_metric_director_adjust_metric_interest_on_thread(int thread_id, uuid_t id, const char *metric, short cnt);
+interest_cnt_t noit_metric_director_adjust_metric_interest(uuid_t id, const char *metric, short cnt);
 
+uint32_t noit_metric_director_register_search_on_thread(int thread_id, int64_t account_id, uuid_t check_uuid, noit_metric_tag_search_ast_t *ast);
+uint32_t noit_metric_director_register_search(int64_t account_id, uuid_t check_uuid, noit_metric_tag_search_ast_t *ast);
+mtev_boolean noit_metric_director_deregister_search_on_thread(int thread_id, uint32_t ast_id);
+mtev_boolean noit_metric_director_deregister_search(uint32_t ast_id);
 /* Tells noit that this thread is interested in recieving "check" information.
  * This includes C records and S records.
  */
-caql_cnt_t noit_adjust_checks_interest(short cnt);
+interest_cnt_t noit_adjust_checks_interest(short cnt) __attribute__((deprecated));
+interest_cnt_t noit_metric_director_adjust_checks_interest_on_thread(int thread_id, short cnt);
+interest_cnt_t noit_metric_director_adjust_checks_interest(short cnt);
 
 /* This gets the next line you've subscribed to, if available. */
 noit_metric_message_t *noit_metric_director_lane_next();

--- a/src/noit_metric_tag_search.h
+++ b/src/noit_metric_tag_search.h
@@ -97,10 +97,14 @@ typedef struct noit_metric_tag_search_ast_t {
   } contents;
   void *user_data;
   void (*user_data_free)(void *);
+  uint32_t refcnt;
 } noit_metric_tag_search_ast_t;
 
 API_EXPORT(noit_metric_tag_search_ast_t *)
   noit_metric_tag_search_clone(const noit_metric_tag_search_ast_t *);
+
+API_EXPORT(noit_metric_tag_search_ast_t *)
+  noit_metric_tag_search_ref(noit_metric_tag_search_ast_t *);
 
 API_EXPORT(void)
   noit_metric_tag_search_free(noit_metric_tag_search_ast_t *);


### PR DESCRIPTION
* Make the direct interests thread safe (cross-thread registration)
* Support registering searches with a lane
* Simplify the distribution path
* Make noit_metric_search_tag_ast_t ref counted.