### PR TITLE
metric_id should act like an IRONdb search result.

### DIFF
--- a/src/modules/noit_lua_noit_binding.c
+++ b/src/modules/noit_lua_noit_binding.c
@@ -169,6 +169,7 @@ static const luaL_Reg noit_binding[] = {
   { "metric_director_subscribe_account", lua_noit_metric_subscribe_account},
   { "metric_director_drop_before", lua_noit_metric_drop_before},
   { "metric_director_drop_backlogged", lua_noit_metric_drop_backlogged},
+  { "metric_id_new", noit_lua_new_metric_id},
   { "tag_parse", lua_noit_tag_parse},
   { "tag_tostring", lua_noit_tag_tostring},
   { "tag_search_parse", lua_noit_tag_search_parse},


### PR DESCRIPTION
* Add an explicit constructor from parts.
* Add `canonical_name` and `tagless_name`
* Add `{stream,check,measurement}_tags` accessors that work like IRONdb
  search items.  This allows simple exctraction of stream tags from
  canonical metric names uses the one-true-code.