### PR TITLE
Make the version cleaner and avoid snprintf.

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -138,7 +138,7 @@ LUALIBS=@LUALIBS@
 LIBNOIT_OBJS=noit_check_log_helpers.lo noit_fb.lo bundle.pb-c.lo \
 	noit_check_tools_shared.lo stratcon_ingest.lo noit_metric_rollup.lo \
 	noit_metric_director.lo noit_message_decoder.hlo noit_metric.hlo \
-	noit_metric_tag_search.lo
+	noit_metric_tag_search.lo noit_version.lo
 
 B2SM_OBJS=noit_b2sm.o noit_check_log_helpers.o bundle.pb-c.o noit_message_decoder.o noit_metric.o
 

--- a/src/noit_version.c
+++ b/src/noit_version.c
@@ -1,0 +1,2 @@
+#define NOIT_VERSION_IMPL
+#include <noit_version.h>


### PR DESCRIPTION
* Expose three global symbols to aide debuggers.