### PR TITLE
Call module cleanup immediately on removal.

### DIFF
--- a/src/modules/external.c
+++ b/src/modules/external.c
@@ -608,6 +608,7 @@ static int external_init(noit_module_t *self) {
 
 static void external_cleanup(noit_module_t *self, noit_check_t *check) {
   struct check_info *ci = (struct check_info *)check->closure;
+  check->closure = NULL;
   if(ci) {
     if(ci->timeout_event) {
       eventer_remove(ci->timeout_event);

--- a/src/modules/graphite.cpp
+++ b/src/modules/graphite.cpp
@@ -441,6 +441,7 @@ static int noit_graphite_initiate_check(noit_module_t *self,
       eventer_t newe = eventer_alloc_fd(listener_listen_handler, ccl, ccl->ipv4_listen_fd,
                                         EVENTER_READ | EVENTER_EXCEPTION);
       eventer_add(newe);
+      mtevL(nldeb, "graphite %s IPv4 listening on fd %d at port %d\n", self->hdr.name, ccl->ipv4_listen_fd, ccl->port);
     }
     if(port > 0) ccl->ipv6_listen_fd = socket(AF_INET6, NE_SOCK_CLOEXEC|SOCK_STREAM, IPPROTO_TCP);
     if(ccl->ipv6_listen_fd < 0) {
@@ -497,6 +498,7 @@ static int noit_graphite_initiate_check(noit_module_t *self,
       eventer_t newe = eventer_alloc_fd(listener_listen_handler, ccl, ccl->ipv6_listen_fd,
                                         EVENTER_READ | EVENTER_EXCEPTION);
       eventer_add(newe);
+      mtevL(nldeb, "graphite %s IPv6 listening on fd %d at port %d\n", self->hdr.name, ccl->ipv6_listen_fd, ccl->port);
     }
   }
   INITIATE_CHECK(listener_submit, self, check, cause);

--- a/src/modules/mysql.c
+++ b/src/modules/mysql.c
@@ -88,6 +88,7 @@ static void mysql_cleanse(noit_module_t *self, noit_check_t *check) {
 static void mysql_cleanup(noit_module_t *self, noit_check_t *check) {
   mysql_check_info_t *ci = check->closure;
   mysql_cleanse(self, check);
+  check->closure = NULL;
   free(ci);
 }
 static void mysql_ingest_stats(mysql_check_info_t *ci) {

--- a/src/modules/ping_icmp.c
+++ b/src/modules/ping_icmp.c
@@ -568,6 +568,7 @@ static int ping_icmp_real_send(eventer_t e, int mask,
 }
 static void ping_check_cleanup(noit_module_t *self, noit_check_t *check) {
   struct check_info *ci = (struct check_info *)check->closure;
+  check->closure = NULL;
   if(ci) {
     if(ci->timeout_event) {
       eventer_t e = eventer_remove(ci->timeout_event);
@@ -579,7 +580,6 @@ static void ping_check_cleanup(noit_module_t *self, noit_check_t *check) {
     if(ci->turnaround) free(ci->turnaround);
     free(ci);
   }
-  check->closure = NULL;
 }
 static int ping_icmp_send(noit_module_t *self, noit_check_t *check,
                           noit_check_t *cause) {

--- a/src/modules/postgres.c
+++ b/src/modules/postgres.c
@@ -99,6 +99,7 @@ static void postgres_cleanse(noit_module_t *self, noit_check_t *check) {
 }
 static void postgres_cleanup(noit_module_t *self, noit_check_t *check) {
   postgres_check_info_t *ci = check->closure;
+  check->closure = NULL;
   postgres_cleanse(self, check);
   free(ci);
 }

--- a/src/modules/selfcheck.c
+++ b/src/modules/selfcheck.c
@@ -92,6 +92,7 @@ static void selfcheck_cleanse(noit_module_t *self, noit_check_t *check) {
 }
 static void selfcheck_cleanup(noit_module_t *self, noit_check_t *check) {
   selfcheck_info_t *ci = check->closure;
+  check->closure = NULL;
   selfcheck_cleanse(self, check);
   free(ci);
 }

--- a/src/modules/test_abort.c
+++ b/src/modules/test_abort.c
@@ -82,10 +82,11 @@ static mtev_log_stream_t nldeb = NULL;
 
 static void test_abort_cleanup(noit_module_t *self, noit_check_t *check) {
   test_abort_check_info_t *ci = check->closure;
+  check->closure = NULL;
   if(ci) {
     memset(ci, 0, sizeof(*ci));
+    free(ci);
   }
-  free(ci);
 }
 
 static int test_abort_drive_session(eventer_t e, int mask, void *closure,


### PR DESCRIPTION
This requires module cleanup functions to be safe when run multiple
times.  This fixes lingering sockets on checks that have listeners
which is important when the check is modified but the port is unchanged
because the stale check will still have an active listener, but will
not handle arriving data which can cause loss.