### PR TITLE
Fix cross call double free in lua cleanup.

### DIFF
--- a/src/noit_check_log.c
+++ b/src/noit_check_log.c
@@ -142,9 +142,9 @@ void feed_process_f(void *vfp, noit_check_t *check, const char *feedname) {
   mtev_log_stream_t ls;
   ls = mtev_log_stream_find(feedname);
   if(!ls ||
-     (fp->log_check && !fp->log_check(ls, check)) ||
-     (fp->log_metrics && !fp->log_metrics(ls, check, fp->metric_whence, fp->metrics)) ||
-     (fp->log_metric && !fp->log_metric(ls, check, fp->uuid_str, fp->metric_whence, fp->metric))) {
+     (fp->log_check && fp->log_check(ls, check) < 0) ||
+     (fp->log_metrics && fp->log_metrics(ls, check, fp->metric_whence, fp->metrics) < 0) ||
+     (fp->log_metric && fp->log_metric(ls, check, fp->uuid_str, fp->metric_whence, fp->metric) < 0)) {
     fp->to_remove = realloc(fp->to_remove, sizeof(*fp->to_remove) * (fp->to_remove_cnt + 1));
     fp->to_remove[fp->to_remove_cnt++] = strdup(feedname);
   }

--- a/test/busted/simple/websocket/websocket_spec.lua
+++ b/test/busted/simple/websocket/websocket_spec.lua
@@ -5,7 +5,7 @@ describe("noit", function()
     noit = Reconnoiter.TestNoit:new("noit",
       { noit_ssl_on = "on",
         rest_acls = { { type = "deny", rules = { { type = "allow", url = "^/livestream/" },
-                                                 { type = "allow", url = "^/checks/set/" } } } }
+                                                 { type = "allow", url = "^/checks/(?:show|set)/" } } } }
       })
   end)
   teardown(function() if noit ~= nil then noit:stop() end end)
@@ -81,6 +81,15 @@ describe("noit", function()
       assert.is_not_nil(expect.check_cnt)
       assert.is_not_nil(expect.checks_run)
       if wsc ~= nil then wsc:close() end
+    end)
+  end)
+
+  describe("selfcheck still there", function()
+    it("waits", function() mtev.sleep(5) end)
+    it("is reporting", function()
+      local code, doc = api:json("GET", "/checks/show/" .. uuid .. ".json")
+      assert.is.equal(200, code)
+      assert.is.equal(true, doc.status.good)
     end)
   end)
 end)


### PR DESCRIPTION
Lua cleanup and timeout both free the resume info. The timeout can
cause logging which can fail which can induce a cleanup causing a
free before out intended free.