### PR TITLE
Fix bare tags and statsd DD tag decoding

### DIFF
--- a/src/modules/statsd.c
+++ b/src/modules/statsd.c
@@ -271,7 +271,6 @@ statsd_handle_payload(noit_check_t **checks, int nchecks,
         case 'c':
         case 'm':
           for(i=0;i<nchecks;i++) {
-            mtevL(nlerr, "update_check -> %s\n", key);
             update_check(checks[i], key, *type, diff, sampleRate);
           }
           break;

--- a/test/busted/checks_data/statsd/statsd_spec.lua
+++ b/test/busted/checks_data/statsd/statsd_spec.lua
@@ -41,12 +41,16 @@ explicit_histogram:1|ms
 explicit_histogram:2|ms
 explicit_histogram:3|ms
 explicit_histogram:4|ms|@0.0083333
+dd_baretag1:60|g#foo
+dd_baretag2:60|g#foo:
 ]=]
   local witnessed_stats = {}
   local expected_stats = {}
   expected_stats["test|ST[env:prod,node:foo,statsd_type:gauge]"] = { _type = "n", _value = "1.844674407371e+19" }
   expected_stats["explicit_histogram|ST[statsd_type:timing]"] = { _type = "h", _value = "AAQKAAABFAAAAR4AAAEoAAB4" }
   expected_stats["times|ST[statsd_type:count]"] = { _type = "h", _value = "AAEAAABu" }
+  expected_stats["dd_baretag1|ST[foo:,statsd_type:gauge]"] = { _type = "n", _value = '6.000000000000e+01' }
+  expected_stats["dd_baretag2|ST[foo:,statsd_type:gauge]"] = { _type = "n", _value = '6.000000000000e+01' }
 
   it("should start", function()
     assert.is_true(noit:start():is_booted())

--- a/test/test_tags.c
+++ b/test/test_tags.c
@@ -15,6 +15,18 @@ const char *tcpairs[][2] = {
   { "woop|ST[a:b,c:d]|MT{foo:bar}|ST[c:d,e:f,a:b]",
     "woop|ST[a:b,c:d,e:f]|MT{foo:bar}" },
 
+  { "woop|ST[a:b,e,c:d]|MT{foo:bar}",
+    "woop|ST[a:b,c:d,e:]|MT{foo:bar}" },
+
+  { "woop|ST[a:b,e:,c:d]|MT{foo:bar}",
+    "woop|ST[a:b,c:d,e:]|MT{foo:bar}" },
+
+  { "woop|ST[a:b,c:d]|MT{foo:bar}|ST[e]",
+    "woop|ST[a:b,c:d,e:]|MT{foo:bar}" },
+
+  { "woop|ST[a:b,c:d]|MT{foo:bar}|ST[e:]",
+    "woop|ST[a:b,c:d,e:]|MT{foo:bar}" },
+
   { "simple string with spaces",
     "simple string with spaces" },
 
@@ -417,7 +429,7 @@ void test_canon(const char *in, const char *expect) {
   int len;
   char buff[MAX_METRIC_TAGGED_NAME];
   len = noit_metric_canonicalize(in, strlen(in), buff, sizeof(buff), mtev_true);
-  if(len < 0) test_assert_namef(expect == NULL, "canon(%s) -> NULL", in);
+  if(len < 0) test_assert_namef(expect == NULL, "canon(%s) -> NULL (%d)", in, len);
   else test_assert_namef(expect && !strcmp(expect, buff), "canon(%s) -> %s", expect, buff);
 }
 


### PR DESCRIPTION
* Allow decoding of bare tag names `foo` as `foo:`
* Fix decoding of DD-style statsd tags in multi-line mode.