### PR TITLE
CIRC-6377 - Set LMDB Checks In Jobq

### DIFF
--- a/src/noit_check_lmdb.c
+++ b/src/noit_check_lmdb.c
@@ -685,7 +685,7 @@ noit_check_lmdb_set_check_asynch(eventer_t e, int mask, void *closure,
       }
       rest_check_free_attrs(target, name, module);
       if(exists) {
-        SET_ERROR_CODE(409, "target`name already registered");
+        SET_ERROR_CODE(409, "target name already registered");
       }
       if(!m) {
         SET_ERROR_CODE(412, "module does not exist");

--- a/src/noit_check_lmdb.h
+++ b/src/noit_check_lmdb.h
@@ -43,7 +43,7 @@ typedef enum {
 
 int noit_check_lmdb_show_checks(mtev_http_rest_closure_t *restc, int npats, char **pats);
 int noit_check_lmdb_show_check(mtev_http_rest_closure_t *restc, int npats, char **pats);
-int noit_check_lmdb_set_check(mtev_http_rest_closure_t *restc, int npats, char **pats);
+int noit_check_lmdb_set_check(mtev_http_rest_closure_t *restc, int npats, char **pats, eventer_jobq_t *jobq);
 int noit_check_lmdb_remove_check_from_db(uuid_t checkid, mtev_boolean force);
 int noit_check_lmdb_delete_check(mtev_http_rest_closure_t *restc, int npats, char **pats);
 void noit_check_lmdb_poller_process_checks(uuid_t *uuids, int uuid_cnt);

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -1279,7 +1279,6 @@ rest_check_get_attrs(xmlNodePtr attr, char **target, char **name, char **module)
   *name = NULL;
   *module = NULL;
 
-  int cnt = 0;
   for(a = attr->children; a; a = a->next) {
     if(!strcmp((char *)a->name, "target")) {
       *target = (char *)xmlNodeGetContent(a);

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -1279,6 +1279,7 @@ rest_check_get_attrs(xmlNodePtr attr, char **target, char **name, char **module)
   *name = NULL;
   *module = NULL;
 
+  int cnt = 0;
   for(a = attr->children; a; a = a->next) {
     if(!strcmp((char *)a->name, "target")) {
       *target = (char *)xmlNodeGetContent(a);
@@ -1307,6 +1308,8 @@ rest_check_free_attrs(char *target, char *name, char *module) {
 
 void
 noit_check_rest_init() {
+  set_check_jobq = eventer_jobq_create("set_check");
+  eventer_jobq_set_concurrency(set_check_jobq, 1);
   mtevAssert(mtev_http_rest_register_auth(
     "GET", "/", "^config(/.*)?$",
     noit_rest_show_config, mtev_http_rest_client_cert_auth

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -1307,8 +1307,8 @@ rest_check_free_attrs(char *target, char *name, char *module) {
 
 void
 noit_check_rest_init() {
-  set_check_jobq = eventer_jobq_create("set_check");
-  eventer_jobq_set_concurrency(set_check_jobq, 1);
+  set_check_jobq = eventer_jobq_retrieve("set_check");
+  mtevAssert(set_check_jobq);
   mtevAssert(mtev_http_rest_register_auth(
     "GET", "/", "^config(/.*)?$",
     noit_rest_show_config, mtev_http_rest_client_cert_auth

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -88,6 +88,8 @@
 } while(0)
 #define NODE_CONTENT(parent, k, v) NS_NODE_CONTENT(parent, NULL, k, v, )
 
+static eventer_jobq_t *set_check_jobq = NULL;
+
 static void
 add_metrics_to_node(noit_check_t *check, stats_t *c, xmlNodePtr metrics, const char *type,
                     int include_time, mtev_hash_table *supp) {
@@ -1113,7 +1115,7 @@ rest_set_check(mtev_http_rest_closure_t *restc,
   mtev_boolean exists = mtev_false;
 
   if(noit_check_get_lmdb_instance()) {
-    return noit_check_lmdb_set_check(restc, npats, pats);
+    return noit_check_lmdb_set_check(restc, npats, pats, set_check_jobq);
   }
   NCINIT_WR;
 

--- a/src/noit_lmdb_tools.c
+++ b/src/noit_lmdb_tools.c
@@ -268,8 +268,6 @@ noit_lmdb_instance_t *noit_lmdb_tools_open_instance(char *path)
 {
   int rc;
   MDB_env *env;
-  MDB_envinfo mei;
-  MDB_stat mst;
 
   mtevAssert(lmdb_instance_mkdir(path));
 
@@ -292,22 +290,6 @@ noit_lmdb_instance_t *noit_lmdb_tools_open_instance(char *path)
     mdb_env_close(env);
     return NULL;
   }
-
-  mdb_env_info(env, &mei);
-  mdb_env_stat(env, &mst);
-
-  uint64_t current_size = mst.ms_psize * mei.me_last_pgno;
-
-#define TEN_GB (uint64_t)(10UL * 1024UL * 1024UL * 1024UL)
-  if (current_size < TEN_GB) {
-    rc = mdb_env_set_mapsize(env, TEN_GB); // at least 10 GB mapsize
-    if (rc != 0) {
-      errno = rc;
-      mdb_env_close(env);
-      return NULL;
-    }
-  }
-#undef TEN_GB
 
   MDB_txn *txn;
   MDB_dbi dbi;

--- a/src/noitd.c
+++ b/src/noitd.c
@@ -319,6 +319,11 @@ noitd_init_globals(void) {
   noit_module_init_globals();
 }
 
+static void 
+noitd_jobqs_init(void) {
+  mtev_main_eventer_config("jobq_set_check", "10,1,50,gc");
+}
+
 int main(int argc, char **argv) {
   mtev_lock_op_t lock = MTEV_LOCK_OP_LOCK;
   mtev_memory_init();
@@ -326,6 +331,7 @@ int main(int argc, char **argv) {
   if(!config_file) config_file = strdup(ETC_DIR "/" APPNAME ".conf");
   if (xpath) lock = MTEV_LOCK_OP_NONE;
   noitd_init_globals();
+  noitd_jobqs_init();
   return mtev_main(APPNAME, config_file, debug, foreground,
                    lock, glider, droptouser, droptogroup, 
                    child_main);


### PR DESCRIPTION
When configuring a check via LMDB, offload the work into a jobq rather than doing it in the
main eventer pool.