### PR TITLE
CIRC-6516 - Quiet Warning

### DIFF
--- a/src/stratcon_jlog_streamer.c
+++ b/src/stratcon_jlog_streamer.c
@@ -609,6 +609,8 @@ stratcon_jlog_recv_handler(eventer_t e, int mask, void *closure,
         if(ctx->stats) stats_set(ctx->stats->jlog_id, STATS_TYPE_UINT32, &ctx->header.chkpt.log);
         change_state(ctx, nctx, JLOG_STREAMER_WANT_COUNT, now);
         break;
+      default:
+        break;
     }
   }
   /* never get here */


### PR DESCRIPTION
Quiet warning because eclipse paints the entire switch statement
yellow