### PR TITLE
Fix run-tests for non-ASAN builds

### DIFF
--- a/test/busted/run-tests.sh
+++ b/test/busted/run-tests.sh
@@ -15,9 +15,9 @@ LD_LIBRARY_PATH=$DIR/../../src
 ASAN_OPTIONS="${ASAN_OPTIONS},log_path=${PWD}/${DIR}/asan.log"
 export LD_LIBRARY_PATH ASAN_SYMBOLIZER_PATH ASAN_OPTIONS
 
-if [ -n $BUILD_ASAN ]; then
+if [ -z "$BUILD_ASAN" ]; then
+  mtevbusted $@
+else
   echo "Running tests with ASAN"
   mtevbusted-asan $@
-else
-  mtevbusted $@
 fi

--- a/test/busted/run-tests.sh
+++ b/test/busted/run-tests.sh
@@ -3,21 +3,23 @@
 PATH=$PATH:/opt/circonus/bin:/opt/pgsql9214/bin
 export PATH
 
-if [ -f /opt/llvm-5.0.0/bin/llvm-symbolizer ]
-then
-  ASAN_SYMBOLIZER_PATH=/opt/llvm-5.0.0/bin/llvm-symbolizer
-else
-  ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
-fi
-
 DIR=`dirname $0`
 LD_LIBRARY_PATH=$DIR/../../src
-ASAN_OPTIONS="${ASAN_OPTIONS},log_path=${PWD}/${DIR}/asan.log"
-export LD_LIBRARY_PATH ASAN_SYMBOLIZER_PATH ASAN_OPTIONS
+export LD_LIBRARY_PATH
 
 if [ -z "$BUILD_ASAN" ]; then
   mtevbusted $@
 else
+  if [ -f /opt/llvm-5.0.0/bin/llvm-symbolizer ]
+  then
+    ASAN_SYMBOLIZER_PATH=/opt/llvm-5.0.0/bin/llvm-symbolizer
+  else
+    ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
+  fi
+
+  ASAN_OPTIONS="${ASAN_OPTIONS},log_path=${PWD}/${DIR}/asan.log"
+  export ASAN_SYMBOLIZER_PATH ASAN_OPTIONS
+
   echo "Running tests with ASAN"
   mtevbusted-asan $@
 fi


### PR DESCRIPTION
#714 added a library preload to the Lua test harness if any `ASAN_*` environment variables were set. This was the case even for non-ASAN builds due to some pre-existing ASAN work in `run-tests.sh`. Non-ASAN builds are now clean of ASAN-related environment variables.