### PR TITLE
CIRC-6923 - Bad Ref Count

### DIFF
--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -1907,7 +1907,7 @@ check_recycle_bin_processor_internal() {
     }
 
     if (free_check == mtev_true) {
-      mtevL(check_debug, "0x%p: Check is ready to free.\n", check);
+      mtevL(check_debug, "%p: Check is ready to free.\n", check);
       noit_poller_free_check_internal(curr->checker, mtev_true);
       if(prev) prev->next = curr->next;
       else checker_rcb = curr->next;


### PR DESCRIPTION
- Properly decrement the reference count from all the eventer
callbacks for ping handlers
- Fix double free