### PR TITLE
CIRC-6926 - Bad Ref Cnt

### DIFF
--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -1443,9 +1443,12 @@ noit_check_transient_remove_feed(noit_check_t *check, const char *feed) {
     mtev_uuid_unparse_lower(check->checkid, uuid_str);
     mtevL(check_debug, "Unwatching %s@%d\n", uuid_str, check->period);
     pthread_mutex_lock(&watchlist_lock);
-    mtev_skiplist_remove(watchlist, check, NULL);
+
+    if (mtev_skiplist_remove(watchlist, check, NULL)) {
+      noit_check_deref(check);
+    }
+
     pthread_mutex_unlock(&watchlist_lock);
-    noit_check_deref(check);
     mtev_skiplist_destroy(check->feeds, free);
     free(check->feeds);
     check->feeds = NULL;

--- a/src/noit_check.h
+++ b/src/noit_check.h
@@ -82,9 +82,9 @@
 #define NP_TRANSIENT             0x00000010
 /* The check requires name service resolution */
 #define NP_RESOLVE               0x00000020
-/* Name service resolution has been compelted for the check */
+/* Name service resolution has been completed for the check */
 #define NP_RESOLVED              0x00000040
-/* The check has been deleted, but is kept as a tombstone */
+/* The check has been deleted but is kept as a tombstone */
 #define NP_DELETED               0x00000080
 /* This check should have 'S' lines suppressed from logging */
 #define NP_SUPPRESS_STATUS       0x00001000
@@ -184,7 +184,7 @@ API_EXPORT(int) noit_poller_check_count();
 API_EXPORT(int) noit_poller_transient_check_count();
 API_EXPORT(void) noit_poller_reload(const char *xpath); /* NULL for all */
 API_EXPORT(void) noit_poller_reload_lmdb(uuid_t *checks, int cnt); /* NULL for all */
-API_EXPORT(void*) noit_poller_check_found_and_backdated(uuid_t uuid,
+API_EXPORT(noit_check_t*) noit_poller_check_found_and_backdated(uuid_t uuid,
                                                         int64_t config_seq,
                                                         int *found,
                                                         mtev_boolean *backdated);


### PR DESCRIPTION
- Use a lock to avoid races between the ref count
  and lookup in the skip list
- In noit_check_add_to_list:
    - Avoid race on mtev_skiplist_remove
    - Pointer removed is not always identical to its
   replacement.  Led to bad reference count for both
   the existing value and its replacement
    - Missing reference count increment in noit_check_add_to_list
   when inserting into the skip list
- Return noit_check_t* from noit_poller_check_found_and_backdated
- Don't assume vcheck stays null in noit_poller_check_found_and_backdated
- Optimize noit_poller_process_checks so it depends on the return
  valie of mtev_skiplist_insert to avoid atomics
- Introduce watchlist_lock to avoid races in-between mtev_skiplist_find and
  possibly removing the value before its reference count is incremented
- noit_console_show_watchlist did not increment ref counts before use
- typos

- [X] Jira [report](https://circonus.atlassian.net/browse/CIRC-6925)
- [X] Tests pass