### PR TITLE
Make metric serarch parsing more flexible.

### DIFF
--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -739,8 +739,7 @@ unescape_regex(char *inout) {
   char *in = inout, *out = inout;
   while(*in) {
     if(*in == '\\') {
-      if(in[1] == ':' || in[1] == ',' || in[1] == '/' ||
-         in[1] == '(' || in[1] == ')' || in[1] == '\\') {
+      if(in[1] == '/' || in[1] == '\\') {
         in++;
       }
     }
@@ -750,14 +749,13 @@ unescape_regex(char *inout) {
 }
 
 static inline mtev_boolean is_allowable_escape(char in) {
-  return in == '\\' || in == ')' || in == '(' || in == ':' || in == ',' || in == '"';
+  return in == '\\' || in == '"';
 }
 static inline void unescape_tag_string(char *inout) {
   char *in = inout, *out = inout;
   while(*in) {
     if(*in == '\\') {
-      if(in[1] == ':' || in[1] == ',' || in[1] == '"' ||
-         in[1] == '(' || in[1] == ')' || in[1] == '\\') {
+      if(in[1] == '"' || in[1] == '\\') {
         in++;
       }
     }

--- a/test/test_tags.c
+++ b/test/test_tags.c
@@ -136,7 +136,7 @@ struct {
       { "and(foo:bar,b\"c29tZTpzdHVmZltoZXJlXQ==\":value)", mtev_true },
       { "and(b/c29tZS4q/:value)", mtev_true },
       { "and(quux:value)", mtev_false },
-      { "and([exact]\"some\\:stuff[here]\":value)", mtev_true },
+      { "and([exact]\"some:stuff[here]\":value)", mtev_true },
       { "and(empty:/^$/)", mtev_true },
       { "and(empty:)", mtev_true },
       { "and(empty)", mtev_true },
@@ -152,7 +152,7 @@ struct {
       { "and(*:*)", mtev_true },
       { "and(*:bar)", mtev_true },
       { "and(foo:bar)", mtev_false },
-      { "and(*:/ba\\(.?\\)r/)", mtev_true },
+      { "and(*:/ba(.?)r/)", mtev_true },
       { "and(b\"KGZvbyk=\":bar)", mtev_true },
       { "and(b/XChm/:bar)", mtev_true },
       { NULL, 0 }


### PR DESCRIPTION
* Allow spaces
* Treat // as a greedier match (allowing for more reserved characters)
* Allow for "<escaped string>" as an alternative b"<encoded string>"