### PR TITLE
CIRC-7654 Search Hinting On Match Nodes

### DIFF
--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -953,6 +953,10 @@ noit_metric_tag_parse_hint(const char *query, const char **endq, noit_metric_tag
     *endq += 10;
     node->hint = HINT_INDEX_NONE;
   }
+  else if (!strncmp(*endq, "index:full", 10)) {
+    *endq += 10;
+    node->hint = HINT_INDEX_FULL;
+  }
   else if (!strncmp(*endq, "index:default", 13)) {
     *endq += 13;
     node->hint = HINT_INDEX_DEFAULT;

--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -1011,7 +1011,7 @@ noit_metric_tag_part_parse(const char *query, const char **endq, mtev_boolean al
     noit_metric_tag_search_ast_t *arg = noit_metric_tag_part_parse(*endq, endq, mtev_true);
     while(**endq && isspace(**endq)) (*endq)++;
     if (hinted) {
-      if (!noit_metric_tag_parse_hint(*endq, endq, node)) goto error;
+      if (!noit_metric_tag_parse_hint(*endq, endq, arg)) goto error;
     }
     if(**endq != ')' || !arg) goto error;
     noit_metric_tag_search_add_arg(node, arg);

--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -935,6 +935,9 @@ noit_metric_tag_match_compile(struct noit_var_match_t *m, const char **endq, int
 static bool
 noit_metric_tag_parse_hint(const char *query, const char **endq, noit_metric_tag_search_ast_t *node) {
   bool found = true;
+  if (!node) return false;
+  node->hint = HINT_INDEX_DEFAULT;
+
   *endq = query;
   if (!*endq) return false;
   if (**endq != ',') return false;
@@ -942,11 +945,10 @@ noit_metric_tag_parse_hint(const char *query, const char **endq, noit_metric_tag
   while(**endq && isspace(**endq)) (*endq)++;
   if (!*endq) return false;;
   if (!strncmp(*endq, "index:none", 10)) {
-    *endq = query + 11;
+    *endq += 10;
     node->hint = HINT_INDEX_NONE;
   }
   if (!found) {
-    node->hint = HINT_INDEX_UNKNOWN;
     return false;
   }
   while(**endq && isspace(**endq)) (*endq)++;
@@ -1004,6 +1006,14 @@ noit_metric_tag_part_parse(const char *query, const char **endq, mtev_boolean al
     }
     if(**endq != ')' || !arg) goto error;
     noit_metric_tag_search_add_arg(node, arg);
+    (*endq)++;
+  }
+  else if(!strncmp(query, "hint(", 5)) {
+    *endq = query + 5;
+    while(**endq && isspace(**endq)) (*endq)++;
+    noit_metric_tag_search_ast_t *arg = noit_metric_tag_part_parse(*endq, endq, mtev_true);
+    while(**endq && isspace(**endq)) (*endq)++;
+    if (!*endq) goto error;
     (*endq)++;
   }
   else if(allow_match) {

--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -619,6 +619,11 @@ noit_metric_tag_search_get_name(const noit_metric_tag_search_ast_t *node) {
   return node->operation == OP_MATCH ? &node->contents.spec.name : NULL;
 }
 
+const noit_metric_tag_search_hint_t
+noit_metric_tag_search_get_hint(const noit_metric_tag_search_ast_t *node) {
+  return node ? node->hint : HINT_INDEX_DEFAULT;
+}
+
 const char *
 noit_var_val(const noit_var_match_t *node) {
   return node ? node->str : NULL;

--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -953,6 +953,10 @@ noit_metric_tag_parse_hint(const char *query, const char **endq, noit_metric_tag
     *endq += 10;
     node->hint = HINT_INDEX_NONE;
   }
+  else if (!strncmp(*endq, "index:default", 13)) {
+    *endq += 13;
+    node->hint = HINT_INDEX_DEFAULT;
+  }
   if (!found) {
     return false;
   }

--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -1008,14 +1008,6 @@ noit_metric_tag_part_parse(const char *query, const char **endq, mtev_boolean al
     noit_metric_tag_search_add_arg(node, arg);
     (*endq)++;
   }
-  else if(!strncmp(query, "hint(", 5)) {
-    *endq = query + 5;
-    while(**endq && isspace(**endq)) (*endq)++;
-    noit_metric_tag_search_ast_t *arg = noit_metric_tag_part_parse(*endq, endq, mtev_true);
-    while(**endq && isspace(**endq)) (*endq)++;
-    if (!*endq) goto error;
-    (*endq)++;
-  }
   else if(allow_match) {
     node = calloc(1, sizeof(*node));
     node->operation = OP_MATCH;

--- a/src/noit_metric_tag_search.h
+++ b/src/noit_metric_tag_search.h
@@ -146,6 +146,9 @@ API_EXPORT(const noit_var_match_t *)
 API_EXPORT(const noit_var_match_t *)
   noit_metric_tag_search_get_name(const noit_metric_tag_search_ast_t *node);
 
+API_EXPORT(const noit_metric_tag_search_hint_t)
+  noit_metric_tag_search_get_hint(const noit_metric_tag_search_ast_t *node);
+
 API_EXPORT(mtev_boolean)
   noit_var_match(const noit_var_match_t *node, const char *subj, size_t subj_len);
 

--- a/src/noit_metric_tag_search.h
+++ b/src/noit_metric_tag_search.h
@@ -76,7 +76,7 @@ typedef enum {
 } noit_metric_tag_search_op_t;
 
 typedef enum {
-  HINT_INDEX_UNKNOWN = 0,
+  HINT_INDEX_DEFAULT = 0,
   HINT_INDEX_NONE
 } noit_metric_tag_search_hint_t;
 

--- a/src/noit_metric_tag_search.h
+++ b/src/noit_metric_tag_search.h
@@ -75,6 +75,11 @@ typedef enum {
   OP_MATCH
 } noit_metric_tag_search_op_t;
 
+typedef enum {
+  HINT_INDEX_UNKNOWN = 0,
+  HINT_INDEX_NONE
+} noit_metric_tag_search_hint_t;
+
 typedef struct noit_metric_tag_search_ast_t noit_metric_tag_search_ast_t;
 typedef struct noit_var_match_t noit_var_match_t;
 

--- a/src/noit_metric_tag_search.h
+++ b/src/noit_metric_tag_search.h
@@ -77,7 +77,8 @@ typedef enum {
 
 typedef enum {
   HINT_INDEX_DEFAULT = 0,
-  HINT_INDEX_NONE
+  HINT_INDEX_NONE,
+  HINT_INDEX_FULL
 } noit_metric_tag_search_hint_t;
 
 typedef struct noit_metric_tag_search_ast_t noit_metric_tag_search_ast_t;


### PR DESCRIPTION
Allow setting various search hints on tag search nodes. Consumers can then utilize these hints to alter search behavior.