### PR TITLE
CIRC-7654 - Make Const Things Const In Tag Search

### DIFF
--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -1074,8 +1074,8 @@ out:
   return rv;
 }
 static mtev_boolean
-noit_metric_tag_match_evaluate_against_tags_multi(struct noit_metric_tag_match_t *match,
-                                                  noit_metric_tagset_t **sets, int set_cnt) {
+noit_metric_tag_match_evaluate_against_tags_multi(const struct noit_metric_tag_match_t *match,
+                                                  const noit_metric_tagset_t **sets, const int set_cnt) {
   for(int s=0; s<set_cnt; s++) {
     noit_metric_tagset_t *set = sets[s];
     for(int i=0; i<set->tag_count; i++) {
@@ -1090,8 +1090,8 @@ noit_metric_tag_match_evaluate_against_tags_multi(struct noit_metric_tag_match_t
   return mtev_false;
 }
 mtev_boolean
-noit_metric_tag_search_evaluate_against_tags_multi(noit_metric_tag_search_ast_t *search,
-                                                   noit_metric_tagset_t **set, int set_cnt) {
+noit_metric_tag_search_evaluate_against_tags_multi(const noit_metric_tag_search_ast_t *search,
+                                                   const noit_metric_tagset_t **set, const int set_cnt) {
   switch(search->operation) {
     case OP_MATCH: return noit_metric_tag_match_evaluate_against_tags_multi(&search->contents.spec, set, set_cnt);
     case OP_NOT_ARGS:
@@ -1120,14 +1120,14 @@ noit_metric_tag_search_evaluate_against_tags_multi(noit_metric_tag_search_ast_t 
   return mtev_false;
 }
 mtev_boolean
-noit_metric_tag_search_evaluate_against_tags(noit_metric_tag_search_ast_t *search,
-                                             noit_metric_tagset_t *set) {
+noit_metric_tag_search_evaluate_against_tags(const noit_metric_tag_search_ast_t *search,
+                                             const noit_metric_tagset_t *set) {
   return noit_metric_tag_search_evaluate_against_tags_multi(search, &set, 1);
 }
 
 mtev_boolean
-noit_metric_tag_search_evaluate_against_metric_id(noit_metric_tag_search_ast_t *search,
-                                                  noit_metric_id_t *id) {
+noit_metric_tag_search_evaluate_against_metric_id(const noit_metric_tag_search_ast_t *search,
+                                                  const noit_metric_id_t *id) {
   mtev_memory_begin();
 
 #define MKTAGSETCOPY(name) \

--- a/src/noit_metric_tag_search.h
+++ b/src/noit_metric_tag_search.h
@@ -155,16 +155,16 @@ API_EXPORT(const char *)
   noit_var_impl_name(const noit_var_match_t *node);
 
 API_EXPORT(mtev_boolean)
-  noit_metric_tag_search_evaluate_against_tags(noit_metric_tag_search_ast_t *search,
-                                               noit_metric_tagset_t *tags);
+  noit_metric_tag_search_evaluate_against_tags(const noit_metric_tag_search_ast_t *search,
+                                               const noit_metric_tagset_t *tags);
 
 API_EXPORT(mtev_boolean)
-  noit_metric_tag_search_evaluate_against_tags_multi(noit_metric_tag_search_ast_t *search,
-                                                     noit_metric_tagset_t **tags, int ntagsets);
+  noit_metric_tag_search_evaluate_against_tags_multi(const noit_metric_tag_search_ast_t *search,
+                                                     const noit_metric_tagset_t **tags, const int ntagsets);
 
 API_EXPORT(mtev_boolean)
-  noit_metric_tag_search_evaluate_against_metric_id(noit_metric_tag_search_ast_t *search,
-                                                    noit_metric_id_t *id);
+  noit_metric_tag_search_evaluate_against_metric_id(const noit_metric_tag_search_ast_t *search,
+                                                    const noit_metric_id_t *id);
 
 API_EXPORT(mtev_boolean)
   noit_metric_tag_search_has_hint(const noit_metric_tag_search_ast_t *search, const char *cat, const char *name);


### PR DESCRIPTION
These fields are not modified, so we should flag them as const.