### PR TITLE
Argument To noit_metric_tag_search_unparse Should Be const

### DIFF
--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -1200,7 +1200,7 @@ noit_metric_tag_search_has_hint(const noit_metric_tag_search_ast_t *search, cons
 }
 
 static void
-noit_metric_tag_search_unparse_part(noit_metric_tag_search_ast_t *search, mtev_dyn_buffer_t *buf) {
+noit_metric_tag_search_unparse_part(const noit_metric_tag_search_ast_t *search, mtev_dyn_buffer_t *buf) {
   switch(search->operation) {
     case OP_MATCH: {
       noit_metric_tag_match_t *spec = &search->contents.spec;
@@ -1242,7 +1242,7 @@ noit_metric_tag_search_unparse_part(noit_metric_tag_search_ast_t *search, mtev_d
 }
 
 char *
-noit_metric_tag_search_unparse(noit_metric_tag_search_ast_t *search) {
+noit_metric_tag_search_unparse(const noit_metric_tag_search_ast_t *search) {
   char *res;
   mtev_dyn_buffer_t buf;
   mtev_dyn_buffer_init(&buf);

--- a/src/noit_metric_tag_search.h
+++ b/src/noit_metric_tag_search.h
@@ -170,7 +170,7 @@ API_EXPORT(mtev_boolean)
   noit_metric_tag_search_has_hint(const noit_metric_tag_search_ast_t *search, const char *cat, const char *name);
 
 API_EXPORT(char *)
-  noit_metric_tag_search_unparse(noit_metric_tag_search_ast_t *);
+  noit_metric_tag_search_unparse(const noit_metric_tag_search_ast_t *);
 
 API_EXPORT(void)
   noit_var_matcher_register(const noit_var_match_impl_t *matcher);


### PR DESCRIPTION
The search passed to noit_metric_tag_search_unparse is not modified; it
should be passed in as a const.