### PR TITLE
Add Filterrule Type To Apply Measurement Tags

### DIFF
--- a/src/flatbuffers/filterset_rule.fbs
+++ b/src/flatbuffers/filterset_rule.fbs
@@ -29,6 +29,11 @@ table FiltersetRuleFlushPeriod {
   value: long (id: 1);
 }
 
+table FiltersetRuleMeasurementTag {
+  cat: string(id: 0);
+  val: string(id: 1);
+}
+
 table FiltersetRule {
   id: string (id: 0);
   filterset_flush_period: FiltersetRuleFlushPeriod (id: 1);
@@ -36,6 +41,7 @@ table FiltersetRule {
   skipto_value: string(id: 3);
   info: [FiltersetRuleInfo] (id: 4);
   tags: [FiltersetRuleTagInfo] (id: 5);
+  measurement_tag_value: FiltersetRuleMeasurementTag(id: 6);
 }
 
 root_type FiltersetRule;

--- a/src/modules/histogram.c
+++ b/src/modules/histogram.c
@@ -168,6 +168,11 @@ noit_log_histo_encoded_function_validate(noit_check_t *check, struct timeval *wh
 #define SECPART(a) ((unsigned long)(a)->tv_sec)
 #define MSECPART(a) ((unsigned long)((a)->tv_usec / 1000) + ms_cluster_jitter)
 
+  metric_t m_onstack = { .metric_name = (char *)metric_name,
+                         .metric_type = METRIC_GUESS,
+                         .metric_value = { .vp = NULL } };
+  bool filtered = !noit_apply_filterset(check->filterset, check, &m_onstack);
+
   if(live_feed && check->feeds) {
     mtev_skiplist_node *curr, *next;
     curr = next = mtev_skiplist_getlist(check->feeds);
@@ -186,10 +191,7 @@ noit_log_histo_encoded_function_validate(noit_check_t *check, struct timeval *wh
     }
   }
 
-  metric_t m_onstack = { .metric_name = (char *)metric_name,
-                         .metric_type = METRIC_GUESS,
-                         .metric_value = { .vp = NULL } };
-  if(!noit_apply_filterset(check->filterset, check, &m_onstack)) return;
+  if(filtered) return;
   if(!live_feed) {
     SETUP_LOG(metrics, return);
     mtev_log(metrics_log, whence, __FILE__, __LINE__,

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -110,11 +110,12 @@ add_metrics_to_node(noit_check_t *check, stats_t *c, xmlNodePtr metrics, const c
       if(mtev_hash_retrieve(supp, k, klen, &unused)) continue;
       mtev_hash_store(supp, k, klen, NULL);
     }
+    bool filtered = noit_apply_filterset(check->filterset, check, m);
     xmlAddChild(metrics, (tmp = xmlNewNode(NULL, (xmlChar *)"metric")));
     xmlSetProp(tmp, (xmlChar *)"name", (xmlChar *)m->metric_name);
     buff[0] = m->metric_type; buff[1] = '\0';
     xmlSetProp(tmp, (xmlChar *)"type", (xmlChar *)buff);
-    if(!noit_apply_filterset(check->filterset, check, m)) {
+    if(!filtered) {
       xmlSetProp(tmp, (xmlChar *)"filtered", (xmlChar *)"true");
     }
     if(m->metric_value.s) {

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -110,12 +110,12 @@ add_metrics_to_node(noit_check_t *check, stats_t *c, xmlNodePtr metrics, const c
       if(mtev_hash_retrieve(supp, k, klen, &unused)) continue;
       mtev_hash_store(supp, k, klen, NULL);
     }
-    bool filtered = noit_apply_filterset(check->filterset, check, m);
+    bool filtered = !noit_apply_filterset(check->filterset, check, m);
     xmlAddChild(metrics, (tmp = xmlNewNode(NULL, (xmlChar *)"metric")));
     xmlSetProp(tmp, (xmlChar *)"name", (xmlChar *)m->metric_name);
     buff[0] = m->metric_type; buff[1] = '\0';
     xmlSetProp(tmp, (xmlChar *)"type", (xmlChar *)buff);
-    if(!filtered) {
+    if(filtered) {
       xmlSetProp(tmp, (xmlChar *)"filtered", (xmlChar *)"true");
     }
     if(m->metric_value.s) {

--- a/src/noit_conf_checks.c
+++ b/src/noit_conf_checks.c
@@ -454,8 +454,8 @@ nc_print_stat_metrics(mtev_console_closure_t ncct,
   while(mtev_hash_next(metrics, &iter, &k, &klen, &data)) {
     if(sorted_keys && mcount < cnt) sorted_keys[mcount++] = k;
     else {
-      noit_stats_snprint_metric(buff, sizeof(buff), (metric_t *)data);
       filtered = !noit_apply_filterset(check->filterset, check, (metric_t *)data);
+      noit_stats_snprint_metric(buff, sizeof(buff), (metric_t *)data);
       nc_printf(ncct, "  %c%s\n", filtered ? '*' : ' ', buff);
     }
   }
@@ -467,8 +467,8 @@ nc_print_stat_metrics(mtev_console_closure_t ncct,
       if(mtev_hash_retrieve(metrics,
                             sorted_keys[j], strlen(sorted_keys[j]),
                             &data)) {
-        noit_stats_snprint_metric(buff, sizeof(buff), (metric_t *)data);
         filtered = !noit_apply_filterset(check->filterset, check, (metric_t *)data);
+        noit_stats_snprint_metric(buff, sizeof(buff), (metric_t *)data);
         nc_printf(ncct, "  %c%s\n", filtered ? '*' : ' ', buff);
       }
     }

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -819,6 +819,10 @@ noit_apply_filterset(const char *filterset,
           skipto_rule = r->skipto_rule;
           continue;
         }
+        else if (r->type == NOIT_FILTER_ADD_MEASUREMENT_TAG) {
+          noit_add_measurement_tag(r, &mtset);
+          continue;
+        }
         ck_pr_inc_32(&r->matches);
         ret = (r->type == NOIT_FILTER_ACCEPT) ? mtev_true : mtev_false;
         break;

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -768,7 +768,11 @@ noit_apply_filterset(const char *filterset,
           continue;
         }
         else if (r->type == NOIT_FILTER_ADD_MEASUREMENT_TAG) {
-          noit_add_measurement_tag(r, &mtset);
+          if (noit_add_measurement_tag(r, &mtset)) {
+            mtevL(nf_error, "could not apply measurement tag - <%s:%s>\n",
+              r->measurement_tag.add_measurement_tag_cat,
+              r->measurement_tag.add_measurement_tag_val ? r->measurement_tag.add_measurement_tag_val : "");
+          }
           continue;
         }
         ck_pr_inc_32(&r->matches);
@@ -820,7 +824,11 @@ noit_apply_filterset(const char *filterset,
           continue;
         }
         else if (r->type == NOIT_FILTER_ADD_MEASUREMENT_TAG) {
-          noit_add_measurement_tag(r, &mtset);
+          if (noit_add_measurement_tag(r, &mtset)) {
+            mtevL(nf_error, "could not apply measurement tag - <%s:%s>\n",
+              r->measurement_tag.add_measurement_tag_cat,
+              r->measurement_tag.add_measurement_tag_val ? r->measurement_tag.add_measurement_tag_val : "");
+          }
           continue;
         }
         ck_pr_inc_32(&r->matches);

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -767,13 +767,13 @@ noit_apply_filterset(const char *filterset,
           skipto_rule = r->skipto_rule;
           continue;
         }
+        else if (r->type == NOIT_FILTER_ADD_MEASUREMENT_TAG) {
+          noit_add_measurement_tag(r, &mtset);
+          continue;
+        }
         ck_pr_inc_32(&r->matches);
         ret = (r->type == NOIT_FILTER_ACCEPT) ? mtev_true : mtev_false;
         break;
-      }
-      else if (r->type == NOIT_FILTER_ADD_MEASUREMENT_TAG) {
-        noit_add_measurement_tag(r, &mtset);
-        continue;
       }
       /* If we need some of these and we have an auto setting that isn't fulfilled for each of them, we can add and succeed */
 #define CHECK_ADD(rname) (!need_##rname || (r->rname##_auto_hash_max > 0 && r->rname##_ht && mtev_hash_size(r->rname##_ht) < r->rname##_auto_hash_max))

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -703,7 +703,7 @@ noit_add_measurement_tag(filterrule_t *r,
   for (int i = 0; i < mtset->tag_count; i++) {
     if (nlen == mtset->tags[i].total_size && !strncmp(encoded_nametag, mtset->tags[i].tag, nlen)) {
       /* tag is already there */
-      return 0;
+      return 1;
     }
   }
 
@@ -796,13 +796,14 @@ noit_apply_filterset(const char *filterset,
           continue;
         }
         else if (r->type == NOIT_FILTER_ADD_MEASUREMENT_TAG) {
-          if (noit_add_measurement_tag(r, metric, &expanded_metric_name, &mtset)) {
+          int result = noit_add_measurement_tag(r, metric, &expanded_metric_name, &mtset);
+          if (result == 0) {
+            mt_modified = true;
+          }
+          else if (result < 0) {
             mtevL(nf_error, "could not apply measurement tag - <%s:%s>\n",
               r->measurement_tag.add_measurement_tag_cat,
               r->measurement_tag.add_measurement_tag_val ? r->measurement_tag.add_measurement_tag_val : "");
-          }
-          else {
-            mt_modified = true;
           }
           continue;
         }
@@ -855,13 +856,14 @@ noit_apply_filterset(const char *filterset,
           continue;
         }
         else if (r->type == NOIT_FILTER_ADD_MEASUREMENT_TAG) {
-          if (noit_add_measurement_tag(r, metric, &expanded_metric_name, &mtset)) {
+          int result = noit_add_measurement_tag(r, metric, &expanded_metric_name, &mtset);
+          if (result == 0) {
+            mt_modified = true;
+          }
+          else if (result < 0) {
             mtevL(nf_error, "could not apply measurement tag - <%s:%s>\n",
               r->measurement_tag.add_measurement_tag_cat,
               r->measurement_tag.add_measurement_tag_val ? r->measurement_tag.add_measurement_tag_val : "");
-          }
-          else {
-            mt_modified = true;
           }
           continue;
         }

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -688,7 +688,7 @@ noit_apply_filterrule_metric(filterrule_t *r,
 static int
 noit_add_measurement_tag(filterrule_t *r,
                          noit_metric_tagset_t *mtset) {
-  if(r && mtset && mtset->tag_count < MAX_TAGS-1) {
+  if(r && mtset && r->measurement_tag.add_measurement_tag_cat && mtset->tag_count < MAX_TAGS-1) {
     char encoded_nametag[NOIT_TAG_MAX_PAIR_LEN+1];
     char decoded_nametag[NOIT_TAG_MAX_PAIR_LEN+1];
     snprintf(decoded_nametag, sizeof(decoded_nametag), "%s%c%s",

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -691,9 +691,10 @@ noit_add_measurement_tag(filterrule_t *r,
   if(r && mtset && r->measurement_tag.add_measurement_tag_cat && mtset->tag_count < MAX_TAGS-1) {
     char encoded_nametag[NOIT_TAG_MAX_PAIR_LEN+1];
     char decoded_nametag[NOIT_TAG_MAX_PAIR_LEN+1];
+    const char *cat = r->measurement_tag.add_measurement_tag_cat;
+    const char *val = r->measurement_tag.add_measurement_tag_val ? r->measurement_tag.add_measurement_tag_val : "";
     snprintf(decoded_nametag, sizeof(decoded_nametag), "%s%c%s",
-      r->measurement_tag.add_measurement_tag_cat, NOIT_TAG_DECODED_SEPARATOR,
-      r->measurement_tag.add_measurement_tag_val);
+      cat, NOIT_TAG_DECODED_SEPARATOR, val);
     size_t nlen = noit_metric_tagset_encode_tag(encoded_nametag, sizeof(encoded_nametag),
                                                 decoded_nametag, strlen(decoded_nametag));
     mtset->tags[mtset->tag_count].category_size = strlen(r->measurement_tag.add_measurement_tag_cat + 1);

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -767,13 +767,13 @@ noit_apply_filterset(const char *filterset,
           skipto_rule = r->skipto_rule;
           continue;
         }
-        else if (r->type == NOIT_FILTER_ADD_MEASUREMENT_TAG) {
-          noit_add_measurement_tag(r, &mtset);
-          continue;
-        }
         ck_pr_inc_32(&r->matches);
         ret = (r->type == NOIT_FILTER_ACCEPT) ? mtev_true : mtev_false;
         break;
+      }
+      else if (r->type == NOIT_FILTER_ADD_MEASUREMENT_TAG) {
+        noit_add_measurement_tag(r, &mtset);
+        continue;
       }
       /* If we need some of these and we have an auto setting that isn't fulfilled for each of them, we can add and succeed */
 #define CHECK_ADD(rname) (!need_##rname || (r->rname##_auto_hash_max > 0 && r->rname##_ht && mtev_hash_size(r->rname##_ht) < r->rname##_auto_hash_max))

--- a/src/noit_filters.h
+++ b/src/noit_filters.h
@@ -49,6 +49,8 @@
 #define FILTERSET_DENY_STRING "deny"
 #define FILTERSET_SKIPTO_STRING "skipto:"
 #define FILTERSET_SKIPTO_STRING_NO_COLON "skipto"
+#define FILTERSET_ADD_MEASUREMENT_TAG_STRING "add_measurement_tag:"
+#define FILTERSET_ADD_MEASUREMENT_TAG_STRING_NO_COLON "add_measurement_tag"
 
 #define FILTERSET_TARGET_STRING "target"
 #define FILTERSET_MODULE_STRING "module"
@@ -58,12 +60,18 @@
 #define FILTERSET_TAG_STREAM_TAGS_STRING "stream_tags"
 #define FILTERSET_TAG_MEASUREMENT_TAGS_STRING "measurement_tags"
 
-typedef enum { NOIT_FILTER_ACCEPT, NOIT_FILTER_DENY, NOIT_FILTER_SKIPTO } noit_ruletype_t;
+typedef enum { NOIT_FILTER_ACCEPT, NOIT_FILTER_DENY, NOIT_FILTER_SKIPTO, NOIT_FILTER_ADD_MEASUREMENT_TAG } noit_ruletype_t;
+
+typedef struct _measurement_tag {
+  char *add_measurement_tag_cat;
+  char *add_measurement_tag_val;
+} _measurement_tag_t;
 
 typedef struct _filterrule {
   char *ruleid;
   char *skipto;
   struct _filterrule *skipto_rule;
+  _measurement_tag_t measurement_tag;
   noit_ruletype_t type;
   char *target_re;
   pcre *target_override;

--- a/src/noit_filters_lmdb.c
+++ b/src/noit_filters_lmdb.c
@@ -999,7 +999,7 @@ noit_filters_lmdb_populate_filterset_xml_from_lmdb(xmlNodePtr root, char *fs_nam
             xmlSetProp(rule, (xmlChar *)"type", (xmlChar *)type);
           }
         }
-        if (!strcmp(type, FILTERSET_ADD_MEASUREMENT_TAG_STRING_NO_COLON)) {
+        else if (!strcmp(type, FILTERSET_ADD_MEASUREMENT_TAG_STRING_NO_COLON)) {
           if (noit_ns(FiltersetRule_measurement_tag_value_is_present(fs_rule))) {
             noit_ns(FiltersetRuleMeasurementTag_table_t) frmt = noit_ns(FiltersetRule_measurement_tag_value(fs_rule));
             flatbuffers_string_t cat = noit_ns(FiltersetRuleMeasurementTag_cat(frmt));

--- a/src/noit_filters_lmdb.c
+++ b/src/noit_filters_lmdb.c
@@ -427,8 +427,9 @@ noit_filters_lmdb_one_xml_rule_to_memory(mtev_conf_section_t rule_conf) {
 
   if(!mtev_conf_get_stringbuf(rule_conf, "@type", buffer, sizeof(buffer)) ||
     (strcmp(buffer, FILTERSET_ACCEPT_STRING) && strcmp(buffer, FILTERSET_ALLOW_STRING) && strcmp(buffer, FILTERSET_DENY_STRING) &&
-    strncmp(buffer, FILTERSET_SKIPTO_STRING, strlen(FILTERSET_SKIPTO_STRING)))) {
-    mtevL(mtev_error, "rule must have type 'accept' or 'allow' or 'deny' or 'skipto:'\n");
+    strncmp(buffer, FILTERSET_SKIPTO_STRING, strlen(FILTERSET_SKIPTO_STRING)) &&
+    strncmp(buffer, FILTERSET_ADD_MEASUREMENT_TAG_STRING, strlen(FILTERSET_ADD_MEASUREMENT_TAG_STRING)))) {
+    mtevL(mtev_error, "rule must have type 'accept' or 'allow' or 'deny' or 'skipto:' or 'add_measurement_tag:'\n");
     free(rule);
     return NULL;
   }

--- a/src/noit_filters_lmdb.c
+++ b/src/noit_filters_lmdb.c
@@ -999,6 +999,23 @@ noit_filters_lmdb_populate_filterset_xml_from_lmdb(xmlNodePtr root, char *fs_nam
             xmlSetProp(rule, (xmlChar *)"type", (xmlChar *)type);
           }
         }
+        if (!strcmp(type, FILTERSET_ADD_MEASUREMENT_TAG_STRING_NO_COLON)) {
+          if (noit_ns(FiltersetRule_measurement_tag_value_is_present(fs_rule))) {
+            noit_ns(FiltersetRuleMeasurementTag_table_t) frmt = noit_ns(FiltersetRule_measurement_tag_value(fs_rule));
+            flatbuffers_string_t cat = noit_ns(FiltersetRuleMeasurementTag_cat(frmt));
+            flatbuffers_string_t val = noit_ns(FiltersetRuleMeasurementTag_val(frmt));
+            if (cat) {
+              snprintf(buffer, sizeof(buffer), "%s:%s:%s", type, cat, val ? val : "");
+              xmlSetProp(rule, (xmlChar *)"type", (xmlChar *)buffer);
+            }
+            else {
+              xmlSetProp(rule, (xmlChar *)"type", (xmlChar *)type);
+            }
+          }
+          else {
+            xmlSetProp(rule, (xmlChar *)"type", (xmlChar *)type);
+          }
+        }
         else {
           xmlSetProp(rule, (xmlChar *)"type", (xmlChar *)type);
         }

--- a/src/noit_filters_lmdb.c
+++ b/src/noit_filters_lmdb.c
@@ -326,7 +326,8 @@ noit_filters_lmdb_write_flatbuffer_to_db(char *filterset_name,
         }
         break;
       case NOIT_FILTER_ADD_MEASUREMENT_TAG:
-        // TODO: Need to handle this
+        noit_ns(FiltersetRule_rule_type_create_str(B, FILTERSET_ADD_MEASUREMENT_TAG_STRING_NO_COLON));
+        // TODO: Need to handle adding measurement tags in the flatbuffer
         break;
       default:
         mtevFatal(mtev_error, "noit_filters_lmdb_write_flatbuffer_to_db: undefined type in db (%d) for %s\n", (int)rule->type, filterset_name);

--- a/src/noit_metric.c
+++ b/src/noit_metric.c
@@ -804,11 +804,8 @@ noit_metric_canonicalize_ex(const char *input, size_t input_len, char *output, s
     *out++ = '}';
   }
   mtev_dyn_buffer_destroy(&tag_scratch);
-  if((out-buff) > MAX_METRIC_TAGGED_NAME) {
-    if (output_len > 0) output[0] = 0;
-    return -8;
-  }
   memcpy(output, buff, (out-buff));
   if(null_term) output[out-buff] = '\0';
+  if((out-buff) > MAX_METRIC_TAGGED_NAME) return -8;
   return (out - buff);
 }

--- a/src/noit_metric.c
+++ b/src/noit_metric.c
@@ -804,8 +804,11 @@ noit_metric_canonicalize_ex(const char *input, size_t input_len, char *output, s
     *out++ = '}';
   }
   mtev_dyn_buffer_destroy(&tag_scratch);
+  if((out-buff) > MAX_METRIC_TAGGED_NAME) {
+    if (output_len > 0) output[0] = 0;
+    return -8;
+  }
   memcpy(output, buff, (out-buff));
   if(null_term) output[out-buff] = '\0';
-  if((out-buff) > MAX_METRIC_TAGGED_NAME) return -8;
   return (out - buff);
 }

--- a/test/busted/cluster/filters/filter_spec.lua
+++ b/test/busted/cluster/filters/filter_spec.lua
@@ -25,6 +25,12 @@ describe("cluster", function()
     rule_data = {}
 
     rule = {}
+    rule.type = "add_measurement_tag:some_mt_cat:some_mt_val"
+    rule.metric = "^dummymetric$"
+    rule.target = "^www.github.com$"
+    rule.module = "^httptrap$"
+    table.insert(rule_data, rule)
+    rule = {}
     rule.type = "accept"
     rule.metric = "^dummymetric$"
     rule.target = "^www.github.com$"

--- a/test/busted/simple/filters/filter_spec.lua
+++ b/test/busted/simple/filters/filter_spec.lua
@@ -121,6 +121,7 @@ describe("noit", function()
       local code, doc, raw = api:raw("PUT", "/filters/set/" .. filter_uuid,
         [=[<?xml version="1.0" encoding="utf8"?>
         <filterset filter_flush_period="1000">
+          <rule type="add_measurement_tag:some_random:measurement_tag"/>
           <rule type="allow" metric_auto_add="2"/>
           <rule type="deny"/>
         </filterset>]=])

--- a/test/busted/simple/filters/filter_spec.lua
+++ b/test/busted/simple/filters/filter_spec.lua
@@ -121,7 +121,10 @@ describe("noit", function()
       local code, doc, raw = api:raw("PUT", "/filters/set/" .. filter_uuid,
         [=[<?xml version="1.0" encoding="utf8"?>
         <filterset filter_flush_period="1000">
-          <rule type="add_measurement_tag:some_random:measurement_tag"/>
+          <rule type="add_measurement_tag:first_mt_tag:first_mt_val"/>
+          <rule type="add_measurement_tag:second_mt_tag:second_mt_val"/>
+          <rule type="add_measurement_tag:third_mt_tag:third_mt_val"/>
+          <rule type="add_measurement_tag:fourth_mt_tag:fourth_mt_val"/>
           <rule type="allow" metric_auto_add="2"/>
           <rule type="deny"/>
         </filterset>]=])
@@ -151,7 +154,7 @@ describe("noit", function()
       local runs = {}
       local run_count = 0
       for i=1,10 do
-        local code, doc = api:json("GET", "/checks/show/" .. check_uuid .. ".json") 
+        local code, doc = api:json("GET", "/checks/show/" .. check_uuid .. ".json")
         assert.message("show check").is.equal(200, code)
         if runs[tostring(doc.last_run)] == nil then
           run_count = run_count + 1


### PR DESCRIPTION
Add a new filterrule type, `add_measurement_tag:<tag>:<cat>`, that will apply a measurement tag and move on to the next rule in the filterset if it is encountered.