### PR TITLE
CIRC-8777 - use after free

### DIFF
--- a/src/modules/histogram.c
+++ b/src/modules/histogram.c
@@ -521,7 +521,6 @@ histogram_sweep_calculations(struct histogram_config *conf, noit_check_t *check)
   mtev_hash_table *metrics;
   double *out_q = NULL;
 
-  noit_check_get_stats_current(check);
   /* Only need to do work if it's asked for */
   if(!conf->mean && !conf->sum && conf->n_quantiles < 1) return;
   metrics = noit_check_get_module_metadata(check, histogram_module_id);

--- a/src/noit_metric.c
+++ b/src/noit_metric.c
@@ -36,6 +36,7 @@
 
 #include <mtev_b64.h>
 #include <mtev_json_object.h>
+#include <mtev_memory.h>
 #include <mtev_str.h>
 #include <mtev_log.h>
 #include <mtev_maybe_alloc.h>
@@ -811,6 +812,25 @@ noit_metric_canonicalize_ex(const char *input, size_t input_len, char *output, s
   memcpy(output, buff, (out-buff));
   if(null_term) output[out-buff] = '\0';
   return (out - buff);
+}
+static void
+noit_metric_free(void *vm)
+{
+  if (vm) {
+    metric_t *m = vm;
+    free(m->metric_name);
+    free(m->expanded_metric_name);
+    free(m->metric_value.vp);
+  }
+}
+metric_t *
+ noit_metric_alloc(void)
+{
+  metric_t *m = (metric_t*) mtev_memory_safe_malloc_cleanup(sizeof(*m),
+      noit_metric_free);
+
+  memset(m, 0, sizeof(*m));
+  return m;
 }
 const char *
 noit_metric_get_full_metric_name(metric_t *m) {

--- a/src/noit_metric.h
+++ b/src/noit_metric.h
@@ -267,6 +267,8 @@ API_EXPORT(const char *)
   noit_metric_tags_parse_one(const char *tagnm, size_t tagnmlen,
                              noit_metric_tag_t *output, mtev_boolean *toolong);
 
+API_EXPORT(metric_t *)
+  noit_metric_alloc(void);
 API_EXPORT(const char *)
   noit_metric_get_full_metric_name(metric_t *m);
 


### PR DESCRIPTION
When using ``noit_stats_mark_metric_logged`` it takes ownership of the passed
in ``metric_t`` pointer.  This creates a race between the 3 updated call sites
clearing, and freeing, their hash table versus the one found inside
``noit_stats``

Harmonize everything with ownership under ``noit_stats`` and the call sites
respecting that

- Remove call to ``noit_check_get_stats_current``, return value is not used
- Consolidate ``metric_local_free`` code
- Only use SMR to allocate ``metric_t``
- ``immediate_metrics`` does not own anything, do not delete from there
- Add a couple of ``default`` clauses, Eclipse paints the entire switch
  statement in yellow otherwise