### PR TITLE
Add Validation Callback To Tagset Compaction

### DIFF
--- a/src/noit_metric.c
+++ b/src/noit_metric.c
@@ -859,6 +859,13 @@ noit_metric_tagset_context_free(noit_metric_tagset_context_t *ctx) {
 }
 
 void
+noit_metric_tagset_context_ref(noit_metric_tagset_context_t *ctx) {
+  if (ctx) {
+    ck_pr_inc_32(&ctx->refcnt);
+  }
+}
+
+void
 noit_metric_tagset_context_set_validate_function(noit_metric_tagset_context_t *ctx,
                                                  bool (*f)(const char * cat,
                                                            const size_t cat_len,

--- a/src/noit_metric.c
+++ b/src/noit_metric.c
@@ -52,6 +52,12 @@ MTEV_HOOK_IMPL(noit_metric_tagset_fixup,
                (void *closure, noit_metric_tagset_class_t cls, noit_metric_tagset_t *tagset),
                (closure,cls,tagset))
 
+typedef struct noit_metric_tagset_context_t {
+  uint32_t refcnt;
+  bool (*validate_function)(const char *cat, const size_t cat_len,
+                            const char *val, const size_t val_len);
+} noit_metric_tagset_context_t;
+
 mtev_boolean
 noit_metric_as_double(metric_t *metric, double *out) {
   if(metric == NULL || metric->metric_value.vp == NULL) return mtev_false;
@@ -836,3 +842,41 @@ const char *
 noit_metric_get_full_metric_name(metric_t *m) {
   return m->expanded_metric_name ? m->expanded_metric_name : m->metric_name;
 }
+
+noit_metric_tagset_context_t *
+noit_metric_tagset_context_alloc(void) {
+  noit_metric_tagset_context_t *ctx = (noit_metric_tagset_context_t *)malloc(sizeof(*ctx));
+  ctx->refcnt = 1;
+  ctx->validate_function = NULL;
+  return ctx;
+}
+
+void
+noit_metric_tagset_context_free(noit_metric_tagset_context_t *ctx) {
+  if (ck_pr_dec_32_is_zero(&ctx->refcnt)) {
+    free(ctx);
+  }
+}
+
+void
+noit_metric_tagset_context_set_validate_function(noit_metric_tagset_context_t *ctx,
+                                                 bool (*f)(const char * cat,
+                                                           const size_t cat_len,
+                                                           const char * val,
+                                                           const size_t val_len)) {
+  ctx->validate_function = f;
+}
+
+bool
+noit_metric_tagset_context_execute_validate_function(const noit_metric_tagset_context_t *ctx,
+                                                     const char *cat,
+                                                     const size_t cat_len,
+                                                     const char *val,
+                                                     const size_t val_len) {
+  if (ctx && ctx->validate_function) {
+    return ctx->validate_function(cat, cat_len, val, val_len);
+  }
+  /* If no validation function is provided, the metric is fine */
+  return true;
+}
+

--- a/src/noit_metric.h
+++ b/src/noit_metric.h
@@ -286,6 +286,9 @@ API_EXPORT(void)
   noit_metric_tagset_context_free(noit_metric_tagset_context_t *ctx);
 
 API_EXPORT(void)
+  noit_metric_tagset_context_ref(noit_metric_tagset_context_t *ctx);
+
+API_EXPORT(void)
   noit_metric_tagset_context_set_validate_function(noit_metric_tagset_context_t *ctx,
                                                    bool (*f)(const char * cat,
                                                              const size_t cat_len,

--- a/src/noit_metric.h
+++ b/src/noit_metric.h
@@ -117,6 +117,10 @@ typedef struct noit_metric_tagset_t {
   int canonical_size;
 } noit_metric_tagset_t;
 
+// Forward declaration - should only be accessed via accessor functions -
+// struct is defined in the .c file
+typedef struct noit_metric_tagset_context_t noit_metric_tagset_context_t;
+
 typedef struct {
   uuid_t id;
   const char *name;
@@ -213,6 +217,9 @@ API_EXPORT(ssize_t)
   noit_metric_tagset_decode_tag(char *decoded_tag, size_t max_len, 
                                 const char *encoded_tag, size_t encoded_size);
 API_EXPORT(int)
+  noit_metric_tagset_init_with_context(noit_metric_tagset_t *lookup, const char *tagstr,
+                                      size_t tagstr_len, noit_metric_tagset_context_t *ctx);
+API_EXPORT(int)
   noit_metric_tagset_init(noit_metric_tagset_t *lookup, const char *tagstr, size_t tagstr_len);
 API_EXPORT(void)
   noit_metric_tagset_cleanup(noit_metric_tagset_t *lookup);
@@ -271,6 +278,26 @@ API_EXPORT(metric_t *)
   noit_metric_alloc(void);
 API_EXPORT(const char *)
   noit_metric_get_full_metric_name(metric_t *m);
+
+API_EXPORT(noit_metric_tagset_context_t *)
+  noit_metric_tagset_context_alloc(void);
+
+API_EXPORT(void)
+  noit_metric_tagset_context_free(noit_metric_tagset_context_t *ctx);
+
+API_EXPORT(void)
+  noit_metric_tagset_context_set_validate_function(noit_metric_tagset_context_t *ctx,
+                                                   bool (*f)(const char * cat,
+                                                             const size_t cat_len,
+                                                             const char * val,
+                                                             const size_t val_len));
+
+API_EXPORT(bool)
+  noit_metric_tagset_context_execute_validate_function(const noit_metric_tagset_context_t *ctx,
+                                                       const char *cat,
+                                                       const size_t cat_len,
+                                                       const char *val,
+                                                       const size_t val_len);
 
 static inline int
 noit_metric_tags_compare(const void *v_l, const void *v_r) {


### PR DESCRIPTION
Add a callback function (wrapped in a context struct for ease of later
expansion) to allow passing a custom validation function to drop certain
tags when doing tag compaction.