### PR TITLE
Use Generations To Determine If Resizes Are Needed

### DIFF
--- a/src/noit_check_lmdb.c
+++ b/src/noit_check_lmdb.c
@@ -467,8 +467,9 @@ put_retry:
         mtev_hash_destroy(&conf_table, free, NULL); \
         free(key); \
         xmlFree(val); \
+        uint64_t initial_generation = noit_lmdb_get_instance_generation(instance); \
         pthread_rwlock_unlock(&instance->lock); \
-        noit_lmdb_resize_instance(instance); \
+        noit_lmdb_resize_instance(instance, initial_generation); \
         goto put_retry; \
       } \
       else if (rc != 0) { \
@@ -546,8 +547,9 @@ put_retry:
           mtev_hash_destroy(&conf_table, free, NULL);
           free(key);
           xmlFree(val);
+          uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
           pthread_rwlock_unlock(&instance->lock);
-          noit_lmdb_resize_instance(instance);
+          noit_lmdb_resize_instance(instance, initial_generation);
           goto put_retry;
         }
         else if (rc != 0) {
@@ -571,8 +573,9 @@ put_retry:
         mdb_cursor_close(cursor);
         mdb_txn_abort(txn);
         mtev_hash_destroy(&conf_table, free, NULL);
+        uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
         pthread_rwlock_unlock(&instance->lock);
-        noit_lmdb_resize_instance(instance);
+        noit_lmdb_resize_instance(instance, initial_generation);
         goto put_retry;
       }
       else if (rc != MDB_NOTFOUND) {
@@ -584,8 +587,9 @@ put_retry:
   rc = mdb_txn_commit(txn);
   if (rc == MDB_MAP_FULL) {
     mtev_hash_destroy(&conf_table, free, NULL);
+    uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
     pthread_rwlock_unlock(&instance->lock);
-    noit_lmdb_resize_instance(instance);
+    noit_lmdb_resize_instance(instance, initial_generation);
     goto put_retry;
   }
   else if (rc != 0) {
@@ -886,8 +890,9 @@ put_retry:
     mdb_cursor_close(cursor);
     mdb_txn_abort(txn);
     free(key);
+    uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
     pthread_rwlock_unlock(&instance->lock);
-    noit_lmdb_resize_instance(instance);
+    noit_lmdb_resize_instance(instance, initial_generation);
     goto put_retry;
   }
   else if (rc != 0) {
@@ -943,8 +948,9 @@ put_retry:
     mdb_cursor_close(cursor);
     mdb_txn_abort(txn);
     free(key);
+    uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
     pthread_rwlock_unlock(&instance->lock);
-    noit_lmdb_resize_instance(instance);
+    noit_lmdb_resize_instance(instance, initial_generation);
     goto put_retry;
   }
   else if (rc != 0) {
@@ -954,8 +960,9 @@ put_retry:
   mdb_cursor_close(cursor);
   rc = mdb_txn_commit(txn);
   if (rc == MDB_MAP_FULL) {
+    uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
     pthread_rwlock_unlock(&instance->lock);
-    noit_lmdb_resize_instance(instance);
+    noit_lmdb_resize_instance(instance, initial_generation);
     goto put_retry;
   }
   else if (rc != 0) {
@@ -1487,8 +1494,9 @@ noit_check_lmdb_convert_one_xml_check_to_lmdb(mtev_conf_section_t section, char 
         free(name); \
       } \
       mtev_hash_destroy(&conf_table, free, NULL); \
+      uint64_t initial_generation = noit_lmdb_get_instance_generation(instance); \
       pthread_rwlock_unlock(&instance->lock); \
-      noit_lmdb_resize_instance(instance); \
+      noit_lmdb_resize_instance(instance, initial_generation); \
       goto put_retry; \
     } \
     else if (rc != 0) { \
@@ -1575,8 +1583,9 @@ put_retry:
         mdb_cursor_close(cursor);
         mdb_txn_abort(txn);
         mtev_hash_destroy(&conf_table, free, NULL);
+        uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
         pthread_rwlock_unlock(&instance->lock);
-        noit_lmdb_resize_instance(instance);
+        noit_lmdb_resize_instance(instance, initial_generation);
         goto put_retry;
       }
       else if (rc != MDB_NOTFOUND) {
@@ -1589,8 +1598,9 @@ put_retry:
   rc = mdb_txn_commit(txn);
   if (rc == MDB_MAP_FULL) {
     mtev_hash_destroy(&conf_table, free, NULL);
+    uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
     pthread_rwlock_unlock(&instance->lock);
-    noit_lmdb_resize_instance(instance);
+    noit_lmdb_resize_instance(instance, initial_generation);
     goto put_retry;
   }
   else if (rc != 0) {

--- a/src/noit_check_lmdb.c
+++ b/src/noit_check_lmdb.c
@@ -467,7 +467,7 @@ put_retry:
         mtev_hash_destroy(&conf_table, free, NULL); \
         free(key); \
         xmlFree(val); \
-        uint64_t initial_generation = noit_lmdb_get_instance_generation(instance); \
+        const uint64_t initial_generation = noit_lmdb_get_instance_generation(instance); \
         pthread_rwlock_unlock(&instance->lock); \
         noit_lmdb_resize_instance(instance, initial_generation); \
         goto put_retry; \
@@ -547,7 +547,7 @@ put_retry:
           mtev_hash_destroy(&conf_table, free, NULL);
           free(key);
           xmlFree(val);
-          uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
+          const uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
           pthread_rwlock_unlock(&instance->lock);
           noit_lmdb_resize_instance(instance, initial_generation);
           goto put_retry;
@@ -573,7 +573,7 @@ put_retry:
         mdb_cursor_close(cursor);
         mdb_txn_abort(txn);
         mtev_hash_destroy(&conf_table, free, NULL);
-        uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
+        const uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
         pthread_rwlock_unlock(&instance->lock);
         noit_lmdb_resize_instance(instance, initial_generation);
         goto put_retry;
@@ -587,7 +587,7 @@ put_retry:
   rc = mdb_txn_commit(txn);
   if (rc == MDB_MAP_FULL) {
     mtev_hash_destroy(&conf_table, free, NULL);
-    uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
+    const uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
     pthread_rwlock_unlock(&instance->lock);
     noit_lmdb_resize_instance(instance, initial_generation);
     goto put_retry;
@@ -890,7 +890,7 @@ put_retry:
     mdb_cursor_close(cursor);
     mdb_txn_abort(txn);
     free(key);
-    uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
+    const uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
     pthread_rwlock_unlock(&instance->lock);
     noit_lmdb_resize_instance(instance, initial_generation);
     goto put_retry;
@@ -948,7 +948,7 @@ put_retry:
     mdb_cursor_close(cursor);
     mdb_txn_abort(txn);
     free(key);
-    uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
+    const uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
     pthread_rwlock_unlock(&instance->lock);
     noit_lmdb_resize_instance(instance, initial_generation);
     goto put_retry;
@@ -960,7 +960,7 @@ put_retry:
   mdb_cursor_close(cursor);
   rc = mdb_txn_commit(txn);
   if (rc == MDB_MAP_FULL) {
-    uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
+    const uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
     pthread_rwlock_unlock(&instance->lock);
     noit_lmdb_resize_instance(instance, initial_generation);
     goto put_retry;
@@ -1494,7 +1494,7 @@ noit_check_lmdb_convert_one_xml_check_to_lmdb(mtev_conf_section_t section, char 
         free(name); \
       } \
       mtev_hash_destroy(&conf_table, free, NULL); \
-      uint64_t initial_generation = noit_lmdb_get_instance_generation(instance); \
+      const uint64_t initial_generation = noit_lmdb_get_instance_generation(instance); \
       pthread_rwlock_unlock(&instance->lock); \
       noit_lmdb_resize_instance(instance, initial_generation); \
       goto put_retry; \
@@ -1583,7 +1583,7 @@ put_retry:
         mdb_cursor_close(cursor);
         mdb_txn_abort(txn);
         mtev_hash_destroy(&conf_table, free, NULL);
-        uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
+        const uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
         pthread_rwlock_unlock(&instance->lock);
         noit_lmdb_resize_instance(instance, initial_generation);
         goto put_retry;
@@ -1598,7 +1598,7 @@ put_retry:
   rc = mdb_txn_commit(txn);
   if (rc == MDB_MAP_FULL) {
     mtev_hash_destroy(&conf_table, free, NULL);
-    uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
+    const uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
     pthread_rwlock_unlock(&instance->lock);
     noit_lmdb_resize_instance(instance, initial_generation);
     goto put_retry;

--- a/src/noit_filters_lmdb.c
+++ b/src/noit_filters_lmdb.c
@@ -138,7 +138,7 @@ noit_filters_lmdb_write_finalized_fb_to_lmdb(char *filterset_name, void *buffer,
       mdb_cursor_close(cursor);
       mdb_txn_abort(txn);
       free(key);
-      uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
+      const uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
       pthread_rwlock_unlock(&instance->lock);
       if (rc == MDB_MAP_FULL) {
         noit_lmdb_resize_instance(instance, initial_generation);
@@ -152,7 +152,7 @@ noit_filters_lmdb_write_finalized_fb_to_lmdb(char *filterset_name, void *buffer,
     rc = mdb_txn_commit(txn);
     if (rc) {
       free(key);
-      uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
+      const uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
       pthread_rwlock_unlock(&instance->lock);
       if (rc == MDB_MAP_FULL) {
         noit_lmdb_resize_instance(instance, initial_generation);

--- a/src/noit_filters_lmdb.c
+++ b/src/noit_filters_lmdb.c
@@ -138,9 +138,10 @@ noit_filters_lmdb_write_finalized_fb_to_lmdb(char *filterset_name, void *buffer,
       mdb_cursor_close(cursor);
       mdb_txn_abort(txn);
       free(key);
+      uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
       pthread_rwlock_unlock(&instance->lock);
       if (rc == MDB_MAP_FULL) {
-        noit_lmdb_resize_instance(instance);
+        noit_lmdb_resize_instance(instance, initial_generation);
         continue;
       }
       else {
@@ -151,9 +152,10 @@ noit_filters_lmdb_write_finalized_fb_to_lmdb(char *filterset_name, void *buffer,
     rc = mdb_txn_commit(txn);
     if (rc) {
       free(key);
+      uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
       pthread_rwlock_unlock(&instance->lock);
       if (rc == MDB_MAP_FULL) {
-        noit_lmdb_resize_instance(instance);
+        noit_lmdb_resize_instance(instance, initial_generation);
         continue;
       }
       else {

--- a/src/noit_lmdb_tools.c
+++ b/src/noit_lmdb_tools.c
@@ -346,7 +346,7 @@ static void noit_lmdb_increment_instance_generation(noit_lmdb_instance_t *instan
 }
 
 #define NOIT_LMDB_RESIZE_FACTOR 1.5
-void noit_lmdb_resize_instance(noit_lmdb_instance_t *instance, uint64_t initial_generation)
+void noit_lmdb_resize_instance(noit_lmdb_instance_t *instance, const uint64_t initial_generation)
 {
   MDB_envinfo mei;
   MDB_stat mst;

--- a/src/noit_lmdb_tools.c
+++ b/src/noit_lmdb_tools.c
@@ -319,6 +319,7 @@ noit_lmdb_instance_t *noit_lmdb_tools_open_instance(char *path)
   instance->dbi = dbi;
   pthread_rwlock_init(&instance->lock, NULL);
   instance->path = strdup(path);
+  instance->generation = 0;
 
   return instance;
 }
@@ -342,16 +343,16 @@ void noit_lmdb_resize_instance(noit_lmdb_instance_t *instance)
   uint64_t new_mapsize;
 
   /* prevent new transactions on the write side */
+
+  uint64_t initial_generation = noit_lmdb_get_instance_generation(instance);
   pthread_rwlock_wrlock(&instance->lock);
 
-  /* check if resize is necessary.. another thread may have already resized. */
   mdb_env_info(instance->env, &mei);
   mdb_env_stat(instance->env, &mst);
 
-  uint64_t size_used = mst.ms_psize * mei.me_last_pgno;
-
-  /* resize on 80% full */
-  if ((double)size_used / mei.me_mapsize < 0.8) {
+  /* If the generation has changed, another thread already did the resize, so
+   * we don't need to do it again */
+  if (initial_generation != noit_lmdb_get_instance_generation(instance)) {
     pthread_rwlock_unlock(&instance->lock);
     return;
   }
@@ -364,6 +365,18 @@ void noit_lmdb_resize_instance(noit_lmdb_instance_t *instance)
   mtevL(mtev_error, "lmdb checks db: mapsize increased. old: %" PRIu64 " MiB, new: %" PRIu64 " MiB\n",
         mei.me_mapsize / (1024 * 1024), new_mapsize / (1024 * 1024));
 
+  noit_lmdb_increment_instance_generation(instance);
+
   pthread_rwlock_unlock(&instance->lock);
+}
+
+uint64_t noit_lmdb_get_instance_generation(noit_lmdb_instance_t *instance)
+{
+  return ck_pr_load_64(&instance->generation);
+}
+
+void noit_lmdb_increment_instance_generation(noit_lmdb_instance_t *instance)
+{
+  ck_pr_inc_64(&instance->generation);
 }
 

--- a/src/noit_lmdb_tools.h
+++ b/src/noit_lmdb_tools.h
@@ -71,9 +71,8 @@ noit_lmdb_filterset_rule_data_t *noit_lmdb_filterset_data_from_key(char *key);
 void noit_lmdb_free_filterset_data(noit_lmdb_filterset_rule_data_t *data);
 noit_lmdb_instance_t *noit_lmdb_tools_open_instance(char *path);
 void noit_lmdb_tools_close_instance(noit_lmdb_instance_t *instance);
-void noit_lmdb_resize_instance(noit_lmdb_instance_t *instance);
 uint64_t noit_lmdb_get_instance_generation(noit_lmdb_instance_t *instance);
-void noit_lmdb_increment_instance_generation(noit_lmdb_instance_t *instance);
+void noit_lmdb_resize_instance(noit_lmdb_instance_t *instance, uint64_t initial_generation);
 
 #ifdef __cplusplus
 }

--- a/src/noit_lmdb_tools.h
+++ b/src/noit_lmdb_tools.h
@@ -44,6 +44,7 @@ typedef struct noit_lmdb_instance {
   MDB_dbi dbi;
   pthread_rwlock_t lock;
   char *path;
+  uint64_t generation;
 } noit_lmdb_instance_t;
 
 typedef struct noit_lmdb_check_data {
@@ -71,6 +72,8 @@ void noit_lmdb_free_filterset_data(noit_lmdb_filterset_rule_data_t *data);
 noit_lmdb_instance_t *noit_lmdb_tools_open_instance(char *path);
 void noit_lmdb_tools_close_instance(noit_lmdb_instance_t *instance);
 void noit_lmdb_resize_instance(noit_lmdb_instance_t *instance);
+uint64_t noit_lmdb_get_instance_generation(noit_lmdb_instance_t *instance);
+void noit_lmdb_increment_instance_generation(noit_lmdb_instance_t *instance);
 
 #ifdef __cplusplus
 }

--- a/src/noit_lmdb_tools.h
+++ b/src/noit_lmdb_tools.h
@@ -72,7 +72,7 @@ void noit_lmdb_free_filterset_data(noit_lmdb_filterset_rule_data_t *data);
 noit_lmdb_instance_t *noit_lmdb_tools_open_instance(char *path);
 void noit_lmdb_tools_close_instance(noit_lmdb_instance_t *instance);
 uint64_t noit_lmdb_get_instance_generation(noit_lmdb_instance_t *instance);
-void noit_lmdb_resize_instance(noit_lmdb_instance_t *instance, uint64_t initial_generation);
+void noit_lmdb_resize_instance(noit_lmdb_instance_t *instance, const uint64_t initial_generation);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Rather than checking to see if we're using at least 80% of the LMDB
map, use generations to determine whether another thread has resized or
not.