### PR TITLE
LMDB Tweaks

### DIFF
--- a/src/noit_lmdb_tools.c
+++ b/src/noit_lmdb_tools.c
@@ -360,7 +360,7 @@ static void noit_lmdb_increment_instance_generation(noit_lmdb_instance_t *instan
   ck_pr_inc_64(&instance->generation);
 }
 
-#define NOIT_LMDB_RESIZE_FACTOR 4
+#define NOIT_LMDB_RESIZE_FACTOR 2
 void noit_lmdb_resize_instance(noit_lmdb_instance_t *instance, const uint64_t initial_generation)
 {
   MDB_envinfo mei;

--- a/src/noit_lmdb_tools.c
+++ b/src/noit_lmdb_tools.c
@@ -284,15 +284,8 @@ noit_lmdb_instance_t *noit_lmdb_tools_open_instance(char *path)
     return NULL;
   }
 
-  /* Align mapsize to pagesize, use enough pages to reach
-   * 64 MB */
-  size_t page_size = getpagesize();
-  size_t map_size = page_size;
-  static const size_t map_size_target = (1024*1024*64);
-  while (map_size < map_size_target) {
-    map_size += page_size;
-  }
-  rc = mdb_env_set_mapsize(env, map_size);
+  /* Set initial pagesize to 64 MiB */
+  rc = mdb_env_set_mapsize(env, 1024*1024*64);
   if (rc != 0) {
     errno = rc;
     mdb_env_close(env);

--- a/src/noit_lmdb_tools.c
+++ b/src/noit_lmdb_tools.c
@@ -284,7 +284,7 @@ noit_lmdb_instance_t *noit_lmdb_tools_open_instance(char *path)
     return NULL;
   }
 
-  /* Set initial pagesize to 64 MiB */
+  /* Set initial mapsize to 64 MiB */
   rc = mdb_env_set_mapsize(env, 1024*1024*64);
   if (rc != 0) {
     errno = rc;


### PR DESCRIPTION
* Use a starting map size aligned with pagesize that is at least 64MB
* Resize DBs by a factor of 4
* Improve resize print messages