### PR TITLE
Pull Check Updates In Jobq

### DIFF
--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -1276,7 +1276,9 @@ static void rest_show_check_updates_free_closure(void *v_rcu) {
 
 int rest_show_check_updates_complete(mtev_http_rest_closure_t *restc, int npats, char **pats) {
   mtev_http_session_ctx *ctx = restc->http_ctx;
+  rest_check_updates_closure_t *rcu = (rest_check_updates_closure_t *) restc->call_closure;
   if (ctx) {
+    mtev_http_response_xml(ctx, rcu->doc);
     mtev_http_response_end(ctx);
   }
   return 0;
@@ -1295,8 +1297,6 @@ rest_show_check_updates_asynch(eventer_t e, int mask, void *closure, struct time
     noit_cluster_xml_check_changes(rcu->peerid, rcu->restc->remote_cn, rcu->prev, rcu->end, root);
     noit_check_set_db_source_header(ctx);
     mtev_http_response_ok(ctx, "text/xml");
-    mtev_http_response_xml(ctx, rcu->doc);
-    mtev_http_response_flush(ctx, mtev_true);
   }
   if(mask == EVENTER_ASYNCH) {
     if (rcu) {

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -1302,11 +1302,11 @@ rest_show_check_updates_asynch(eventer_t e, int mask, void *closure, struct time
     /* This can be *really* large depending on the amount of data
      * requested. We want to flush out as much as possible from within
      * the jobq thread before going back */
-    if (mtev_http_response_flush(ctx, mtev_false) <= 0) {
+    if (mtev_http_response_flush(ctx, mtev_false) == mtev_false) {
       return 0;
     }
     while (mtev_http_response_buffered(ctx) >= FLUSH_BUFFER_SIZE) {
-      if (mtev_http_response_flush(ctx, mtev_false) <= 0) {
+      if (mtev_http_response_flush(ctx, mtev_false) == mtev_false) {
         return 0;
       }
       usleep(100);

--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -1279,7 +1279,6 @@ int rest_show_check_updates_complete(mtev_http_rest_closure_t *restc, int npats,
   rest_check_updates_closure_t *rcu = (rest_check_updates_closure_t *) restc->call_closure;
   if (ctx) {
     mtev_http_response_xml(ctx, rcu->doc);
-    mtev_http_response_end(ctx);
   }
   return 0;
 }

--- a/src/noitd.c
+++ b/src/noitd.c
@@ -322,6 +322,7 @@ noitd_init_globals(void) {
 static void 
 noitd_jobqs_init(void) {
   mtev_main_eventer_config("jobq_set_check", "10,1,50,gc");
+  mtev_main_eventer_config("jobq_check_updates", "1,1,50,gc");
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
The checks/updates functionality grabs a lock and can iterate a lot of checks and build a large XML document. Should do this work in a jobq.