### PR TITLE
Fix Bad mtev_conf Lock Acquisition

### DIFF
--- a/src/noit_check_rest.c
+++ b/src/noit_check_rest.c
@@ -808,8 +808,10 @@ noit_validate_check_rest_post(xmlDocPtr doc, xmlNodePtr *a, xmlNodePtr *c,
     *error = "invalid namespace provided";
     goto out;
   }
-      
-  if(strcmp((char *)root->name, "check")) return 0;
+  if(strcmp((char *)root->name, "check")) {
+    *error = "root name is not check";
+    goto out;
+  }
   for(tl = root->children; tl; tl = tl->next) {
     if(tl->type != XML_ELEMENT_NODE) continue;
     if(!strcmp((char *)tl->name, "attributes")) {

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -994,8 +994,8 @@ noit_console_filter_show(mtev_console_closure_t ncct,
     DUMP_ATTR(id);
     DUMP_ATTR(skipto);
   }
-  mtev_conf_release_sections_write(rules, rulecnt);
-  mtev_conf_release_section_write(fsnode);
+  mtev_conf_release_sections_read(rules, rulecnt);
+  mtev_conf_release_section_read(fsnode);
   return 0;
 }
 static int


### PR DESCRIPTION
Fix two issues: One where we acquire a read lock and never release it in
an error case, and one where we acquired a read lock, but release a
write lock.