### PR TITLE
CIRC-9039 - null metric

### DIFF
--- a/src/noit_check_log.c
+++ b/src/noit_check_log.c
@@ -601,6 +601,7 @@ noit_check_log_bundle_fb_serialize(mtev_log_stream_t ls, noit_check_t *check, co
   while(mtev_hash_next(metrics, &iter, &key, &klen, &vm)) {
     /* If we apply the filter set and it returns false, we don't log */
     metric_t *m = (metric_t *)vm;
+    if(!m) continue;
     if(!noit_apply_filterset(check->filterset, check, m)) continue;
     if(m->logged) continue;
 

--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -1226,7 +1226,7 @@ noit_metric_tag_search_parse(const char *query, int *erroff) {
   int error_offset = 0;
   if(!noit_metric_tag_search_compile(tree, &error_offset)) {
     noit_metric_tag_search_free(tree);
-    *erroff = query + (error_offset < strlen(query)) ? error_offset : 0;
+    *erroff = error_offset < strlen(query) ? error_offset : 0;
     return NULL;
   }
   *erroff = -1;


### PR DESCRIPTION
Somehow a null pointer got into the current stats hash table.
Don't crash when it does happen