### PR TITLE
Better Null Metric Handling

### DIFF
--- a/src/noit_check_log.c
+++ b/src/noit_check_log.c
@@ -738,6 +738,10 @@ noit_check_log_bundle_serialize(mtev_log_stream_t ls, noit_check_t *check, const
       /* make sure we don't go past our allocation for some reason*/
       if((i / metrics_per_bundle) >= n_bundles) break;
 
+      /* Make sure nobody added a null metric to the hash table...
+       * if they did, just move on */
+      if (!vm) continue;
+
       int b_idx = i / metrics_per_bundle;
       Bundle *bundle = &bundles[b_idx];
       int b_i = i % metrics_per_bundle;

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -765,6 +765,7 @@ noit_apply_filterset(const char *filterset,
   void *vfs;
   if(!filterset) return mtev_true;   /* No filter */
   if(!filtersets) return mtev_false; /* Couldn't possibly match */
+  if(!metric) return mtev_false;     /* Can't match a null metric */
   struct timeval now;
   const char *local_metric_name = noit_metric_get_full_metric_name(metric);
   mtev_gettimeofday(&now, NULL);


### PR DESCRIPTION
If we get a null metric when trying to log or filter, just skip it.