### PR TITLE
Add Size-Limited Noit Metric Find Unparse Function

### DIFF
--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -1395,59 +1395,93 @@ noit_metric_tag_search_has_hint(const noit_metric_tag_search_ast_t *search, cons
   return mtev_false;
 }
 
-static void
-noit_metric_tag_search_unparse_part(const noit_metric_tag_search_ast_t *search, mtev_dyn_buffer_t *buf) {
+/* NOTE: This function makes no guarantees about the state of buf if the unparsing fails and the function returns false.
+ * The caller should check the return value and not use the data in the buffer if the return value was false */
+static bool
+noit_metric_tag_search_unparse_part(const noit_metric_tag_search_ast_t *search, mtev_dyn_buffer_t *buf, int64_t limit) {
+  if ((limit != NOIT_METRIC_TAG_SEARCH_UNPARSE_NO_SIZE_LIMIT) && (mtev_dyn_buffer_used(buf) >= limit)) {
+    return false;
+  }
   switch(search->operation) {
     case OP_MATCH: {
       const noit_metric_tag_match_t *spec = &search->contents.spec;
       mtev_dyn_buffer_add_printf(buf, "[%s]%s", spec->cat.impl->impl_name, spec->cat.str);
-      if (spec->name.str) mtev_dyn_buffer_add_printf(buf, ":[%s]%s", spec->name.impl->impl_name, spec->name.str);
+      if (spec->name.str) {
+        mtev_dyn_buffer_add_printf(buf, ":[%s]%s", spec->name.impl->impl_name, spec->name.str);
+      }
       break;
     }
     case OP_NOT_ARGS:
       mtevAssert(search->contents.args.cnt == 1);
       mtev_dyn_buffer_add_printf(buf, "not(");
-      noit_metric_tag_search_unparse_part(search->contents.args.node[0], buf);
+      if (!noit_metric_tag_search_unparse_part(search->contents.args.node[0], buf, limit)) {
+        return false;
+      }
       mtev_dyn_buffer_add_printf(buf, ")");
       break;
     case OP_AND_ARGS:
       mtev_dyn_buffer_add_printf(buf, "and(");
       for(int i=0; i<search->contents.args.cnt; i++) {
-        noit_metric_tag_search_unparse_part(search->contents.args.node[i], buf);
-        if (i != search->contents.args.cnt - 1) mtev_dyn_buffer_add_printf(buf, ",");
+        if (!noit_metric_tag_search_unparse_part(search->contents.args.node[i], buf, limit)) {
+          return false;
+        }
+        if (i != search->contents.args.cnt - 1) {
+          mtev_dyn_buffer_add_printf(buf, ",");
+        }
       }
       mtev_dyn_buffer_add_printf(buf, ")");
       break;
     case OP_HINT_ARGS:
       mtev_dyn_buffer_add_printf(buf, "hint(");
       for(int i=0; i<search->contents.args.cnt; i++) {
-        noit_metric_tag_search_unparse_part(search->contents.args.node[i], buf);
-        if (i != search->contents.args.cnt - 1) mtev_dyn_buffer_add_printf(buf, ",");
+        if (!noit_metric_tag_search_unparse_part(search->contents.args.node[i], buf, limit)) {
+          return false;
+        }
+        if (i != search->contents.args.cnt - 1) {
+          mtev_dyn_buffer_add_printf(buf, ",");
+        }
       }
       mtev_dyn_buffer_add_printf(buf, ")");
       break;
     case OP_OR_ARGS:
       mtev_dyn_buffer_add_printf(buf, "or(");
       for(int i=0; i<search->contents.args.cnt; i++) {
-        noit_metric_tag_search_unparse_part(search->contents.args.node[i], buf);
-        if (i != search->contents.args.cnt - 1) mtev_dyn_buffer_add_printf(buf, ",");
+        if (!noit_metric_tag_search_unparse_part(search->contents.args.node[i], buf, limit)) {
+          return false;
+        }
+        if (i != search->contents.args.cnt - 1) {
+          mtev_dyn_buffer_add_printf(buf, ",");
+        }
       }
       mtev_dyn_buffer_add_printf(buf, ")");
       break;
     default:
       break;
   }
+  if ((limit != NOIT_METRIC_TAG_SEARCH_UNPARSE_NO_SIZE_LIMIT) && (mtev_dyn_buffer_used(buf) >= limit)) {
+    return false;
+  }
+  return true;
+}
+
+char *
+noit_metric_tag_search_unparse_limit_size(const noit_metric_tag_search_ast_t *search, int64_t limit) {
+  char *res;
+  mtev_dyn_buffer_t buf;
+  mtev_dyn_buffer_init(&buf);
+  if (noit_metric_tag_search_unparse_part(search, &buf, limit)) {
+    res = strdup((const char *)mtev_dyn_buffer_data(&buf));
+  }
+  else {
+    res = NULL;
+  }
+  mtev_dyn_buffer_destroy(&buf);
+  return res;
 }
 
 char *
 noit_metric_tag_search_unparse(const noit_metric_tag_search_ast_t *search) {
-  char *res;
-  mtev_dyn_buffer_t buf;
-  mtev_dyn_buffer_init(&buf);
-  noit_metric_tag_search_unparse_part(search, &buf);
-  res = strdup((const char *)mtev_dyn_buffer_data(&buf));
-  mtev_dyn_buffer_destroy(&buf);
-  return res;
+  return noit_metric_tag_search_unparse_limit_size(search, NOIT_METRIC_TAG_SEARCH_UNPARSE_NO_SIZE_LIMIT);
 }
 
 int

--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -43,7 +43,7 @@
 #include <ctype.h>
 
 int STUDY_EXECUTION_THRESHOLD = 50;
-int64_t NOIT_METRIC_TAG_SEARCH_UNPARSE_RECURSION_LIMIT = 1000;
+const int64_t NOIT_METRIC_TAG_SEARCH_UNPARSE_RECURSION_LIMIT = 1000;
 
 typedef struct noit_var_match_t {
   char *str;

--- a/src/noit_metric_tag_search.h
+++ b/src/noit_metric_tag_search.h
@@ -68,6 +68,8 @@
 extern "C" {
 #endif
 
+#define NOIT_METRIC_TAG_SEARCH_UNPARSE_NO_SIZE_LIMIT -1
+
 typedef enum {
   OP_AND_ARGS,
   OP_OR_ARGS,
@@ -178,6 +180,8 @@ API_EXPORT(mtev_boolean)
 
 API_EXPORT(char *)
   noit_metric_tag_search_unparse(const noit_metric_tag_search_ast_t *);
+API_EXPORT(char *)
+  noit_metric_tag_search_unparse_limit_size(const noit_metric_tag_search_ast_t *search, int64_t limit);
 
 API_EXPORT(int)
   noit_metric_tag_search_swap(noit_metric_tag_search_ast_t *, int, int);


### PR DESCRIPTION
Add noit_metric_tag_search_unparse_limit_size, which allows setting a
size limit to ensure that we don't go overboard with extremely large
queries.

Limit recursion to make sure we don't blow out the stack.