### PR TITLE
Put Filter Updates In Separate Jobq

### DIFF
--- a/src/noitd.c
+++ b/src/noitd.c
@@ -323,6 +323,7 @@ static void
 noitd_jobqs_init(void) {
   mtev_main_eventer_config("jobq_set_check", "10,1,50,gc");
   mtev_main_eventer_config("jobq_check_updates", "1,1,50,gc");
+  mtev_main_eventer_config("jobq_filter_updates", "1,1,50,gc");
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This task takes a lock, which could result in blocking the main eventer thread. This should go into a separate jobq.