### PR TITLE
Use Trylock When Checking If Delete Is Pending

### DIFF
--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -1973,7 +1973,9 @@ check_recycle_bin_processor_internal() {
   pthread_mutex_lock(&polls_lock);
   while(mtev_hash_adv(&polls, &iter)) {
     noit_check_t *check = (noit_check_t *)iter.value.ptr;
-    if(NOIT_CHECK_DELETED(check) && !noit_cluster_checkid_replication_pending(check->checkid)) {
+    /* noit_cluster_checkid_replication_pending will attempt to get a lock... if
+     * it can't get the lock, it will return true and we will skip the check for now */
+    if(NOIT_CHECK_DELETED(check) && !noit_cluster_checkid_replication_pending(check->checkid, mtev_true)) {
       char idstr[UUID_STR_LEN+1];
       mtev_uuid_unparse_lower(check->checkid, idstr);
 

--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -1973,9 +1973,10 @@ check_recycle_bin_processor_internal() {
   pthread_mutex_lock(&polls_lock);
   while(mtev_hash_adv(&polls, &iter)) {
     noit_check_t *check = (noit_check_t *)iter.value.ptr;
-    /* noit_cluster_checkid_replication_pending will attempt to get a lock... if
-     * it can't get the lock, it will return true and we will skip the check for now */
-    if(NOIT_CHECK_DELETED(check) && !noit_cluster_checkid_replication_pending(check->checkid, mtev_true)) {
+    /* noit_cluster_checkid_replication_pending_or_cant_acquire_lock  will attempt to get a
+     * lock... if it can't get the lock, it will return true and we will skip the check for now */
+    if(NOIT_CHECK_DELETED(check) &&
+        !noit_cluster_checkid_replication_pending_or_cant_acquire_lock(check->checkid)) {
       char idstr[UUID_STR_LEN+1];
       mtev_uuid_unparse_lower(check->checkid, idstr);
 

--- a/src/noit_clustering.c
+++ b/src/noit_clustering.c
@@ -678,8 +678,8 @@ possibly_start_job(noit_peer_t *peer) {
   }
 }
 
-mtev_boolean
-noit_cluster_checkid_replication_pending(uuid_t checkid, mtev_boolean bail_if_cant_lock) {
+static mtev_boolean
+noit_cluster_checkid_replication_pending_internal(uuid_t checkid, mtev_boolean bail_if_cant_lock) {
   if(!my_cluster) {
     return mtev_false;
   }
@@ -708,6 +708,16 @@ noit_cluster_checkid_replication_pending(uuid_t checkid, mtev_boolean bail_if_ca
   }
   pthread_mutex_unlock(&noit_peer_lock);
   return mtev_false;
+}
+
+mtev_boolean
+noit_cluster_checkid_replication_pending(uuid_t checkid) {
+  return noit_cluster_checkid_replication_pending_internal(checkid, mtev_false);
+}
+
+mtev_boolean
+noit_cluster_checkid_replication_pending_or_cant_acquire_lock(uuid_t checkid) {
+  return noit_cluster_checkid_replication_pending_internal(checkid, mtev_true);
 }
 
 static void

--- a/src/noit_clustering.h
+++ b/src/noit_clustering.h
@@ -59,7 +59,7 @@ void
                                   int64_t prev_end, int64_t limit, xmlNodePtr parent);
 
 mtev_boolean
-  noit_cluster_checkid_replication_pending(uuid_t);
+  noit_cluster_checkid_replication_pending(uuid_t, mtev_boolean);
 
 int
   noit_cluster_self_index(void);

--- a/src/noit_clustering.h
+++ b/src/noit_clustering.h
@@ -59,7 +59,9 @@ void
                                   int64_t prev_end, int64_t limit, xmlNodePtr parent);
 
 mtev_boolean
-  noit_cluster_checkid_replication_pending(uuid_t, mtev_boolean);
+  noit_cluster_checkid_replication_pending(uuid_t checkid);
+mtev_boolean
+  noit_cluster_checkid_replication_pending_or_cant_acquire_lock(uuid_t checkid);
 
 int
   noit_cluster_self_index(void);


### PR DESCRIPTION
When the check recycler is seeing if a delete is pending, it grabs a lock that can potentially freeze things up. Rather than taking the lock, we should only attempt to get it, and if it fails, we should go back and try again later.