### PR TITLE
Do Filterset Culls In Jobq

### DIFF
--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -43,6 +43,8 @@
 void noit_lua_libnoit_init();
 static ck_spinlock_t noit_lua_libnoit_init_lock = CK_SPINLOCK_INITIALIZER;
 
+static eventer_jobq_t *filterset_cull_jobq = NULL;
+
 // We need to hold-on to a reference to the metric name as long as we make use of the tagset
 // we also need to hold onto any dynamically constructed tag strings we add.
 typedef struct noit_lua_tagset_allocation {
@@ -714,6 +716,8 @@ noit_lua_libnoit_init() {
     mtev_hash_init(tmp);
     ck_pr_store_ptr(&account_set, tmp);
     metric_director_want_hook_register("metrics_select", hook_metric_subscribe_account, NULL);
+    filterset_cull_jobq = eventer_jobq_retrieve("filterset_cull");
+    mtevAssert(filterset_cull_jobq);
   }
   ck_spinlock_unlock(&noit_lua_libnoit_init_lock);
 }

--- a/src/modules/noit_lua_libnoit_binding.c
+++ b/src/modules/noit_lua_libnoit_binding.c
@@ -43,8 +43,6 @@
 void noit_lua_libnoit_init();
 static ck_spinlock_t noit_lua_libnoit_init_lock = CK_SPINLOCK_INITIALIZER;
 
-static eventer_jobq_t *filterset_cull_jobq = NULL;
-
 // We need to hold-on to a reference to the metric name as long as we make use of the tagset
 // we also need to hold onto any dynamically constructed tag strings we add.
 typedef struct noit_lua_tagset_allocation {
@@ -716,8 +714,6 @@ noit_lua_libnoit_init() {
     mtev_hash_init(tmp);
     ck_pr_store_ptr(&account_set, tmp);
     metric_director_want_hook_register("metrics_select", hook_metric_subscribe_account, NULL);
-    filterset_cull_jobq = eventer_jobq_retrieve("filterset_cull");
-    mtevAssert(filterset_cull_jobq);
   }
   ck_spinlock_unlock(&noit_lua_libnoit_init_lock);
 }

--- a/src/modules/noit_lua_noit_binding.c
+++ b/src/modules/noit_lua_noit_binding.c
@@ -121,8 +121,12 @@ lua_general_filtersets_cull_asynch(eventer_t e, int mask, void *closure,
     }
   }
   if(mask == EVENTER_ASYNCH) {
-    lua_pushinteger(fcc->L, fcc->count);
-    mtev_lua_lmc_resume(fcc->ci->lmc, fcc->ci, 1);
+    mtev_lua_resume_info_t *ci = fcc->ci;
+    lua_State *L = fcc->L;
+    int count = fcc->count;
+    free(fcc);
+    lua_pushinteger(L, count);
+    mtev_lua_lmc_resume(ci->lmc, ci, 1);
   }
   return 0;
 }

--- a/src/modules/noit_lua_noit_binding.c
+++ b/src/modules/noit_lua_noit_binding.c
@@ -39,6 +39,8 @@
 #include "noit_filters_lmdb.h"
 #include "lua_check.h"
 
+static eventer_jobq_t *filterset_cull_jobq = NULL;
+
 typedef struct lua_callback_ref{
   lua_State *L;
   int callback_reference;
@@ -189,6 +191,10 @@ static const luaL_Reg noit_binding[] = {
 
 LUALIB_API int luaopen_noit_binding(lua_State *L)
 {
+  if (!filterset_cull_jobq) {
+    filterset_cull_jobq = eventer_jobq_retrieve("filterset_cull");
+    mtevAssert(filterset_cull_jobq);
+  }
   luaL_openlib(L, "noit_binding", noit_binding, 0);
   return 1;
 }

--- a/src/noitd.c
+++ b/src/noitd.c
@@ -335,6 +335,7 @@ noitd_jobqs_init(void) {
    * TODO: Fan out deletes across multiple threads so they can run in
    * parallel */
   mtev_main_eventer_config("jobq_lmdb_check_delete", "1,1,1,gc");
+  mtev_main_eventer_config("jobq_filterset_cull", "1,1,1,gc");
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Make both the lua filterset cull integration and REST API filterset cull endpoint do their work in a jobq to keep large operations from blocking the eventer thread.