### PR TITLE
CIRC-9495 - fix handling of tags that are too long

### DIFF
--- a/src/noit_message_decoder.c
+++ b/src/noit_message_decoder.c
@@ -447,12 +447,12 @@ noit_metric_tags_parse_one(const char *tagnm, size_t tagnmlen,
   }
   /* make sure we covered everything */
   if(colon_pos == 0) return 0;
+  output->total_size = cur_size;
   /* tag category and name must combined be <= NOIT_TAG_MAX_PAIR_LEN */
   if(cur_size > NOIT_TAG_MAX_PAIR_LEN) {
     *toolong = mtev_true;
     return tagnm + cur_size;
   }
-  output->total_size = cur_size;
   output->category_size = colon_pos >= cur_size ? cur_size : colon_pos + 1;
   output->tag = tagnm;
   return tagnm + cur_size;


### PR DESCRIPTION
`noit_metric_tagset_builder_add_many` needs access to `tag.total_size` to correctly iterate through `tagstr`. 

this fixes a bug where, when a `tagnm` was `toolong` the `total_size` was not being set and would result in an overflow when trying to subtract an unknown value from the `size_t tagstr_len` which is unsigned. 

add test for tag pairs that are too long.


in the test file, I made `Matches` a structure definition to prevent merge conflicts when I add the implicit tag testing that uses the same struct.