### PR TITLE
Fix Computed Value When Only One Value Present

### DIFF
--- a/src/modules/httptrap.c
+++ b/src/modules/httptrap.c
@@ -595,7 +595,7 @@ httptrap_yajl_cb_end_map(void *ctx) {
      * avoid losing precision by converting to a double, just use the original
      * type */
     if ((json->cnt <= 1) &&
-        (json->vop_flag != HTTPTRAP_VOP_ACCUMULATE)) {
+        (json->vop_flag == HTTPTRAP_VOP_REPLACE)) {
       use_computed_value = mtev_false;
     }
     if(use_computed_value) {

--- a/src/modules/httptrap.c
+++ b/src/modules/httptrap.c
@@ -594,7 +594,8 @@ httptrap_yajl_cb_end_map(void *ctx) {
     /* If we only have a single value, we don't have any average to compute... to
      * avoid losing precision by converting to a double, just use the original
      * type */
-    if (json->cnt <= 1) {
+    if ((json->cnt <= 1) &&
+        (json->vop_flag != HTTPTRAP_VOP_ACCUMULATE)) {
       use_computed_value = mtev_false;
     }
     if(use_computed_value) {

--- a/src/modules/httptrap.c
+++ b/src/modules/httptrap.c
@@ -591,6 +591,12 @@ httptrap_yajl_cb_end_map(void *ctx) {
       }
       json->cnt++;
     }
+    /* If we only have a single value, we don't have any average to compute... to
+     * avoid losing precision by converting to a double, just use the original
+     * type */
+    if (json->cnt <= 1) {
+      use_computed_value = mtev_false;
+    }
     if(use_computed_value) {
       newval = (double)(total / (long double)cnt);
       /* Perform and in-place update of the metric value correcting it */


### PR DESCRIPTION
In the httptrap module, if a metric is given as a JSON object but there's only a single value, we should use the original type. Previously, we converted all incoming values to doubles.