### PR TITLE
Fix HTTPTRAP Data Type Loss

### DIFF
--- a/test/busted/checks_data/httptrap/httptrap_spec.lua
+++ b/test/busted/checks_data/httptrap/httptrap_spec.lua
@@ -36,7 +36,8 @@ describe("noit", function()
   local b64hist_double = "AAQKAAACFAAAAh4AAAIoAADw"
   local payload = [=[{
     "array": [ 1, 1.2, "string", { "_type": "s", "_value": "100" },
-               { "_type": "L", "_value": 18446744073709551614 } ],
+               { "_type": "L", "_value": 18446744073709551614 },
+               { "_type": "L", "_value": 1, "_value": 2 }],
     "lvl1": {
       "lvl2": {
         "boolean": true
@@ -53,7 +54,8 @@ describe("noit", function()
   expected_stats["array`1"] = { _type = "n", _value = "1.200000000000e+00" }
   expected_stats["array`2"] = { _type = "s", _value = "string" }
   expected_stats["array`3"] = { _type = "s", _value = "100" }
-  expected_stats["array`4"] = { _type = "n", _value = "1.844674407371e+19" }
+  expected_stats["array`4"] = { _type = "L", _value = "18446744073709551614" }
+  expected_stats["array`5"] = { _type = "n", _value = "1.500000000000e+00" }
   expected_stats["explicit_histogram"] = { _type = "h", _value = b64hist }
   expected_stats["implicit_histogram"] = { _type = "h", _value = b64hist }
   expected_stats["cumulative_b64histogram_1"] = { _type = "H", _value = b64hist }

--- a/test/busted/checks_data/httptrap/httptrap_spec.lua
+++ b/test/busted/checks_data/httptrap/httptrap_spec.lua
@@ -37,7 +37,8 @@ describe("noit", function()
   local payload = [=[{
     "array": [ 1, 1.2, "string", { "_type": "s", "_value": "100" },
                { "_type": "L", "_value": 18446744073709551614 },
-               { "_type": "L", "_value": 1, "_value": 2 }],
+               { "_type": "L", "_value": 1, "_value": 2 },
+               { "_type": "L", "_value": 1, "_fl": "+" }],
     "lvl1": {
       "lvl2": {
         "boolean": true
@@ -50,18 +51,38 @@ describe("noit", function()
     "implicit_b64histogram_1": { "_type": "h", "_value": ["H[4]=120", 3, 2, 1, "]=] .. b64hist .. [=[" ] }
   }]=]
   local expected_stats = {}
+  local cumulative_metric_count = 0
   expected_stats["array`0"] = { _type = "L", _value = "1" }
   expected_stats["array`1"] = { _type = "n", _value = "1.200000000000e+00" }
   expected_stats["array`2"] = { _type = "s", _value = "string" }
   expected_stats["array`3"] = { _type = "s", _value = "100" }
   expected_stats["array`4"] = { _type = "L", _value = "18446744073709551614" }
   expected_stats["array`5"] = { _type = "n", _value = "1.500000000000e+00" }
+  -- array`6 is a placeholder - this will get updated with each payload post since the
+  -- value is cumulative
+  expected_stats["array`6"] = {}
   expected_stats["explicit_histogram"] = { _type = "h", _value = b64hist }
   expected_stats["implicit_histogram"] = { _type = "h", _value = b64hist }
   expected_stats["cumulative_b64histogram_1"] = { _type = "H", _value = b64hist }
   expected_stats["cumulative_b64histogram_2"] = { _type = "H", _value = b64hist }
   expected_stats["implicit_b64histogram_1"] = { _type = "h", _value = b64hist_double }
   expected_stats["lvl1`lvl2`boolean"] = { _type = "i", _value = "1" }
+
+  function update_expected_cumulative_value()
+    cumulative_metric_count = cumulative_metric_count + 1
+    -- Don't need to support higher values for now
+    assert.is_true(cumulative_metric_count < 100)
+    if cumulative_metric_count < 10 then
+      expected_stats["array`6"] = { _type = "n", _value = tostring(cumulative_metric_count) .. ".000000000000e+00" }
+    elseif cumulative_metric_count >= 10 and cumulative_metric_count <= 99 then
+      local divided = cumulative_metric_count / 10
+      if cumulative_metric_count % 10 == 0 then
+        expected_stats["array`6"] = { _type = "n", _value = tostring(divided) .. ".000000000000e+01" }
+      else
+        expected_stats["array`6"] = { _type = "n", _value = tostring(divided) .. "00000000000e+01" }
+      end
+    end
+  end
 
   it("should start", function()
     assert.is_true(noit:start():is_booted())
@@ -81,6 +102,7 @@ describe("noit", function()
     it("accepts payload", function()
       local code, doc, raw = api:json("POST", "/module/httptrap/" .. uuid .. "/foofoo", payload)
       assert.is.equal(200, code)
+      update_expected_cumulative_value()
     end)
     it("has matching H1/2 records", function()
       local record = {}
@@ -113,6 +135,7 @@ describe("noit", function()
       for i=1,10 do
         code, doc = api:json("POST", "/module/httptrap/" .. uuid .. "/foofoo", payload)
         assert.is.equal(200, code)
+        update_expected_cumulative_value()
         mtev.sleep(1.1)
         code, doc = api:json("GET", "/checks/show/" .. uuid .. ".json")
         assert.is.equal(200, code)

--- a/test/busted/checks_data/httptrap_synch/httptrap_synch_spec.lua
+++ b/test/busted/checks_data/httptrap_synch/httptrap_synch_spec.lua
@@ -49,7 +49,7 @@ describe("noit", function()
   expected_stats["array`1"] = { _type = "n", _value = "1.200000000000e+00" }
   expected_stats["array`2"] = { _type = "s", _value = "string" }
   expected_stats["array`3"] = { _type = "s", _value = "100" }
-  expected_stats["array`4"] = { _type = "n", _value = "1.844674407371e+19" }
+  expected_stats["array`4"] = { _type = "L", _value = "18446744073709551614" }
   expected_stats["explicit_histogram"] = { _type = "h", _value = "AAQKAAABFAAAAR4AAAEoAAB4" }
   expected_stats["implicit_histogram"] = expected_stats["explicit_histogram"]
   expected_stats["lvl1`lvl2`boolean"] = { _type = "i", _value = "1" }


### PR DESCRIPTION
We were losing the original data type in httptrap checks in situations where we didn't need to.

Fix this so that if a complex type is provided, but there's only a single value, we preserve the type rather than converting it to a double.