### PR TITLE
Update build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 Compiler:
- * Support for C11 and C++17 standards is required. This means GCC 9 or later;
+ * Support for C11 and C++20 standards is required. This means GCC 11 or later;
    Clang/LLVM is less tested but recent versions should work.
 
 ### Third-party Libraries
@@ -11,6 +11,8 @@ Compiler:
 [Important build notes](THIRDPARTY-LIBS.md)
 
 Required Libraries:
+ * [c-ares](https://c-ares.org/) version 1.10.0+, for asynchronous DNS
+   resolution in libcurl.
  * [Concurrency Kit](https://github.com/concurrencykit/ck) (libck), version 0.7.1 or later ([Patch required](THIRDPARTY-LIBS.md#concurrencykit-libck))
  * [flatcc](https://github.com/dvidelabs/flatcc), version 0.6.0. ([Patch required](THIRDPARTY-LIBS.md#flatcc))
  * [libcircllhist](https://github.com/openhistogram/libcircllhist)
@@ -19,19 +21,20 @@ Required Libraries:
  * [libmtev](https://github.com/circonus-labs/libmtev)
  * [LMDB](https://www.symas.com/lmdb)
  * [LuaJIT](https://luajit.org/luajit.html) version 2.1.
- * NetSNMP 5.7+
+ * NetSNMP 5.8+
    * NetSNMP is required for the lua-snmp bindings that power OID lookups. The
      standard SNMP querying implementation is in Java and shipped with the
      repo.  A pure-C SNMP check implementation exists, but requires
      [patches](THIRDPARTY-LIBS.md#netsnmp) (producing libnetsnmp-c).
- * lz4
+ * [nghttp2](https://nghttp2.org/) 1.39.0+, for HTTP/2 support in libcurl.
+ * [lz4](https://github.com/lz4/lz4)
  * [JLog](https://github.com/omniti-labs/jlog)
  * [Picklingtools](http://www.picklingtools.com) ([Patch required](THIRDPARTY-LIBS.md#picklingtools))
  * PostgreSQL 8.4+
  * Protobuf 3.19+
  * Protobuf-C 1.4+
  * [snappy-c](https://github.com/andikleen/snappy-c.git)
- * [udns](https://www.corpit.ru/mjt/udns.html)
+ * [udns](https://www.corpit.ru/mjt/udns.html) version 0.4
  * [wslay](https://github.com/tatsuhiro-t/wslay) for WebSockets support.
  * [yajl](https://github.com/lloyd/yajl)
 
@@ -52,15 +55,23 @@ Tested on 20.04 LTS
 
 Install dependencies that are available as packages:
 
+    sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+    sudo apt-get update && sudo apt-get install gcc-11 g++-11
+
     sudo apt-get install autoconf build-essential cmake \
       libapr1-dev libaprutil1-dev libcurl4-openssl-dev libhwloc-dev \
-      liblz4-dev libncurses-dev libnghttp2-dev libpcre3-dev \
+      liblmdb-dev liblz4-dev libncurses-dev libnghttp2-dev libpcre3-dev \
       libpq-dev librabbitmq-dev libsqlite3-dev libssl-dev libudns-dev \
       libwslay-dev libxslt1-dev libyajl-dev openjdk-8-jdk-headless pkg-config \
       uuid-dev xsltproc zlib1g-dev
 
+Ensure the necessary compiler version is used:
+
+    export CC=gcc-11
+    export CXX=g++-11
+
 Follow [build instructions for third-party libraries](THIRDPARTY-LIBS.md) that
-are not available as packages.
+are not available as packages. Then come back here and continue below.
 
     git clone https://github.com/circonus-labs/reconnoiter
     cd reconnoiter
@@ -75,16 +86,16 @@ Install dependencies that are available as packages:
 
     sudo yum groupinstall "Development Tools"
     sudo yum --enablerepo=extras install centos-release-scl
-    sudo yum install devtoolset-9
-    sudo yum install autoconf apr-devel apr-util-devel cmake hwloc-devel \
-      java-1.8.0-openjdk-devel libnghttp2-devel librabbitmq-devel \
-      libtermcap-devel libuuid-devel libxslt-devel lz4-devel ncurses-devel \
-      openssl openssl-devel pcre-devel pkgconfig postgresql-devel \
-      sqlite-devel udns-devel yajl-devel zlib-devel
-    scl enable devtoolset-9 bash
+    sudo yum install devtoolset-11
+    sudo yum install autoconf apr-devel apr-util-devel c-ares-devel cmake \
+      hwloc-devel java-1.8.0-openjdk-devel libtermcap-devel libuuid-devel \
+      libxslt-devel ncurses-devel openssl openssl-devel pcre-devel \
+      pkgconfig postgresql-devel sqlite-devel udns-devel yajl-devel \
+      zlib-devel
+    scl enable devtoolset-11 bash
 
 Follow [build instructions for third-party libraries](THIRDPARTY-LIBS.md) that
-are not available as packages.
+are not available as packages. Then come back here and continue below.
 
     git clone https://github.com/circonus-labs/reconnoiter
     cd reconnoiter

--- a/THIRDPARTY-LIBS.md
+++ b/THIRDPARTY-LIBS.md
@@ -23,21 +23,46 @@ make
 sudo make install
 ```
 
+## nghttp2
+
+Obtain source for version 1.39.0 or later from the [download
+page](https://github.com/nghttp2/nghttp2/releases) and extract it.
+
+```
+./configure --prefix=/usr/local --enable-lib-only
+make
+sudo make install
+```
+
 ## cURL
 
 Obtain source for version 7.49.0 or later from the [download
 page](https://curl.se/download.html) and extract it.
 
-The only required option is which SSL/TLS library to build against. OpenSSL is
-the most common, and recommended. Ensure that you have the appropriate OpenSSL
-headers installed.
+It is recommended to use OpenSSL for SSL/TLS support. Ensure that you have the
+appropriate OpenSSL headers installed.
 
 ```
-./configure --prefix=/usr/local --with-openssl
+LDFLAGS="-Wl,-rpath=/usr/local/lib" ./configure \
+  --with-openssl \
+  --enable-thread \
+  --enable-ares \
+  --with-nghttp2=/usr/local
 make
 sudo make install
 ```
 
+## lz4
+
+Substitute desired version for `X.Y.Z` below.
+
+```
+git clone https://github.com/lz4/lz4.git
+cd lz4
+git checkout tags/vX.Y.Z
+make
+sudo make BINDIR=/usr/local/bin LIBDIR=/usr/local/lib install
+```
 
 ## flatcc
 
@@ -116,7 +141,7 @@ sudo make install
 
 ## NetSNMP
 
-Obtain source for 5.7.1 or later from the [download
+Obtain source for 5.8 or later from the [download
 page](http://www.net-snmp.org/download.html) and extract it.
 
 ```
@@ -180,7 +205,7 @@ git checkout tags/v1.4.0
 autoreconf -i
 PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
   LDFLAGS="-L/usr/local/lib -Wl,-rpath=/usr/local/lib" \
-  ./configure
+  ./configure --disable-static
 make
 sudo make install
 ```
@@ -228,11 +253,24 @@ Obtain source for 1.0.0 or later from the [download
 page](https://github.com/tatsuhiro-t/wslay/releases) and extract it.
 
 ```
-./configure
-make
-sudo make install
+autoreconf -i
+./configure --disable-static
+make -C lib
+sudo make -C lib install
 ```
 
+## udns
+
+Obtain source for version 0.4 from https://www.corpit.ru/mjt/udns/udns-0.4.tar.gz
+and extract it.
+
+```
+patch -p1 < [reconnoiter source]/patches/udns.patch
+./configure
+make
+make shared
+sudo make install
+```
 
 ## libmtev
 
@@ -244,7 +282,9 @@ installing the libraries on this page before proceeding with the
 git clone https://github.com/circonus-labs/libmtev
 cd libmtev
 autoreconf -i -I buildtools
-CPPFLAGS="-I/usr/local/include/luajit-2.1" ./configure
+CPPFLAGS="-I/usr/local/include/luajit-2.1" \
+  CFLAGS="-Wno-uninitialized -Wno-misleading-indentation -Wno-free-nonheap-object" \
+  ./configure
 make
 sudo make install
 ```


### PR DESCRIPTION
Now need GCC 11 or other C++20 compiler.

Review and update system package list for EL7 and Ubuntu 20.04, and update third-party library build instructions.