### PR TITLE
Remove custom DH params

### DIFF
--- a/src/et.conf
+++ b/src/et.conf
@@ -6,8 +6,6 @@
       <concurrency>4</concurrency>
       <default_queue_threads>10</default_queue_threads>
       <default_ca_chain>/export/home/jesus/src/reconnoiter/src/default-ca-chain.crt</default_ca_chain>
-      <ssl_dhparam512_file>/export/home/jesus/src/reconnoiter/src/dhparam512.txt</ssl_dhparam512_file>
-      <ssl_dhparam1024_file>/export/home/jesus/src/reconnoiter/src/dhparam1024.txt</ssl_dhparam1024_file>
     </config>
   </eventer>
   <resolver>

--- a/src/noit.conf.in
+++ b/src/noit.conf.in
@@ -6,8 +6,6 @@
       <concurrency>4</concurrency>
       <default_queue_threads>10</default_queue_threads>
       <default_ca_chain>%sysconfdir%/default-ca-chain.crt</default_ca_chain>
-      <ssl_dhparam1024_file>%sysconfdir%/dhparam1024.txt</ssl_dhparam1024_file>
-      <ssl_dhparam2048_file>%sysconfdir%/dhparam2048.txt</ssl_dhparam2048_file>
     </config>
   </eventer>
   <resolver>

--- a/test/busted/lua-support/reconnoiter.lua
+++ b/test/busted/lua-support/reconnoiter.lua
@@ -243,8 +243,6 @@ function TestConfig:make_eventer_config(fd, opts)
   "  <config>\n" ..
   "    <default_queue_threads>" .. opts['eventer_config']['default_queue_threads'] .. "</default_queue_threads>\n" ..
   "    <default_ca_chain>" .. opts['eventer_config']['default_ca_chain'] .. "</default_ca_chain>\n" ..
-  "    <ssl_dhparam1024_file/>\n" ..
-  "    <ssl_dhparam2048_file/>\n" ..
   "  </config>\n" ..
   "</eventer>\n"
   mtev.write(fd, out)


### PR DESCRIPTION
Ignored as of libmtev 2.5.0 in favor of safe primes built into OpenSSL.