### PR TITLE
CIRC-10357 Address linker issue with OpenSSL 1.0

### DIFF
--- a/src/Makefile.dep
+++ b/src/Makefile.dep
@@ -107,6 +107,19 @@ noit_conf_checks_lmdb.o noit_conf_checks_lmdb.lo: noit_conf_checks_lmdb.c noit_c
   noit_metric.h noit_lmdb_tools.h  \
   noit_check_lmdb.h \
 
+noitd.o noitd.lo: noitd.c noit_config.h noit_version.h \
+  noit_clustering.h noit_check.h \
+  noit_metric.h noit_lmdb_tools.h  \
+  libnoit.h noit_mtev_bridge.h noit_jlog_listener.h noit_check_rest.h \
+  noit_check.h noit_check_tools.h noit_module.h \
+  noit_clustering.h \
+  noit_check_tools_shared.h noit_module.h noit_livestream_listener.h \
+  noit_websocket_handler.h noit_conf_checks.h \
+  noit_filters.h \
+  noit_metric_tag_search.h noit_metric.h noit_metric_director.h \
+  noit_message_decoder.h noit_metric_tag_search.h noit_check_log_helpers.h \
+  man/noitd.usage.h
+
 noit_fb.o noit_fb.lo: noit_fb.c noit_fb.h  \
   noit_metric.h \
   flatbuffers/metric_batch_builder.h \
@@ -201,6 +214,8 @@ noit_socket_listener.o noit_socket_listener.lo: noit_socket_listener.c \
   noit_check_tools_shared.h \
   noit_module.h noit_mtev_bridge.h noit_socket_listener.h
 
+noit_ssl10_compat.o noit_ssl10_compat.lo: noit_ssl10_compat.c
+
 noit_version.o noit_version.lo: noit_version.c noit_version.h \
 
 noit_websocket_handler.o noit_websocket_handler.lo: noit_websocket_handler.c \
@@ -209,24 +224,22 @@ noit_websocket_handler.o noit_websocket_handler.lo: noit_websocket_handler.c \
   noit_check_log_helpers.h noit_message_decoder.h noit_metric.h \
   noit_mtev_bridge.h noit_websocket_handler.h \
 
-noitd.o noitd.lo: noitd.c noit_config.h noit_version.h \
-  noit_clustering.h noit_check.h \
-  noit_metric.h noit_lmdb_tools.h  \
-  libnoit.h noit_mtev_bridge.h noit_jlog_listener.h noit_check_rest.h \
-  noit_check.h noit_check_tools.h noit_module.h \
-  noit_clustering.h \
-  noit_check_tools_shared.h noit_module.h noit_livestream_listener.h \
-  noit_websocket_handler.h noit_conf_checks.h \
-  noit_filters.h \
-  noit_metric_tag_search.h noit_metric.h noit_metric_director.h \
-  noit_message_decoder.h noit_metric_tag_search.h noit_check_log_helpers.h \
-  man/noitd.usage.h
-
 stratcon_datastore.o stratcon_datastore.lo: stratcon_datastore.c \
   noit_mtev_bridge.h stratcon_datastore.h stratcon_realtime_http.h \
   stratcon_ingest.h stratcon_iep.h stratcon_jlog_streamer.h \
   noit_check.h noit_metric.h \
   noit_lmdb_tools.h  \
+
+stratcond.o stratcond.lo: stratcond.c  \
+  noit_version.h  \
+  libnoit.h noit_mtev_bridge.h \
+  noit_config.h noit_module.h  \
+  noit_check.h noit_metric.h noit_lmdb_tools.h \
+  noit_check_tools.h noit_clustering.h noit_check.h \
+  noit_check_tools_shared.h \
+  noit_module.h stratcon_jlog_streamer.h  \
+  stratcon_datastore.h \
+  stratcon_realtime_http.h stratcon_iep.h man/stratcond.usage.h
 
 stratcon_iep.o stratcon_iep.lo: stratcon_iep.c  \
   noit_mtev_bridge.h noit_jlog_listener.h stratcon_jlog_streamer.h \
@@ -255,14 +268,3 @@ stratcon_realtime_http.o stratcon_realtime_http.lo: stratcon_realtime_http.c \
   noit_livestream_listener.h stratcon_realtime_http.h \
   stratcon_jlog_streamer.h  \
   stratcon_datastore.h
-
-stratcond.o stratcond.lo: stratcond.c  \
-  noit_version.h  \
-  libnoit.h noit_mtev_bridge.h \
-  noit_config.h noit_module.h  \
-  noit_check.h noit_metric.h noit_lmdb_tools.h \
-  noit_check_tools.h noit_clustering.h noit_check.h \
-  noit_check_tools_shared.h \
-  noit_module.h stratcon_jlog_streamer.h  \
-  stratcon_datastore.h \
-  stratcon_realtime_http.h stratcon_iep.h man/stratcond.usage.h

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -140,9 +140,10 @@ LUALIBS=@LUALIBS@
 LIBNOIT_OBJS=noit_check_log_helpers.lo noit_fb.lo bundle.pb-c.lo \
 	noit_check_tools_shared.lo stratcon_ingest.lo noit_metric_rollup.lo \
 	noit_metric_director.lo noit_message_decoder.hlo noit_metric.hlo \
-	noit_metric_tag_search.lo noit_version.lo libnoit.lo
+	noit_metric_tag_search.lo noit_ssl10_compat.lo noit_version.lo libnoit.lo
 
-B2SM_OBJS=noit_b2sm.o noit_check_log_helpers.o bundle.pb-c.o noit_message_decoder.o noit_metric.o
+B2SM_OBJS=noit_b2sm.o noit_check_log_helpers.o bundle.pb-c.o noit_message_decoder.o \
+	noit_metric.o noit_ssl10_compat.o
 
 NOIT_OBJS=noitd.o noit_mtev_bridge.o \
 	noit_check_resolver.o noit_check_log.o \

--- a/src/noit_ssl10_compat.c
+++ b/src/noit_ssl10_compat.c
@@ -1,0 +1,28 @@
+#include <openssl/opensslv.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+#include <string.h>
+#include <openssl/engine.h>
+
+void *OPENSSL_zalloc(size_t num)
+{
+   void *ret = OPENSSL_malloc(num);
+
+   if (ret) {
+       memset(ret, 0, num);
+   }
+   return ret;
+}
+
+EVP_MD_CTX *EVP_MD_CTX_new(void)
+{
+  return OPENSSL_zalloc(sizeof(EVP_MD_CTX));
+}
+
+void EVP_MD_CTX_free(EVP_MD_CTX *ctx)
+{
+  EVP_MD_CTX_cleanup(ctx);
+  OPENSSL_free(ctx);
+}
+#endif

--- a/src/noit_ssl10_compat.h
+++ b/src/noit_ssl10_compat.h
@@ -8,26 +8,11 @@
 #include <string.h>
 #include <openssl/engine.h>
 
-inline void *OPENSSL_zalloc(size_t num)
-{
-   void *ret = OPENSSL_malloc(num);
+void *OPENSSL_zalloc(size_t num);
 
-   if (ret) {
-       memset(ret, 0, num);
-   }
-   return ret;
-}
+EVP_MD_CTX *EVP_MD_CTX_new(void);
 
-inline EVP_MD_CTX *EVP_MD_CTX_new(void)
-{
-  return OPENSSL_zalloc(sizeof(EVP_MD_CTX));
-}
-
-inline void EVP_MD_CTX_free(EVP_MD_CTX *ctx)
-{
-  EVP_MD_CTX_cleanup(ctx);
-  OPENSSL_free(ctx);
-}
+void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
 #endif
 
 #endif // NOIT_SSL10_COMPAT_H


### PR DESCRIPTION
The compiler seems unable to get the inline functions from the compat header into the object, leading to an undefined symbol at link time.

Create a C file with the compat functions so it can be linked properly.