### PR TITLE
Make grpc disabled and grpc ssl disabled the default

### DIFF
--- a/src/modules/otlphttp.cpp
+++ b/src/modules/otlphttp.cpp
@@ -1061,12 +1061,12 @@ static int noit_otlphttp_init(noit_module_t *self) {
   otlphttp_mod_config *conf = static_cast<otlphttp_mod_config*>(noit_module_get_userdata(self));
 
 #ifdef HAVE_GRPC
-  conf->enable_grpc = true;
+  conf->enable_grpc = false;
   if (mtev_hash_retr_str(conf->options,
                          "enable_grpc", strlen("enable_grpc"),
                          (const char **)&config_val)) {
-    if (!strcasecmp(config_val, "false") || !strcasecmp(config_val, "off")) {
-      conf->enable_grpc = false;
+    if (!strcasecmp(config_val, "true") || !strcasecmp(config_val, "on")) {
+      conf->enable_grpc = true;
     }
   }
 
@@ -1097,15 +1097,15 @@ static int noit_otlphttp_init(noit_module_t *self) {
     }
   }
 
-  conf->use_grpc_ssl = true;
+  conf->use_grpc_ssl = false;
   conf->grpc_ssl_use_broker_cert = false;
   conf->grpc_ssl_use_root_cert = false;
   if (conf->enable_grpc) {
     if (mtev_hash_retr_str(conf->options,
                            "use_grpc_ssl", strlen("use_grpc_ssl"),
                            (const char **)&config_val)) {
-      if (!strcasecmp(config_val, "false") || !strcasecmp(config_val, "off")) {
-        conf->use_grpc_ssl = false;
+      if (!strcasecmp(config_val, "true") || !strcasecmp(config_val, "on")) {
+        conf->use_grpc_ssl = true;
       }
     }
     if (conf->use_grpc_ssl) {
@@ -1124,9 +1124,6 @@ static int noit_otlphttp_init(noit_module_t *self) {
         }
       }
     }
-  }
-  else {
-    conf->use_grpc_ssl = false; // because grpc is disabled
   }
 #endif
 

--- a/src/modules/otlphttp.xml
+++ b/src/modules/otlphttp.xml
@@ -12,7 +12,7 @@
       allowed="^(?:true|false|on|off)$">Specify if the http listener is enabled via the configured http URL including check_uuid and optional secret.</parameter>
     <parameter name="enable_grpc"
       required="optional"
-      default="true"
+      default="false"
       allowed="^(?:true|false|on|off)$">Specify if the grpc listener is enabled via the configured server address and port.</parameter>
     <parameter name="grpc_server"
       required="optional"
@@ -24,7 +24,7 @@
       allowed="\d+">Specify the listening port that is to be used for grpc.</parameter>
     <parameter name="use_grpc_ssl"
       required="optional"
-      default="true"
+      default="false"
       allowed="^(?:true|false|on|off)$">Specify if SSL/TLS security should be used on the grpc listening port.</parameter>
     <parameter name="grpc_ssl_use_broker_cert"
       required="optional"

--- a/test/busted/listener/otlphttp/otlphttp_scratch.lua
+++ b/test/busted/listener/otlphttp/otlphttp_scratch.lua
@@ -3,7 +3,7 @@ describe("otelproto #otelproto #listener", function()
   setup(function()
     Reconnoiter.clean_workspace()
     noit = Reconnoiter.TestNoit:new("otlphttp", {
-      modules = { otlphttp = { image = "otlphttp", config = { use_grpc_ssl = "false" } } }
+      modules = { otlphttp = { image = "otlphttp", config = { enable_grpc = "true", use_grpc_ssl = "false" } } }
     })
   end)
   teardown(function()


### PR DESCRIPTION
In testing of the broker with the enhanced otlphttp module, the default of grpc enabled and grpc ssl enabled causes a crash loop because grpc ssl is not configured properly (by the user).  In hindsight, we probably don't want port 4317 open by default, even if ssl were configured to some default.  And then we also don't want enabling grpc to result in immediate crash because ssl is enabled to try to protect the user from accidentally exposing unencrypted grpc port 4317 on the internet.
So...we just will make the default to disable grpc and disable grpc ssl, and let the user turn those on as they need/want them and on their own to configure them responsibly.