### PR TITLE
Fix Deadlock In Noit Check Resolver

### DIFF
--- a/src/noit_check_resolver.c
+++ b/src/noit_check_resolver.c
@@ -532,6 +532,10 @@ int noit_check_resolver_loop(eventer_t e, int mask, void *c,
   return 0;
 }
 
+static inline void start_noit_check_resolver_loop() {
+  eventer_add_in_s_us(noit_check_resolver_loop, NULL, 1, 0);
+}
+
 static int
 nc_print_dns_cache_node(mtev_console_closure_t ncct,
                         const char *target, dns_cache_node *n) {
@@ -825,7 +829,7 @@ void noit_check_resolver_init() {
     }
   }
 
-  noit_check_resolver_loop(NULL, 0, NULL, NULL);
+  start_noit_check_resolver_loop();
   register_console_dns_cache_commands();
 
   mtev_hash_init(&etc_hosts_cache);

--- a/src/noit_check_resolver.c
+++ b/src/noit_check_resolver.c
@@ -533,7 +533,7 @@ int noit_check_resolver_loop(eventer_t e, int mask, void *c,
 }
 
 static inline void start_noit_check_resolver_loop() {
-  eventer_add_in_s_us(noit_check_resolver_loop, NULL, 1, 0);
+  eventer_add_in_s_us(noit_check_resolver_loop, NULL, 0, 0);
 }
 
 static int


### PR DESCRIPTION
The noit_check_resolver_init() function was calling a function that could try to take a lock that the function already holds, leading to deadlock. Added a new, simple helper function to add the offending locking call to the event loop without calling it first, preventing the deadlock.