### PR TITLE
Fix OTLP/GRPC Module Memory Leaks/Misuses

### DIFF
--- a/src/modules/otlp.cpp
+++ b/src/modules/otlp.cpp
@@ -216,7 +216,7 @@ metric_local_batch(otlp_upload *rxc, const char *name, double *val, int64_t *val
   if (!mtev_hash_store(rxc->immediate_metrics, m->metric_name, cmetric_len, m)) {
     metric_local_batch_flush_immediate(rxc);
     if (!mtev_hash_store(rxc->immediate_metrics, m->metric_name, cmetric_len, m)) {
-      mtevL(nlerr, "%s: could not sure metric %s in otlp\n", __func__, m->metric_name);
+      mtevL(nlerr, "%s: could not store metric %s in otlp\n", __func__, m->metric_name);
       mtev_memory_safe_free(m);
     }
   }

--- a/src/modules/otlp.cpp
+++ b/src/modules/otlp.cpp
@@ -189,7 +189,7 @@ metric_local_batch(otlp_upload *rxc, const char *name, double *val, int64_t *val
   }
   auto cmetric_len = strlen(cmetric);
   if(auto metric = static_cast<metric_t *>(mtev_hash_get(rxc->immediate_metrics, cmetric, cmetric_len))) {
-    if (metric->whence.tv_sec = w.tv_sec && metric->whence.tv_usec == w.tv_usec) {
+    if (metric->whence.tv_sec == w.tv_sec && metric->whence.tv_usec == w.tv_usec) {
       return;
     }
     metric_local_batch_flush_immediate(rxc);

--- a/src/modules/otlp.cpp
+++ b/src/modules/otlp.cpp
@@ -219,8 +219,12 @@ metric_local_batch(otlp_upload *rxc, const char *name, double *val, int64_t *val
     metric_local_batch_flush_immediate(rxc);
   }
   noit_stats_mark_metric_logged(noit_check_get_stats_inprogress(rxc->check), m, mtev_false);
-  while (!mtev_hash_store(rxc->immediate_metrics, m->metric_name, cmetric_len, m)) {
+  if (!mtev_hash_store(rxc->immediate_metrics, m->metric_name, cmetric_len, m)) {
     metric_local_batch_flush_immediate(rxc);
+    if (!mtev_hash_store(rxc->immediate_metrics, m->metric_name, cmetric_len, m)) {
+      mtevL(nlerr, "%s: could not sure metric %s in otlp\n", __func__, m->metric_name);
+      mtev_memory_safe_free(m);
+    }
   }
 }
 

--- a/src/modules/otlp.cpp
+++ b/src/modules/otlp.cpp
@@ -195,7 +195,7 @@ metric_local_batch(otlp_upload *rxc, const char *name, double *val, int64_t *val
   memcpy(cmetric + cmetric_len + 1, &t, sizeof(uint64_t));
   cmetric_len += 1 + sizeof(uint64_t);
 
-  if(mtev_hash_retrieve(rxc->immediate_metrics, cmetric, cmetric_len, NULL)) {
+  if(mtev_hash_get(rxc->immediate_metrics, cmetric, cmetric_len)) {
     return;
   }
   ck_pr_barrier();

--- a/src/modules/otlp.cpp
+++ b/src/modules/otlp.cpp
@@ -200,7 +200,8 @@ metric_local_batch(otlp_upload *rxc, const char *name, double *val, int64_t *val
   }
   ck_pr_barrier();
   metric_t *m = noit_metric_alloc();
-  m->metric_name = mtev_strndup(cmetric, cmetric_len);
+  m->metric_name = static_cast<char *>(malloc(cmetric_len));
+  memcpy(m->metric_name, cmetric, cmetric_len);
   if(val) {
     m->metric_type = METRIC_DOUBLE;
     memcpy(&m->whence, &w, sizeof(struct timeval));

--- a/src/modules/otlp.cpp
+++ b/src/modules/otlp.cpp
@@ -198,7 +198,6 @@ metric_local_batch(otlp_upload *rxc, const char *name, double *val, int64_t *val
   if(mtev_hash_get(rxc->immediate_metrics, cmetric, cmetric_len)) {
     return;
   }
-  ck_pr_barrier();
   metric_t *m = noit_metric_alloc();
   m->metric_name = static_cast<char *>(malloc(cmetric_len));
   memcpy(m->metric_name, cmetric, cmetric_len);

--- a/src/modules/otlp.cpp
+++ b/src/modules/otlp.cpp
@@ -213,7 +213,6 @@ metric_local_batch(otlp_upload *rxc, const char *name, double *val, int64_t *val
   if(mtev_hash_size(rxc->immediate_metrics) > 1000) {
     metric_local_batch_flush_immediate(rxc);
   }
-  noit_stats_mark_metric_logged(noit_check_get_stats_inprogress(rxc->check), m, mtev_false);
   if (!mtev_hash_store(rxc->immediate_metrics, m->metric_name, cmetric_len, m)) {
     metric_local_batch_flush_immediate(rxc);
     if (!mtev_hash_store(rxc->immediate_metrics, m->metric_name, cmetric_len, m)) {
@@ -221,6 +220,7 @@ metric_local_batch(otlp_upload *rxc, const char *name, double *val, int64_t *val
       mtev_memory_safe_free(m);
     }
   }
+  noit_stats_mark_metric_logged(noit_check_get_stats_inprogress(rxc->check), m, mtev_false);
 }
 
 class name_builder {

--- a/src/modules/otlpgrpc.cpp
+++ b/src/modules/otlpgrpc.cpp
@@ -117,10 +117,6 @@ grpc::Status GRPCService::Export(grpc::ServerContext* context,
                                  const OtelCollectorMetrics::ExportMetricsServiceRequest* request,
                                  OtelCollectorMetrics::ExportMetricsServiceResponse* response)
 {
-  std::string check_name;
-  std::string check_uuid;
-  std::string secret;
-
   constexpr auto handle_error = [](const std::string &error) {
     mtevL(nldeb_verbose, "[otlpgrpc] grpc metric data batch error: %s\n", error.c_str());
     return grpc::Status(grpc::StatusCode::NOT_FOUND, error);
@@ -129,6 +125,9 @@ grpc::Status GRPCService::Export(grpc::ServerContext* context,
   mtevL(nldeb_verbose, "[otlpgrpc] grpc incoming payload - client metadata:\n");
   const std::multimap<grpc::string_ref, grpc::string_ref> metadata =
       context->client_metadata();
+
+  std::string check_uuid;
+  std::string secret;
   for (auto iter = metadata.begin(); iter != metadata.end(); ++iter) {
     std::string key{iter->first.data(), iter->first.length()};
     mtevL(nldeb_verbose, "[otlpgrpc] header key: %s\n", key.c_str());
@@ -146,9 +145,6 @@ grpc::Status GRPCService::Export(grpc::ServerContext* context,
     mtevL(nldeb_verbose, "[otlpgrpc] value: %s\n", value.c_str());
     if (key == "check_uuid") {
       check_uuid = value;
-    }
-    else if (key == "check_name") {
-      check_name = value;
     }
     else if (key == "secret" || key == "api_key") {
       secret = value;


### PR DESCRIPTION
Fix several memory leaks and places where hash tables were being used incorrectly. Also fix some issues where data points were being lost.