### PR TITLE
Fix otlpgrpc Module Memory Leak

### DIFF
--- a/src/modules/otlpgrpc.cpp
+++ b/src/modules/otlpgrpc.cpp
@@ -189,6 +189,7 @@ grpc::Status GRPCService::Export(grpc::ServerContext* context,
   handle_message(&rxc, *request);
   metric_local_batch_flush_immediate(&rxc);
   mtev_memory_end();
+  mtev_memory_fini_thread();
 
   mtevL(nldeb_verbose, "[otlpgrpc] grpc metric data batch submitted successfully.\n");
   return grpc::Status::OK;


### PR DESCRIPTION
Need to call `mtev_memory_finish_thread` after handling the metric data.