### PR TITLE
Fix Memory Leak In Marking Metrics Logged

### DIFF
--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -2903,8 +2903,8 @@ record_immediate_metric_with_tagset(noit_check_t *check,
     mtev_memory_safe_free(m);
     return;
   }
+  struct timeval now;
   if(time == NULL) {
-    struct timeval now;
     gettimeofday(&now, NULL);
     time = &now;
   }


### PR DESCRIPTION
We were checking the return on whether we marked a metric logged, but the function being called duplicates the metric if it needs it, so we need to unconditionally clean up.