### PR TITLE
Improve LMDB Filter Processing Time And Cleanup

### DIFF
--- a/src/noit_check.c
+++ b/src/noit_check.c
@@ -3548,16 +3548,18 @@ noit_check_build_cluster_changelog(void *vpeer) {
 int
 noit_check_process_repl(xmlDocPtr doc) {
   int i = 0;
-  xmlNodePtr root, child, next = NULL, node;
-  if(!initialized) return -1;
+  if(!initialized) {
+    return -1;
+  }
   if (noit_check_get_lmdb_instance()) {
     return noit_check_lmdb_process_repl(doc);
   }
-  root = xmlDocGetRootElement(doc);
+  xmlNodePtr next = NULL, node = NULL;
+  xmlNodePtr root = xmlDocGetRootElement(doc);
   mtev_conf_section_t section;
   mtev_conf_section_t checks = mtev_conf_get_section_write(MTEV_CONF_ROOT, "/noit/checks");
   mtevAssert(!mtev_conf_section_is_empty(checks));
-  for(child = xmlFirstElementChild(root); child; child = next) {
+  for(xmlNodePtr child = xmlFirstElementChild(root); child; child = next) {
     next = xmlNextElementSibling(child);
 
     uuid_t checkid;

--- a/src/noit_check_lmdb.c
+++ b/src/noit_check_lmdb.c
@@ -1773,17 +1773,14 @@ noit_check_lmdb_migrate_xml_checks_to_lmdb() {
 
 int
 noit_check_lmdb_process_repl(xmlDocPtr doc) {
-  int i = 0, j = 0, namespace_cnt = 0;
-  xmlNodePtr next = NULL;
+  int ret = 0, namespace_cnt = 0;
   mtev_conf_section_t section;
   char **namespaces = noit_check_get_namespaces(&namespace_cnt);
 
   xmlNodePtr root = xmlDocGetRootElement(doc);
   mtev_conf_section_t checks = mtev_conf_get_section_write(MTEV_CONF_ROOT, "/noit/checks");
   mtevAssert(!mtev_conf_section_is_empty(checks));
-  for(xmlNodePtr child = xmlFirstElementChild(root); child; child = next) {
-    next = xmlNextElementSibling(child);
-
+  for(xmlNodePtr child = xmlFirstElementChild(root); child; child = xmlNextElementSibling(child)) {
     uuid_t checkid;
     int64_t seq;
     char uuid_str[UUID_STR_LEN+1], seq_str[32];
@@ -1801,7 +1798,7 @@ noit_check_lmdb_process_repl(xmlDocPtr doc) {
     /* too old, don't bother */
     if(check && check->config_seq >= seq) {
       noit_check_deref(check);
-      i++;
+      ret++;
       continue;
     }
     noit_check_deref(check);
@@ -1814,14 +1811,14 @@ noit_check_lmdb_process_repl(xmlDocPtr doc) {
       noit_check_lmdb_poller_process_checks(&checkid, 1);
     }
 
-    i++;
+    ret++;
   }
   mtev_conf_release_section_write(checks);
-  for(j=0; j<namespace_cnt; j++) {
+  for(int j=0; j<namespace_cnt; j++) {
     free(namespaces[j]);
   }
   free(namespaces);
-  return i;
+  return ret;
 }
 
 mtev_boolean

--- a/src/noit_check_lmdb.c
+++ b/src/noit_check_lmdb.c
@@ -1774,14 +1774,14 @@ noit_check_lmdb_migrate_xml_checks_to_lmdb() {
 int
 noit_check_lmdb_process_repl(xmlDocPtr doc) {
   int i = 0, j = 0, namespace_cnt = 0;
-  xmlNodePtr root = NULL, child = NULL, next = NULL;
+  xmlNodePtr next = NULL;
   mtev_conf_section_t section;
   char **namespaces = noit_check_get_namespaces(&namespace_cnt);
 
-  root = xmlDocGetRootElement(doc);
+  xmlNodePtr root = xmlDocGetRootElement(doc);
   mtev_conf_section_t checks = mtev_conf_get_section_write(MTEV_CONF_ROOT, "/noit/checks");
   mtevAssert(!mtev_conf_section_is_empty(checks));
-  for(child = xmlFirstElementChild(root); child; child = next) {
+  for(xmlNodePtr child = xmlFirstElementChild(root); child; child = next) {
     next = xmlNextElementSibling(child);
 
     uuid_t checkid;

--- a/src/noit_filters.c
+++ b/src/noit_filters.c
@@ -573,7 +573,6 @@ noit_filters_from_conf() {
 int
 noit_filters_process_repl(xmlDocPtr doc) {
   int i = 0;
-  xmlNodePtr root, child, next = NULL;
 
   if (noit_filters_get_lmdb_instance()) {
     return noit_filters_lmdb_process_repl(doc);
@@ -583,10 +582,11 @@ noit_filters_process_repl(xmlDocPtr doc) {
     mtevL(nf_debug, "filterset replication pending initialization\n");
     return -1;
   }
-  root = xmlDocGetRootElement(doc);
+  xmlNodePtr next = NULL;
+  xmlNodePtr root = xmlDocGetRootElement(doc);
   mtev_conf_section_t filtersets = mtev_conf_get_section_write(MTEV_CONF_ROOT, filtersets_replication_path);
   mtevAssert(!mtev_conf_section_is_empty(filtersets));
-  for(child = xmlFirstElementChild(root); child; child = next) {
+  for(xmlNodePtr child = xmlFirstElementChild(root); child; child = next) {
     next = xmlNextElementSibling(child);
 
     char filterset_name[MAX_METRIC_TAGGED_NAME];

--- a/src/noit_filters_lmdb.c
+++ b/src/noit_filters_lmdb.c
@@ -1283,15 +1283,15 @@ noit_filters_lmdb_migrate_xml_filtersets_to_lmdb() {
 int
 noit_filters_lmdb_process_repl(xmlDocPtr doc) {
   int i = 0;
-  xmlNodePtr root, child, next = NULL;
+  xmlNodePtr next = NULL;
 
   if(!noit_filter_initialized()) {
     mtevL(mtev_debug, "filterset replication pending initialization\n");
     return -1;
   }
 
-  root = xmlDocGetRootElement(doc);
-  for(child = xmlFirstElementChild(root); child; child = next) {
+  xmlNodePtr root = xmlDocGetRootElement(doc);
+  for(xmlNodePtr child = xmlFirstElementChild(root); child; child = next) {
     next = xmlNextElementSibling(child);
 
     char filterset_name[MAX_METRIC_TAGGED_NAME];

--- a/src/noit_filters_lmdb.c
+++ b/src/noit_filters_lmdb.c
@@ -1282,8 +1282,7 @@ noit_filters_lmdb_migrate_xml_filtersets_to_lmdb() {
 
 int
 noit_filters_lmdb_process_repl(xmlDocPtr doc) {
-  int i = 0;
-  xmlNodePtr next = NULL;
+  int ret = 0;
 
   if(!noit_filter_initialized()) {
     mtevL(mtev_debug, "filterset replication pending initialization\n");
@@ -1291,9 +1290,7 @@ noit_filters_lmdb_process_repl(xmlDocPtr doc) {
   }
 
   xmlNodePtr root = xmlDocGetRootElement(doc);
-  for(xmlNodePtr child = xmlFirstElementChild(root); child; child = next) {
-    next = xmlNextElementSibling(child);
-
+  for(xmlNodePtr child = xmlFirstElementChild(root); child; child = xmlNextElementSibling(child)) {
     char filterset_name[MAX_METRIC_TAGGED_NAME];
     mtevAssert(mtev_conf_get_stringbuf(mtev_conf_section_from_xmlnodeptr(child), "@name",
                                        filterset_name, sizeof(filterset_name)));
@@ -1305,9 +1302,9 @@ noit_filters_lmdb_process_repl(xmlDocPtr doc) {
         free(error);
       }
     }
-    i++;
+    ret++;
   }
-  return i;
+  return ret;
 }
 
 int


### PR DESCRIPTION
Added a check against the existing filtersets when doing cluster replication to make sure we're not blowing away more current data and to reduce the amount of unneeded work, which should speed up startup and reduce memory usage.

Also did various small bits of cleanup.