### PR TITLE
Set Metric Lengths Properly In Prometheus Handling

### DIFF
--- a/src/modules/prometheus.c
+++ b/src/modules/prometheus.c
@@ -475,8 +475,8 @@ rest_prometheus_handler(mtev_http_rest_closure_t *restc, int npats, char **pats)
       coercion = noit_prometheus_metric_name_coerce(ts->labels, ts->n_labels, rxc->extract_units,
                                     rxc->coerce_histograms, rxc->allowed_units);
     }
-    char *metric_name = noit_prometheus_metric_name_from_labels(ts->labels, ts->n_labels, coercion.units,
-                                                            coercion.is_histogram && rxc->coerce_histograms);
+    prometheus_metric_name_t *metric_data = noit_prometheus_metric_name_from_labels(ts->labels, ts->n_labels, coercion.units,
+                                                                                    coercion.is_histogram && rxc->coerce_histograms);
 
     for (size_t j = 0; j < ts->n_samples; j++) {
       Prometheus__Sample *sample = ts->samples[j];
@@ -485,12 +485,12 @@ rest_prometheus_handler(mtev_http_rest_closure_t *restc, int npats, char **pats)
       tv.tv_usec = (suseconds_t)((sample->timestamp % 1000L) * 1000);
 
       if(coercion.is_histogram) {
-        noit_prometheus_track_histogram(&rxc->hists, metric_name, coercion.hist_boundary, sample->value, tv);
+        noit_prometheus_track_histogram(&rxc->hists, metric_data->name, coercion.hist_boundary, sample->value, tv);
       } else {
-        metric_local_batch(rxc, metric_name, sample->value, tv);
+        metric_local_batch(rxc, metric_data->name, sample->value, tv);
       }
     }
-    free(metric_name);
+    noit_prometheus_metric_name_free(metric_data);
   }
   metric_local_batch_flush_immediate(rxc);
   flush_histograms(rxc);

--- a/src/modules/prometheus.c
+++ b/src/modules/prometheus.c
@@ -485,7 +485,7 @@ rest_prometheus_handler(mtev_http_rest_closure_t *restc, int npats, char **pats)
       tv.tv_usec = (suseconds_t)((sample->timestamp % 1000L) * 1000);
 
       if(coercion.is_histogram) {
-        noit_prometheus_track_histogram(&rxc->hists, metric_data->name, coercion.hist_boundary, sample->value, tv);
+        noit_prometheus_track_histogram(&rxc->hists, metric_data, coercion.hist_boundary, sample->value, tv);
       } else {
         metric_local_batch(rxc, metric_data->name, sample->value, tv);
       }

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -1198,7 +1198,7 @@ handle_prometheus_message(const int64_t account_id,
     for (size_t j = 0; j < ts->n_samples; j++) {
       if (!coercion.is_histogram) {
         noit_metric_message_t *message = noit_prometheus_translate_to_noit_metric_message(&coercion,
-          account_id, check_uuid, metric_data->name, ts->samples[j]);
+          account_id, check_uuid, metric_data, ts->samples[j]);
         if (message) {
           distribute_message(message);
           noit_metric_director_message_deref(message);

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -1209,7 +1209,7 @@ handle_prometheus_message(const int64_t account_id,
         struct timeval tv;
         tv.tv_sec = (time_t)(sample->timestamp / 1000L);
         tv.tv_usec = (suseconds_t)((sample->timestamp % 1000L) * 1000);
-        noit_prometheus_track_histogram(&hists, metric_data->name, coercion.hist_boundary, sample->value, tv);
+        noit_prometheus_track_histogram(&hists, metric_data, coercion.hist_boundary, sample->value, tv);
       }
     }
     noit_prometheus_metric_name_free(metric_data);

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -1227,7 +1227,8 @@ handle_prometheus_message(const int64_t account_id,
         if (hist_encoded_len >= 0) {
           int64_t timestamp_ms = (hip->whence.tv_sec * 1000) + (hip->whence.tv_usec / 1000);
           noit_metric_message_t *message = noit_prometheus_create_histogram_noit_metric_object(account_id,
-            check_uuid, hip->name, timestamp_ms, hist_encoded);
+            check_uuid, hip->name, hip->untagged_name_len, hip->tagged_name_len, timestamp_ms,
+            hist_encoded);
           if (message) {
             distribute_message(message);
             noit_metric_director_message_deref(message);

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -1193,12 +1193,12 @@ handle_prometheus_message(const int64_t account_id,
     /* each timeseries has a list of labels (Tags) and a list of samples */
     prometheus_coercion_t coercion = noit_prometheus_metric_name_coerce(ts->labels, ts->n_labels,
                                                                         false, true, NULL);
-    char *metric_name = noit_prometheus_metric_name_from_labels(ts->labels, ts->n_labels, coercion.units,
-                                                                coercion.is_histogram);
+    prometheus_metric_name_t *metric_data = noit_prometheus_metric_name_from_labels(ts->labels,
+        ts->n_labels, coercion.units, coercion.is_histogram);
     for (size_t j = 0; j < ts->n_samples; j++) {
       if (!coercion.is_histogram) {
         noit_metric_message_t *message = noit_prometheus_translate_to_noit_metric_message(&coercion,
-          account_id, check_uuid, metric_name, ts->samples[j]);
+          account_id, check_uuid, metric_data->name, ts->samples[j]);
         if (message) {
           distribute_message(message);
           noit_metric_director_message_deref(message);
@@ -1209,10 +1209,10 @@ handle_prometheus_message(const int64_t account_id,
         struct timeval tv;
         tv.tv_sec = (time_t)(sample->timestamp / 1000L);
         tv.tv_usec = (suseconds_t)((sample->timestamp % 1000L) * 1000);
-        noit_prometheus_track_histogram(&hists, metric_name, coercion.hist_boundary, sample->value, tv);
+        noit_prometheus_track_histogram(&hists, metric_data->name, coercion.hist_boundary, sample->value, tv);
       }
     }
-    free(metric_name);
+    noit_prometheus_metric_name_free(metric_data);
   }
   if (hists) {
     mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;

--- a/src/noit_prometheus_translation.c
+++ b/src/noit_prometheus_translation.c
@@ -68,6 +68,12 @@ void noit_prometheus_hist_in_progress_free(void *vhip) {
   free(hip);
 }
 
+void noit_prometheus_metric_name_free(void *vpmn) {
+  prometheus_metric_name_t *pmn = (prometheus_metric_name_t *)vpmn;
+  free(pmn->name);
+  free(pmn);
+}
+
 char *noit_prometheus_metric_name_from_labels(Prometheus__Label **labels,
                                               size_t label_count,
                                               const char *units,

--- a/src/noit_prometheus_translation.c
+++ b/src/noit_prometheus_translation.c
@@ -74,10 +74,10 @@ void noit_prometheus_metric_name_free(void *vpmn) {
   free(pmn);
 }
 
-char *noit_prometheus_metric_name_from_labels(Prometheus__Label **labels,
-                                              size_t label_count,
-                                              const char *units,
-                                              bool coerce_hist)
+prometheus_metric_name_t *noit_prometheus_metric_name_from_labels(Prometheus__Label **labels,
+                                                                  size_t label_count,
+                                                                  const char *units,
+                                                                  bool coerce_hist)
 {
   char final_name[MAX_METRIC_TAGGED_NAME] = {0};
   char *name = final_name;
@@ -85,6 +85,7 @@ char *noit_prometheus_metric_name_from_labels(Prometheus__Label **labels,
   char encode_buffer[MAX_METRIC_TAGGED_NAME] = {0};
   char *b = buffer;
   size_t tag_count = 0;
+  prometheus_metric_name_t *metric_data = (prometheus_metric_name_t *)malloc(sizeof(prometheus_metric_name_t));
   for (size_t i = 0; i < label_count; i++) {
     Prometheus__Label *l = labels[i];
     if (strcmp("__name__", l->name) == 0) {
@@ -135,6 +136,7 @@ char *noit_prometheus_metric_name_from_labels(Prometheus__Label **labels,
       tag_count++;
     }
   }
+  metric_data->untagged_len = strlen(name);
   strlcat(name, "|ST[", sizeof(final_name));
   strlcat(name, buffer, sizeof(final_name));
   if (units) {
@@ -159,7 +161,9 @@ char *noit_prometheus_metric_name_from_labels(Prometheus__Label **labels,
   strlcat(name, "]", sizeof(final_name));
 
   /* we don't have to canonicalize here as reconnoiter will do that for us */
-  return strdup(final_name);
+  metric_data->name = strdup(final_name);
+  metric_data->tagged_len = strlen(final_name);
+  return metric_data;
 }
 
 bool noit_prometheus_snappy_uncompress(mtev_dyn_buffer_t *uncompressed_data_out,

--- a/src/noit_prometheus_translation.c
+++ b/src/noit_prometheus_translation.c
@@ -298,24 +298,24 @@ static void noit_prometheus_fill_in_common_fields(noit_metric_message_t *message
 noit_metric_message_t *noit_prometheus_translate_to_noit_metric_message(prometheus_coercion_t *coercion,
                                                                         const int64_t account_id,
                                                                         const uuid_t check_uuid,
-                                                                        const char *metric_name,
+                                                                        const prometheus_metric_name_t *metric_name,
                                                                         const Prometheus__Sample *sample) {
   if (!coercion || !metric_name || !sample) {
     mtevL(mtev_error, "%s: misuse of function, received unexpected null argument\n", __func__);
     return NULL;
   }
   if (sample->timestamp < 0) {
-    mtevL(mtev_error, "%s: timestamp for metric %s is less than zero, skipping\n", __func__, metric_name);
+    mtevL(mtev_error, "%s: timestamp for metric %s is less than zero, skipping\n", __func__, metric_name->name);
     return NULL;
   }
   if (coercion->is_histogram) {
     mtevL(mtev_error, "%s: misuse of function, received unexpected histogram argument (metric %s)\n", __func__,
-      metric_name);
+      metric_name->name);
     return NULL;
   }
   noit_metric_message_t *message = (noit_metric_message_t *)calloc(1, sizeof(noit_metric_message_t));
   noit_metric_director_message_ref(message);
-  noit_prometheus_fill_in_common_fields(message, account_id, check_uuid, metric_name);
+  noit_prometheus_fill_in_common_fields(message, account_id, check_uuid, metric_name->name);
 
   message->type = MESSAGE_TYPE_M;
   message->value.whence_ms = (uint64_t) sample->timestamp * 1000;

--- a/src/noit_prometheus_translation.h
+++ b/src/noit_prometheus_translation.h
@@ -83,7 +83,7 @@ noit_metric_message_t *
 noit_prometheus_translate_to_noit_metric_message(prometheus_coercion_t *coercion,
                                                  const int64_t account_id,
                                                  const uuid_t check_uuid,
-                                                 const char *metric_name,
+                                                 const prometheus_metric_name_t *metric_name,
                                                  const Prometheus__Sample *sample);
 noit_metric_message_t *
 noit_prometheus_create_histogram_noit_metric_object(const int64_t account_id,

--- a/src/noit_prometheus_translation.h
+++ b/src/noit_prometheus_translation.h
@@ -61,10 +61,10 @@ typedef struct {
 
 void noit_prometheus_metric_name_free(void *vpmn);
 
-char *noit_prometheus_metric_name_from_labels(Prometheus__Label **labels,
-                                              size_t label_count,
-                                              const char *units,
-                                              bool coerce_hist);
+prometheus_metric_name_t *noit_prometheus_metric_name_from_labels(Prometheus__Label **labels,
+                                                                  size_t label_count,
+                                                                  const char *units,
+                                                                  bool coerce_hist);
 
 bool noit_prometheus_snappy_uncompress(mtev_dyn_buffer_t *uncompressed_data_out,
                                        size_t *uncompressed_size_out,

--- a/src/noit_prometheus_translation.h
+++ b/src/noit_prometheus_translation.h
@@ -50,6 +50,8 @@ typedef struct {
   int nallocdbins;
   struct timeval whence;
   char name[MAX_METRIC_TAGGED_NAME];
+  size_t untagged_name_len;
+  size_t tagged_name_len;
 } prometheus_hist_in_progress_t;
 
 void noit_prometheus_hist_in_progress_free(void *vhip);
@@ -92,7 +94,7 @@ noit_prometheus_create_histogram_noit_metric_object(const int64_t account_id,
 
 void
 noit_prometheus_track_histogram(mtev_hash_table **hist_hash,
-                                const char *name,
+                                const prometheus_metric_name_t *name,
                                 double boundary,
                                 double val,
                                 struct timeval w);

--- a/src/noit_prometheus_translation.h
+++ b/src/noit_prometheus_translation.h
@@ -89,6 +89,8 @@ noit_metric_message_t *
 noit_prometheus_create_histogram_noit_metric_object(const int64_t account_id,
                                                     const uuid_t check_uuid,
                                                     const char *metric_name,
+                                                    const size_t untagged_metric_name_len,
+                                                    const size_t tagged_metric_name_len,
                                                     const int64_t timestamp_ms,
                                                     const char *histogram_string);
 

--- a/src/noit_prometheus_translation.h
+++ b/src/noit_prometheus_translation.h
@@ -53,6 +53,13 @@ typedef struct {
 } prometheus_hist_in_progress_t;
 
 void noit_prometheus_hist_in_progress_free(void *vhip);
+typedef struct {
+  char *name;
+  size_t untagged_len;
+  size_t tagged_len;
+} prometheus_metric_name_t;
+
+void noit_prometheus_metric_name_free(void *vpmn);
 
 char *noit_prometheus_metric_name_from_labels(Prometheus__Label **labels,
                                               size_t label_count,


### PR DESCRIPTION
Pass around the tagged and untagged metric lengths so we properly set the values on incoming kafka/prometheus data.