### PR TITLE
Fix Prometheus Timestamp

### DIFF
--- a/src/noit_prometheus_translation.c
+++ b/src/noit_prometheus_translation.c
@@ -320,7 +320,7 @@ noit_metric_message_t *noit_prometheus_translate_to_noit_metric_message(promethe
     metric_name->untagged_len, metric_name->tagged_len);
 
   message->type = MESSAGE_TYPE_M;
-  message->value.whence_ms = (uint64_t) sample->timestamp * 1000;
+  message->value.whence_ms = (uint64_t) sample->timestamp;
   message->value.type = METRIC_DOUBLE;
   message->value.is_null = false;
   message->value.value.v_double = sample->value;


### PR DESCRIPTION
Prometheus sample timestamps are already in milliseconds, so we don't need to multiply by 1000.