### PR TITLE
Add Dedupe For Prometheus-Fomatted Data In Metric Director

### DIFF
--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -1190,7 +1190,7 @@ check_duplicate_from_noit_metric_message(noit_metric_message_t *msg) {
         EVP_DigestUpdate(ctx, &msg->value.value.v_uint64, sizeof(msg->value.value.v_uint64));
         break;
       default:
-        //treat METRIC_GUESS and METRIC_ABSENT as zero
+        //treat METRIC_GUESS and METRIC_ABSENT as zero-length
         break;
     }
     EVP_DigestFinal(ctx, digest, NULL);

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -1195,6 +1195,11 @@ check_duplicate_from_noit_metric_message(noit_metric_message_t *msg) {
           msg->id.name_len_with_tags, msg->id.name, uuid_str, (char)msg->value.type,
           msg->value.value.v_uint64);
         break;
+      case METRIC_ABSENT:
+        written = asprintf(&buffer, BASE_DUPLICATE_PRINT_FORMAT "%s", msg->value.whence_ms, msg->id.account_id,
+          msg->id.name_len_with_tags, msg->id.name, uuid_str, (char)msg->value.type,
+          "[[null]]");
+        break;
       default:
         // unsupported
         break;

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -1156,7 +1156,6 @@ check_dedupe_hash(unsigned char *digest, uint64_t whence) {
 static mtev_boolean
 check_duplicate_from_noit_metric_message(noit_metric_message_t *msg) {
   mtev_boolean ret_val = mtev_false;
-  #define BASE_DUPLICATE_PRINT_FORMAT "%lu\t%ld\t%.*s\t%s\t%c\t"
   if (msg && dedupe && msg->value.whence_ms > 0) {
     unsigned char *digest = malloc(MD5_DIGEST_LENGTH);
     const EVP_MD *md = EVP_get_digestbyname("MD5");

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -1110,7 +1110,7 @@ handle_metric_buffer(const char *payload, int payload_len,
 }
 
 static uint64_t
-get_message_time(const char* msg, int msg_length) {
+get_message_time_s(const char* msg, int msg_length) {
   const int minimum_bytes_before_second_tab = sizeof("M\t1.2.3.4");
   if (msg_length <= minimum_bytes_before_second_tab) {
     mtevL(mtev_error, "Unable to retrieve timestamp from message: %s\n", msg);
@@ -1232,8 +1232,8 @@ check_duplicate(const char *payload, const size_t payload_len) {
     EVP_DigestUpdate(ctx, payload, payload_len);
     EVP_DigestFinal(ctx, digest, NULL);
     EVP_MD_CTX_free(ctx);
-    uint64_t whence = get_message_time(payload, payload_len);
-    ret_val = check_dedupe_hash(digest, whence);
+    uint64_t whence_s = get_message_time_s(payload, payload_len);
+    ret_val = check_dedupe_hash(digest, whence_s);
   }
   return ret_val;
 }

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -1272,8 +1272,9 @@ handle_prometheus_message(const int64_t account_id,
       histogram_t *h = hist_create_approximation_from_adhoc(HIST_APPROX_HIGH, hip->bins, hip->nbins, 0);
       ssize_t est = hist_serialize_b64_estimate(h);
       if(est > 0) {
-        char *hist_encoded = (char *)malloc(est);
+        char *hist_encoded = (char *)malloc(est+1);
         ssize_t hist_encoded_len = hist_serialize_b64(h, hist_encoded, est);
+        hist_encoded[hist_encoded_len] = 0;
         if (hist_encoded_len >= 0) {
           int64_t timestamp_ms = (hip->whence.tv_sec * 1000) + (hip->whence.tv_usec / 1000);
           noit_metric_message_t *message = noit_prometheus_create_histogram_noit_metric_object(account_id,

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -1166,7 +1166,7 @@ check_duplicate_from_noit_metric_message(noit_metric_message_t *msg) {
     EVP_DigestUpdate(ctx, &msg->value.whence_ms, sizeof(msg->value.whence_ms));
     EVP_DigestUpdate(ctx, &msg->id.account_id, sizeof(msg->id.account_id));
     EVP_DigestUpdate(ctx, msg->id.name, msg->id.name_len_with_tags);
-    EVP_DigestUpdate(ctx, &msg->id.id, sizeof(msg->id.id));
+    EVP_DigestUpdate(ctx, msg->id.id, sizeof(uuid_t));
     EVP_DigestUpdate(ctx, &msg->value.type, sizeof(msg->value.type));
     switch(msg->value.type) {
       case METRIC_STRING:

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -1156,6 +1156,7 @@ check_dedupe_hash(unsigned char *digest, uint64_t whence) {
 static mtev_boolean
 check_duplicate_from_noit_metric_message(noit_metric_message_t *msg) {
   mtev_boolean ret_val = mtev_false;
+  #define BASE_DUPLICATE_PRINT_FORMAT "%lu\t%ld\t%.*s\t%s\t%c\t"
   if (msg && dedupe && msg->value.whence_ms > 0) {
     char *buffer = NULL;
     char uuid_str[UUID_PRINTABLE_STRING_LENGTH];
@@ -1170,12 +1171,12 @@ check_duplicate_from_noit_metric_message(noit_metric_message_t *msg) {
     }
     int written = 0;
     if (is_string) {
-      written = asprintf(&buffer, "%lu\t%ld\t%.*s\t%s\t%c\t%s", msg->value.whence_ms, msg->id.account_id,
+      written = asprintf(&buffer, BASE_DUPLICATE_PRINT_FORMAT "%s", msg->value.whence_ms, msg->id.account_id,
         msg->id.name_len_with_tags, msg->id.name, uuid_str, (char)msg->value.type,
         msg->value.value.v_string);
     }
     else {
-      written = asprintf(&buffer, "%lu\t%ld\t%.*s\t%s\t%c\t%.10f", msg->value.whence_ms, msg->id.account_id,
+      written = asprintf(&buffer, BASE_DUPLICATE_PRINT_FORMAT "%.10f", msg->value.whence_ms, msg->id.account_id,
         msg->id.name_len_with_tags, msg->id.name, uuid_str, (char)msg->value.type,
         msg->value.value.v_double);
     }

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -1139,9 +1139,16 @@ check_dedupe_hash(unsigned char *digest, uint64_t whence) {
       int x = mtev_hash_store(hash, (const char *)digest, MD5_DIGEST_LENGTH, (void *)0x1);
       if (x == 0) {
         /* this is a dupe */
+        free(digest);
         return mtev_true;
       }
     }
+    else {
+      free(digest);
+    }
+  }
+  else {
+    free(digest);
   }
   return mtev_false;
 }
@@ -1182,9 +1189,6 @@ check_duplicate_from_noit_metric_message(noit_metric_message_t *msg) {
     EVP_MD_CTX_free(ctx);
     free(buffer);
     ret_val = check_dedupe_hash(digest, msg->value.whence_ms);
-    if (ret_val == mtev_false) {
-      free(digest);
-    }
   }
   return ret_val;
 }
@@ -1203,9 +1207,6 @@ check_duplicate(const char *payload, const size_t payload_len) {
     EVP_MD_CTX_free(ctx);
     uint64_t whence = get_message_time(payload, payload_len);
     ret_val = check_dedupe_hash(digest, whence);
-    if (ret_val == mtev_false) {
-      free(digest);
-    }
   }
   return ret_val;
 }

--- a/src/noit_metric_director.c
+++ b/src/noit_metric_director.c
@@ -1213,7 +1213,7 @@ check_duplicate_from_noit_metric_message(noit_metric_message_t *msg) {
       EVP_DigestUpdate(ctx, buffer, written);
       EVP_DigestFinal(ctx, digest, NULL);
       EVP_MD_CTX_free(ctx);
-      ret_val = check_dedupe_hash(digest, msg->value.whence_ms);
+      ret_val = check_dedupe_hash(digest, msg->value.whence_ms / 1000);
     }
     free(buffer);
   }


### PR DESCRIPTION
Added the ability to dedupe prometheus metric messages. Since the remote_write endpoint lacks a timestamp, added a new method to dedupe messages based on parsed noit_metric messages to make this work.