### PR TITLE
SO-8180 Fix warning popped by gcc-13

### DIFF
--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -457,8 +457,7 @@ graphite_expand_braces(const char *pre, const char *s, const char *suf, struct g
     if (len_suf > 0) {
       MTEV_MAYBE_DECL_VARS(char, prefix, 256);
       MTEV_MAYBE_REALLOC(prefix, len_s + len_pre + 2);
-      if (snprintf(prefix, MTEV_MAYBE_SIZE(prefix), "%s%s", pre, s) > MTEV_MAYBE_SIZE(prefix))
-      {
+      if (snprintf(prefix, MTEV_MAYBE_SIZE(prefix), "%s%s", pre, s) > MTEV_MAYBE_SIZE(prefix)) {
         mtevFatal(mtev_error, "%s: Failed to write to buffer while expanding graphite braces\n", __func__);
       }
       graphite_expand_braces(prefix, suf, "", g);

--- a/src/noit_metric_tag_search.c
+++ b/src/noit_metric_tag_search.c
@@ -457,7 +457,10 @@ graphite_expand_braces(const char *pre, const char *s, const char *suf, struct g
     if (len_suf > 0) {
       MTEV_MAYBE_DECL_VARS(char, prefix, 256);
       MTEV_MAYBE_REALLOC(prefix, len_s + len_pre + 2);
-      snprintf(prefix, MTEV_MAYBE_SIZE(prefix), "%s%s", pre, s);
+      if (snprintf(prefix, MTEV_MAYBE_SIZE(prefix), "%s%s", pre, s) > MTEV_MAYBE_SIZE(prefix))
+      {
+        mtevFatal(mtev_error, "%s: Failed to write to buffer while expanding graphite braces\n", __func__);
+      }
       graphite_expand_braces(prefix, suf, "", g);
       MTEV_MAYBE_FREE(prefix);
     }


### PR DESCRIPTION
Witnessed this warning with gcc-13 on Ubuntu 24.04:

```
noit_metric_tag_search.c: In function 'graphite_expand_braces':
noit_metric_tag_search.c:460:52: error: '%s' directive output may be truncated writing up to 254 bytes into a region of size between 2 and 256 [-Werror=format-truncation=]
  460 |       snprintf(prefix, MTEV_MAYBE_SIZE(prefix), "%s%s", pre, s);
      |                                                    ^~
In file included from /usr/include/stdio.h:980,
                 from noit_metric_tag_search.c:41:
In function 'snprintf',
    inlined from 'graphite_expand_braces' at noit_metric_tag_search.c:460:7:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: '__builtin___snprintf_chk' output between 1 and 509 bytes into a destination of size 256
   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   55 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   56 |                                    __va_arg_pack ());
      |                                    ~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:348: noit_metric_tag_search.o] Error 1
```

Looking at the code it doesn't seem possible for the buffer to ever be less than 256, but this simple check makes the warning go away.