### PR TITLE
Generated Flatbuffer Include Fixes

### DIFF
--- a/src/noit_check_log.c
+++ b/src/noit_check_log.c
@@ -81,7 +81,6 @@
  */
 
 static mtev_log_stream_t check_log = NULL;
-static mtev_log_stream_t filterset_log = NULL;
 static mtev_log_stream_t status_log = NULL;
 static mtev_log_stream_t delete_log = NULL;
 static mtev_log_stream_t bundle_log = NULL;
@@ -260,8 +259,6 @@ noit_check_log_bundle_metric_flatbuffer_serialize_log(mtev_log_stream_t ls,
   int rv = -1;
   char check_name[256 * 3] = {0};
   int len = sizeof(check_name);
-
-  static char *ip_str = "ip";
 
   if(!noit_apply_filterset(check->filterset, check, m)) return 0;
   if(m->logged) return 0;
@@ -546,16 +543,13 @@ _noit_check_log_bundle_metric(mtev_log_stream_t ls, Metric *metric, metric_t *m)
 static int
 noit_check_log_bundle_fb_serialize(mtev_log_stream_t ls, noit_check_t *check, const struct timeval *w, mtev_hash_table *in_metrics) {
   int rv_sum = 0, rv_err = 0;
-  static char *ip_str = "ip";
   char check_name[256 * 3] = {0};
   int len = sizeof(check_name);
   const char *key;
-  int klen, i=0, j;
-  unsigned int out_size;
+  int klen;
   stats_t *c;
   void *vm;
   const struct timeval *whence;
-  char *buf, *out_buf;
   mtev_hash_table *metrics;
 
   c = noit_check_get_stats_current(check);
@@ -674,8 +668,6 @@ noit_check_log_bundle_serialize(mtev_log_stream_t ls, noit_check_t *check, const
   int metrics_per_bundle = 0;
   if(v_mpb) metrics_per_bundle = atoi(v_mpb);
   if(metrics_per_bundle <= 0) metrics_per_bundle = METRICS_PER_BUNDLE;
-
-  struct timeval latest_metric_whence = { 0, 0 };
 
   // Get a bundle
   c = noit_check_get_stats_current(check);

--- a/src/noit_check_log_helpers.c
+++ b/src/noit_check_log_helpers.c
@@ -46,10 +46,11 @@
 #include "bundle.pb-c.h"
 #include "noit_metric.h"
 #include "noit_check_log_helpers.h"
+#include "noit_message_decoder.h"
+
 #include "flatbuffers/metric_reader.h"
 #include "flatbuffers/metric_batch_reader.h"
 #include "flatbuffers/metric_batch_verifier.h"
-#include "noit_message_decoder.h"
 
 static void *__c_allocator_alloc(void *d, size_t size) {
   return malloc(size);

--- a/src/noit_fb.c
+++ b/src/noit_fb.c
@@ -33,8 +33,12 @@
  */
 
 #include "noit_fb.h"
-#include "flatbuffers/metric_list_reader.h"
 #include <mtev_log.h>
+
+#include "flatbuffers/metric_list_reader.h"
+#include "flatbuffers/metric_batch_builder.h"
+#include "flatbuffers/metric_common_builder.h"
+#include "flatbuffers/metric_list_builder.h"
 
 static void
 flatbuffer_encode_metric(flatcc_builder_t *B, metric_t *m, const uint16_t generation)

--- a/src/noit_fb.h
+++ b/src/noit_fb.h
@@ -42,10 +42,6 @@
 extern "C" {
 #endif
 
-#include <flatbuffers/metric_batch_builder.h>
-#include <flatbuffers/metric_common_builder.h>
-#include <flatbuffers/metric_list_builder.h>
-
 /*!
   \fn noit_fb_serialize_metricbatch(uint64_t whence_ms, uuid_t check_uuid, const char *check_name, int account_id, metric_t *m,size_t* out_size)
   \brief Create a MetricBatch flatbuffer representing a set of records

--- a/src/noit_filters_lmdb.c
+++ b/src/noit_filters_lmdb.c
@@ -31,13 +31,14 @@
 #include "noit_filters.h"
 #include "noit_lmdb_tools.h"
 #include "noit_fb.h"
+#include <mtev_conf.h>
+#include <mtev_memory.h>
+#include <mtev_watchdog.h>
+
 #include "flatbuffers/filterset_builder.h"
 #include "flatbuffers/filterset_verifier.h"
 #include "flatbuffers/filterset_rule_builder.h"
 #include "flatbuffers/filterset_rule_verifier.h"
-#include <mtev_conf.h>
-#include <mtev_memory.h>
-#include <mtev_watchdog.h>
 
 static int32_t global_default_filter_flush_period_ms = DEFAULT_FILTER_FLUSH_PERIOD_MS;
 static pcre *fallback_no_match = NULL;


### PR DESCRIPTION
Three changes:
* Always use quotation marks for the generated flatbuffer files
* Keep these includes confined (IE, don't put them in header files unnecessarily)
* Always put the flatbuffer files last.