### PR TITLE
Add Functions To Canonicalize Prometheus Metric Names

### DIFF
--- a/src/noit_prometheus_translation.c
+++ b/src/noit_prometheus_translation.c
@@ -522,13 +522,14 @@ noit_prometheus_sort_and_dedupe_histogram_in_progress(prometheus_hist_in_progres
   }
 }
 
-int
-noit_prometheus_translate_snappy_data(const int64_t account_id,
-                                      const uuid_t check_uuid,
-                                      const void *data,
-                                      size_t data_len,
-                                      noit_prometheus_translate_cb_t cb,
-                                      void *cb_closure)
+static int
+translate_snappy_data(const int64_t account_id,
+                      const uuid_t check_uuid,
+                      const void *data,
+                      size_t data_len,
+                      noit_prometheus_translate_cb_t cb,
+                      void *cb_closure,
+                      bool canonicalize_metric_name)
 {
   mtev_dyn_buffer_t uncompressed;
   mtev_dyn_buffer_init(&uncompressed);
@@ -561,8 +562,15 @@ noit_prometheus_translate_snappy_data(const int64_t account_id,
     /* each timeseries has a list of labels (Tags) and a list of samples */
     prometheus_coercion_t coercion = noit_prometheus_metric_name_coerce(ts->labels, ts->n_labels,
                                                                         false, true, NULL);
-    prometheus_metric_name_t *metric_data = noit_prometheus_metric_name_from_labels(ts->labels,
-        ts->n_labels, coercion.units, coercion.is_histogram);
+    prometheus_metric_name_t *metric_data = NULL;
+    if (canonicalize_metric_name) {
+      metric_data = noit_prometheus_metric_name_from_labels_canonical(ts->labels, ts->n_labels,
+        coercion.units, coercion.is_histogram);
+    }
+    else {
+      metric_data = noit_prometheus_metric_name_from_labels(ts->labels, ts->n_labels,
+        coercion.units, coercion.is_histogram);
+    }
     for (size_t j = 0; j < ts->n_samples; j++) {
       if (!coercion.is_histogram) {
         metric_t *metric = noit_prometheus_translate_to_metric(&coercion,
@@ -610,4 +618,26 @@ noit_prometheus_translate_snappy_data(const int64_t account_id,
     free(hists);
   }
   return 0;
+}
+
+int
+noit_prometheus_translate_snappy_data(const int64_t account_id,
+                                      const uuid_t check_uuid,
+                                      const void *data,
+                                      size_t data_len,
+                                      noit_prometheus_translate_cb_t cb,
+                                      void *cb_closure)
+{
+  return translate_snappy_data(account_id, check_uuid, data, data_len, cb, cb_closure, false);
+}
+
+int
+noit_prometheus_translate_snappy_data_canonical(const int64_t account_id,
+                                                const uuid_t check_uuid,
+                                                const void *data,
+                                                size_t data_len,
+                                                noit_prometheus_translate_cb_t cb,
+                                                void *cb_closure)
+{
+  return translate_snappy_data(account_id, check_uuid, data, data_len, cb, cb_closure, true);
 }

--- a/src/noit_prometheus_translation.c
+++ b/src/noit_prometheus_translation.c
@@ -174,11 +174,9 @@ prometheus_metric_name_t *noit_prometheus_metric_name_from_labels(Prometheus__La
   }
   strlcat(name, "]", sizeof(final_name));
 
-  char canonicalized_final_name[MAX_METRIC_TAGGED_NAME + 1];
-  noit_metric_canonicalize(final_name, strlen(final_name), canonicalized_final_name, MAX_METRIC_TAGGED_NAME + 1, mtev_true);
-
-  metric_data->name = strdup(canonicalized_final_name);
-  metric_data->tagged_len = strlen(canonicalized_final_name);
+  /* we don't have to canonicalize here as reconnoiter will do that for us */
+  metric_data->name = strdup(final_name);
+  metric_data->tagged_len = strlen(final_name);
   return metric_data;
 }
 

--- a/src/noit_prometheus_translation.c
+++ b/src/noit_prometheus_translation.c
@@ -174,9 +174,11 @@ prometheus_metric_name_t *noit_prometheus_metric_name_from_labels(Prometheus__La
   }
   strlcat(name, "]", sizeof(final_name));
 
-  /* we don't have to canonicalize here as reconnoiter will do that for us */
-  metric_data->name = strdup(final_name);
-  metric_data->tagged_len = strlen(final_name);
+  char canonicalized_final_name[MAX_METRIC_TAGGED_NAME + 1];
+  noit_metric_canonicalize(final_name, strlen(final_name), canonicalized_final_name, MAX_METRIC_TAGGED_NAME + 1, mtev_true);
+
+  metric_data->name = strdup(canonicalized_final_name);
+  metric_data->tagged_len = strlen(canonicalized_final_name);
   return metric_data;
 }
 

--- a/src/noit_prometheus_translation.c
+++ b/src/noit_prometheus_translation.c
@@ -88,13 +88,14 @@ void noit_prometheus_metric_name_free(void *vpmn) {
   free(pmn);
 }
 
-prometheus_metric_name_t *noit_prometheus_metric_name_from_labels(Prometheus__Label **labels,
-                                                                  size_t label_count,
-                                                                  const char *units,
-                                                                  bool coerce_hist)
+static prometheus_metric_name_t *get_prometheus_metric_name(Prometheus__Label **labels,
+                                                            const size_t label_count,
+                                                            const char *units,
+                                                            const bool coerce_hist,
+                                                            char *name_buffer,
+                                                            const size_t name_buffer_len)
 {
-  char final_name[MAX_METRIC_TAGGED_NAME] = {0};
-  char *name = final_name;
+  char *name = name_buffer;
   char buffer[MAX_METRIC_TAGGED_NAME] = {0};
   char encode_buffer[MAX_METRIC_TAGGED_NAME] = {0};
   char *b = buffer;
@@ -103,7 +104,7 @@ prometheus_metric_name_t *noit_prometheus_metric_name_from_labels(Prometheus__La
   for (size_t i = 0; i < label_count; i++) {
     Prometheus__Label *l = labels[i];
     if (strcmp("__name__", l->name) == 0) {
-      strncpy(name, l->value, sizeof(final_name) - 1);
+      strncpy(name, l->value, name_buffer_len - 1);
     }
     else {
       /* if we're coercing histograms, remove the "le" label */
@@ -151,32 +152,60 @@ prometheus_metric_name_t *noit_prometheus_metric_name_from_labels(Prometheus__La
     }
   }
   metric_data->untagged_len = strlen(name);
-  strlcat(name, "|ST[", sizeof(final_name));
-  strlcat(name, buffer, sizeof(final_name));
+  strlcat(name, "|ST[", name_buffer_len);
+  strlcat(name, buffer, name_buffer_len);
   if (units) {
     if (noit_metric_tagset_is_taggable_value(units, strlen(units))) {
       if (strlen(buffer) > 0)
-        strlcat(name, ",", sizeof(final_name));
-      strlcat(name, "units:", sizeof(final_name));
-      strlcat(name, units, sizeof(final_name));
+        strlcat(name, ",", name_buffer_len);
+      strlcat(name, "units:", name_buffer_len);
+      strlcat(name, units, name_buffer_len);
     }
     else {
       int len = mtev_b64_encode((const unsigned char *) units, strlen(units), encode_buffer,
                                 sizeof(encode_buffer) - 1);
       if (len > 0) {
         if (strlen(buffer) > 0)
-          strlcat(name, ",", sizeof(final_name));
-        strlcat(name, "units:", sizeof(final_name));
+          strlcat(name, ",", name_buffer_len);
+        strlcat(name, "units:", name_buffer_len);
         encode_buffer[len] = '\0';
-        strlcat(name, encode_buffer, sizeof(final_name));
+        strlcat(name, encode_buffer, name_buffer_len);
       }
     }
   }
-  strlcat(name, "]", sizeof(final_name));
+  strlcat(name, "]", name_buffer_len);
+  return metric_data;
+}
 
-  /* we don't have to canonicalize here as reconnoiter will do that for us */
+prometheus_metric_name_t *noit_prometheus_metric_name_from_labels(Prometheus__Label **labels,
+                                                                  size_t label_count,
+                                                                  const char *units,
+                                                                  bool coerce_hist)
+{
+  char final_name[MAX_METRIC_TAGGED_NAME] = {0};
+  prometheus_metric_name_t *metric_data =
+    get_prometheus_metric_name(labels, label_count, units, coerce_hist, final_name, MAX_METRIC_TAGGED_NAME);
+
   metric_data->name = strdup(final_name);
   metric_data->tagged_len = strlen(final_name);
+  return metric_data;
+}
+
+prometheus_metric_name_t *noit_prometheus_metric_name_from_labels_canonical(Prometheus__Label **labels,
+                                                                            size_t label_count,
+                                                                            const char *units,
+                                                                            bool coerce_hist)
+{
+  char final_name[MAX_METRIC_TAGGED_NAME] = {0};
+  prometheus_metric_name_t *metric_data =
+    get_prometheus_metric_name(labels, label_count, units, coerce_hist, final_name, MAX_METRIC_TAGGED_NAME);
+
+  char canonicalized_final_name[MAX_METRIC_TAGGED_NAME + 1];
+  noit_metric_canonicalize(final_name, strlen(final_name), canonicalized_final_name, MAX_METRIC_TAGGED_NAME + 1, mtev_true);
+
+  metric_data->name = strdup(canonicalized_final_name);
+  metric_data->tagged_len = strlen(canonicalized_final_name);
+
   return metric_data;
 }
 

--- a/src/noit_prometheus_translation.h
+++ b/src/noit_prometheus_translation.h
@@ -110,6 +110,14 @@ noit_prometheus_translate_snappy_data(const int64_t account_id,
                                       noit_prometheus_translate_cb_t cb,
                                       void *cb_closure);
 
+int
+noit_prometheus_translate_snappy_data_canonical(const int64_t account_id,
+                                                const uuid_t check_uuid,
+                                                const void *data,
+                                                size_t data_len,
+                                                noit_prometheus_translate_cb_t cb,
+                                                void *cb_closure);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/noit_prometheus_translation_internal.h
+++ b/src/noit_prometheus_translation_internal.h
@@ -18,6 +18,12 @@ prometheus_metric_name_t *noit_prometheus_metric_name_from_labels(Prometheus__La
                                                                   const char *units,
                                                                   bool coerce_hist);
 
+prometheus_metric_name_t *noit_prometheus_metric_name_from_labels_canonical(Prometheus__Label **labels,
+                                                                            size_t label_count,
+                                                                            const char *units,
+                                                                            bool coerce_hist);
+
+
 prometheus_coercion_t noit_prometheus_metric_name_coerce(Prometheus__Label **labels,
                                                          size_t label_count,
                                                          bool do_units,


### PR DESCRIPTION
Added two new functions, `noit_prometheus_translate_snappy_data_canonical` and `noit_prometheus_metric_name_from_labels_canonical`, that will guarantee that the caller gets fully canonical metric names.